### PR TITLE
Move tokens in `RaiSync.request`

### DIFF
--- a/contracts/RaiSync.sol
+++ b/contracts/RaiSync.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
-pragma abicoder v2;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract RaiSync {
 
     struct Request {
         uint256 chain_id;
-        address token_address;
+        address token_address_source;
+        address token_address_target;
         uint256 amount;
         address target_address;
     }
@@ -14,7 +16,7 @@ contract RaiSync {
     event RequestCreated(
         uint256 request_id,
         uint256 indexed chain_id,
-        address indexed token_address,
+        address indexed token_address_target,
         uint256 amount
     );
 
@@ -24,7 +26,8 @@ contract RaiSync {
 
     function request(
         uint256 chain_id,
-        address token_address,
+        address token_address_source,
+        address token_address_target,
         uint256 amount,
         address target_address
     )
@@ -35,16 +38,20 @@ contract RaiSync {
 
         Request storage new_request = requests[request_id];
         new_request.chain_id = chain_id;
-        new_request.token_address = token_address;
+        new_request.token_address_source = token_address_source;
+        new_request.token_address_target = token_address_target;
         new_request.amount = amount;
         new_request.target_address = target_address;
 
         emit RequestCreated(
             request_id,
             chain_id,
-            token_address,
+            token_address_target,
             amount
         );
+
+        IERC20 token = IERC20(token_address_source);
+        require(token.transferFrom(msg.sender, address(this), amount), "transfer failed");
 
         return request_id;
     }


### PR DESCRIPTION
Actually move the tokens into the contract when requesting.