### PR TITLE
contracts: Make claimId a composite id

### DIFF
--- a/contracts/tests/test_request_manager.py
+++ b/contracts/tests/test_request_manager.py
@@ -113,12 +113,6 @@ def test_claim_period_extension(
         request_manager.counterChallenge(claim_id, {"from": claimer, "value": 2})
 
 
-def test_withdraw_nonexistent_claim(request_manager):
-    """Test withdrawing a non-existant claim"""
-    with brownie.reverts("claimId not valid"):
-        request_manager.withdraw(1234, {"from": accounts[0]})
-
-
 def test_withdraw_without_challenge(request_manager, token, claim_stake, claim_period):
     """Test withdraw when a claim was not challenged"""
     requester = accounts[1]
@@ -224,3 +218,34 @@ def test_withdraw_with_challenge(request_manager, token, claim_stake, challenge_
     # Another withdraw must fail
     with brownie.reverts("Already withdrawn"):
         request_manager.withdraw(claim_id, {"from": claimer})
+
+
+def test_claim_after_withdraw(request_manager, token, claim_stake, claim_period):
+    """Test that the same account can not claim a already withdrawn fill again"""
+    requester = accounts[1]
+    claimer = accounts[2]
+
+    transfer_amount = 23
+
+    token.mint(requester, transfer_amount, {"from": requester})
+    token.approve(request_manager.address, transfer_amount, {"from": requester})
+    request_tx = request_manager.request(
+        1,
+        token.address,
+        token.address,
+        "0x5d5640575161450A674a094730365A223B226649",
+        transfer_amount,
+        {"from": requester},
+    )
+    request_id = request_tx.return_value
+    claim_tx = request_manager.claimRequest(request_id, {"from": claimer, "value": claim_stake})
+    claim_id = claim_tx.return_value
+
+    # Timetravel after claim period
+    chain.mine(timedelta=claim_period)
+    withdraw_tx = request_manager.withdraw(claim_id, {"from": claimer})
+    assert "ClaimWithdrawn" in withdraw_tx.events
+
+    # Claiming the same request again must fail
+    with brownie.reverts("Request has already been claimed"):
+        request_manager.claimRequest(request_id, {"from": claimer, "value": claim_stake})


### PR DESCRIPTION
The system needs to ensure that every request can be claimed multiple
times. However, it must only be able to be claimed once by any account.

This was not true before, when the claim id was a simple counter. This
PR changes the id to be a hashed composite value, consisting of the
request id and the claimer. This allows for easy checks whether or not
the claiming account has already done so.

Resolves #20