### PR TITLE
Improved event filtering

### DIFF
--- a/raisync/cli.py
+++ b/raisync/cli.py
@@ -9,7 +9,7 @@ from eth_account import Account
 from eth_account.signers.local import LocalAccount
 
 import raisync.util
-from raisync.node import Config, Node
+from raisync.node import Config, ContractInfo, Node
 from raisync.typing import URL
 
 log = structlog.get_logger(__name__)
@@ -20,7 +20,11 @@ def _load_contracts_info(contracts_path: Path) -> dict[str, Any]:
     for path in contracts_path.glob("*.json"):
         with path.open() as fp:
             info = json.load(fp)
-        contracts[info["contractName"]] = info["deployment"], info["abi"]
+        contracts[info["contractName"]] = ContractInfo(
+            address=info["deployment"]["address"],
+            deployment_block=info["deployment"]["blockHeight"],
+            abi=info["abi"],
+        )
     return contracts
 
 

--- a/raisync/contracts.py
+++ b/raisync/contracts.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+import web3
+
+from raisync.typing import Address, BlockNumber
+
+
+@dataclass
+class ContractInfo:
+    address: Address
+    deployment_block: BlockNumber
+    abi: list
+
+
+def make_contracts(w3: web3.Web3, contracts_info: dict[str, ContractInfo]) -> dict:
+    return {
+        name: w3.eth.contract(info.address, abi=info.abi) for name, info in contracts_info.items()
+    }

--- a/raisync/node.py
+++ b/raisync/node.py
@@ -6,6 +6,7 @@ from eth_account.signers.local import LocalAccount
 from eth_typing import Address
 
 from raisync.chain import ChainMonitor, PendingRequests, RequestHandler
+from raisync.contracts import ContractInfo
 from raisync.typing import URL
 
 log = structlog.get_logger(__name__)
@@ -13,7 +14,7 @@ log = structlog.get_logger(__name__)
 
 @dataclass(frozen=True)
 class Config:
-    contracts_info: dict
+    contracts_info: dict[str, ContractInfo]
     account: LocalAccount
     l2a_rpc_url: URL
     l2b_rpc_url: URL

--- a/raisync/tests/conftest.py
+++ b/raisync/tests/conftest.py
@@ -3,7 +3,8 @@ import eth_account
 import pytest
 from brownie import Wei, accounts
 
-import raisync.node
+from raisync.node import Config, ContractInfo, Node
+from raisync.typing import BlockNumber
 
 # brownie local account, to be used for fulfilling requests.
 # The private key here corresponds to the 10th account ganache creates on
@@ -30,16 +31,22 @@ def l1_resolver():
 @pytest.fixture
 def node(request_manager, fill_manager, token):
     contracts_info = dict(
-        RequestManager=(dict(blockHeight=0, address=request_manager.address), request_manager.abi),
-        FillManager=(dict(blockHeight=0, address=fill_manager.address), fill_manager.abi),
+        RequestManager=ContractInfo(
+            deployment_block=BlockNumber(0),
+            address=request_manager.address,
+            abi=request_manager.abi,
+        ),
+        FillManager=ContractInfo(
+            deployment_block=BlockNumber(0), address=fill_manager.address, abi=fill_manager.abi
+        ),
     )
     account = eth_account.Account.from_key(_LOCAL_ACCOUNT.private_key)
     token.mint(account.address, 300)
     url = brownie.web3.provider.endpoint_uri
-    config = raisync.node.Config(
+    config = Config(
         l2a_rpc_url=url, l2b_rpc_url=url, contracts_info=contracts_info, account=account
     )
-    return raisync.node.Node(config)
+    return Node(config)
 
 
 @pytest.fixture


### PR DESCRIPTION
Don't rely on RPC server's stateful filters anymore.
Also make sure not to try filling requests that are already filled.

:warning: This is based on top of #73 so it would be good to have that one merged first and then rebase this one.
