### PR TITLE
contracts: Fix request fund payout when challenger wins

### DIFF
--- a/contracts/contracts/RequestManager.sol
+++ b/contracts/contracts/RequestManager.sol
@@ -206,7 +206,7 @@ contract RequestManager {
     function withdraw(uint256 claimId) external validClaimId(claimId) returns (address) {
         Claim storage claim = claims[claimId];
         Request storage request = requests[claim.requestId];
-        require(!claim.withdrawn, "Already withdrawn");
+        require(!claim.withdrawn, "Claim already withdrawn");
 
         bool requestClaimed = request.depositWithdrawn;
 
@@ -226,7 +226,7 @@ contract RequestManager {
 
         claim.withdrawn = true;
         uint256 ethToTransfer = claimStake;
-        if (!requestClaimed) {
+        if (!requestClaimed && claimReceiver == claim.claimer) {
             request.depositWithdrawn = true;
             withdraw_deposit(claimId, request, claim, claimReceiver);
         }

--- a/contracts/tests/test_request_manager.py
+++ b/contracts/tests/test_request_manager.py
@@ -168,12 +168,14 @@ def test_withdraw_without_challenge(request_manager, token, claim_stake, claim_p
     assert web3.eth.get_balance(claimer.address) == claimer_eth_balance
 
     # Another withdraw must fail
-    with brownie.reverts("Already withdrawn"):
+    with brownie.reverts("Claim already withdrawn"):
         request_manager.withdraw(claim_id, {"from": claimer})
 
 
 def test_withdraw_with_challenge(request_manager, token, claim_stake, challenge_period):
-    """Test withdraw when a claim was challenged"""
+    """Test withdraw when a claim was challenged, and the challenger won.
+    In that case, the request funds must not be paid out to the challenger."""
+
     requester = accounts[1]
     claimer = accounts[2]
     challenger = accounts[3]
@@ -203,6 +205,8 @@ def test_withdraw_with_challenge(request_manager, token, claim_stake, challenge_
     claim_tx = request_manager.claimRequest(request_id, {"from": claimer, "value": claim_stake})
     claim_id = claim_tx.return_value
 
+    assert token.balanceOf(request_manager.address) == transfer_amount
+
     assert web3.eth.get_balance(claimer.address) == claimer_eth_balance - claim_stake
     assert web3.eth.get_balance(challenger.address) == challenger_eth_balance
 
@@ -221,21 +225,22 @@ def test_withdraw_with_challenge(request_manager, token, claim_stake, challenge_
     assert web3.eth.get_balance(request_manager.address) == 2 * claim_stake + 1
 
     # The challenger sent the last bet
-    # Even if the requester calls withdraw, the funds go to the challenger
+    # Even if the requester calls withdraw, the challenge funds go to the challenger
+    # However, the request funds stay in the contract
     withdraw_tx = request_manager.withdraw(claim_id, {"from": requester})
-    assert "ClaimWithdrawn" in withdraw_tx.events
+    assert "ClaimWithdrawn" not in withdraw_tx.events
 
     assert token.balanceOf(requester) == 0
     assert token.balanceOf(claimer) == 0
-    assert token.balanceOf(challenger) == transfer_amount
+    assert token.balanceOf(challenger) == 0
+    assert token.balanceOf(request_manager.address) == transfer_amount
 
     assert web3.eth.get_balance(request_manager.address) == 0
-
     assert web3.eth.get_balance(claimer.address) == claimer_eth_balance - claim_stake
     assert web3.eth.get_balance(challenger.address) == challenger_eth_balance + claim_stake
 
     # Another withdraw must fail
-    with brownie.reverts("Already withdrawn"):
+    with brownie.reverts("Claim already withdrawn"):
         request_manager.withdraw(claim_id, {"from": claimer})
 
 
@@ -300,7 +305,7 @@ def test_withdraw_with_two_claims(request_manager, token, claim_stake, claim_per
     assert web3.eth.get_balance(claimer2.address) == claimer2_eth_balance - claim_stake
 
     # Another withdraw must fail
-    with brownie.reverts("Already withdrawn"):
+    with brownie.reverts("Claim already withdrawn"):
         request_manager.withdraw(claim1_id, {"from": claimer1})
 
     # The other claim must be withdrawable
@@ -388,7 +393,7 @@ def test_withdraw_with_two_claims_and_challenge(
     assert web3.eth.get_balance(challenger.address) == challenger_eth_balance - claim_stake - 1
 
     # Another withdraw must fail
-    with brownie.reverts("Already withdrawn"):
+    with brownie.reverts("Claim already withdrawn"):
         request_manager.withdraw(claim1_id, {"from": claimer1})
 
     # Timetravel after claim period
@@ -404,6 +409,101 @@ def test_withdraw_with_two_claims_and_challenge(
     assert web3.eth.get_balance(request_manager.address) == 0
     assert web3.eth.get_balance(claimer1.address) == claimer1_eth_balance
     assert web3.eth.get_balance(claimer2.address) == claimer2_eth_balance - claim_stake
+    assert web3.eth.get_balance(challenger.address) == challenger_eth_balance + claim_stake
+
+
+def test_withdraw_with_two_claims_first_unsuccessful_then_successful(
+    request_manager, token, claim_stake, claim_period, challenge_period
+):
+    """Test withdraw when a request was claimed twice. The first claim fails, while the second
+    is successful and should be paid out the request funds."""
+    requester = accounts[1]
+    claimer1 = accounts[2]
+    claimer2 = accounts[3]
+    challenger = accounts[4]
+
+    transfer_amount = 23
+
+    claimer1_eth_balance = web3.eth.get_balance(claimer1.address)
+    claimer2_eth_balance = web3.eth.get_balance(claimer2.address)
+    challenger_eth_balance = web3.eth.get_balance(challenger.address)
+
+    token.mint(requester, transfer_amount, {"from": requester})
+    assert token.balanceOf(requester) == transfer_amount
+    assert token.balanceOf(claimer1) == 0
+    assert token.balanceOf(claimer2) == 0
+    assert token.balanceOf(request_manager.address) == 0
+
+    assert web3.eth.get_balance(request_manager.address) == 0
+
+    token.approve(request_manager.address, transfer_amount, {"from": requester})
+    request_tx = request_manager.request(
+        1,
+        token.address,
+        token.address,
+        "0x5d5640575161450A674a094730365A223B226649",
+        transfer_amount,
+        {"from": requester},
+    )
+    request_id = request_tx.return_value
+
+    claim1_tx = request_manager.claimRequest(request_id, {"from": claimer1, "value": claim_stake})
+    claim1_id = claim1_tx.return_value
+
+    claim2_tx = request_manager.claimRequest(request_id, {"from": claimer2, "value": claim_stake})
+    claim2_id = claim2_tx.return_value
+
+    assert web3.eth.get_balance(claimer1.address) == claimer1_eth_balance - claim_stake
+    assert web3.eth.get_balance(claimer2.address) == claimer2_eth_balance - claim_stake
+    assert web3.eth.get_balance(challenger.address) == challenger_eth_balance
+
+    request_manager.challengeClaim(claim1_id, {"from": challenger, "value": claim_stake + 1})
+
+    assert web3.eth.get_balance(claimer1.address) == claimer1_eth_balance - claim_stake
+    assert web3.eth.get_balance(claimer2.address) == claimer2_eth_balance - claim_stake
+    assert web3.eth.get_balance(challenger.address) == challenger_eth_balance - claim_stake - 1
+
+    # Withdraw must fail when claim pariod is not over
+    with brownie.reverts("Challenge period not finished"):
+        request_manager.withdraw(claim1_id, {"from": claimer1})
+
+    # Timetravel after claim period
+    chain.mine(timedelta=claim_period + challenge_period)
+
+    assert token.balanceOf(request_manager.address) == transfer_amount
+    assert web3.eth.get_balance(request_manager.address) == 3 * claim_stake + 1
+
+    # The first claim gets withdrawn first
+    # As the challenger wins, no requests funds must be paid out
+    withdraw1_tx = request_manager.withdraw(claim1_id, {"from": requester})
+    assert "ClaimWithdrawn" not in withdraw1_tx.events
+
+    assert token.balanceOf(requester) == 0
+    assert token.balanceOf(claimer1) == 0
+    assert token.balanceOf(claimer2) == 0
+    assert token.balanceOf(request_manager.address) == transfer_amount
+
+    assert web3.eth.get_balance(request_manager.address) == claim_stake
+    assert web3.eth.get_balance(claimer1.address) == claimer1_eth_balance - claim_stake
+    assert web3.eth.get_balance(claimer2.address) == claimer2_eth_balance - claim_stake
+    assert web3.eth.get_balance(challenger.address) == challenger_eth_balance + claim_stake
+
+    # Another withdraw must fail
+    with brownie.reverts("Claim already withdrawn"):
+        request_manager.withdraw(claim1_id, {"from": claimer1})
+
+    # The other claim must be withdrawable, but mustn't transfer the request tokens again
+    withdraw2_tx = request_manager.withdraw(claim2_id, {"from": requester})
+    assert "ClaimWithdrawn" in withdraw2_tx.events
+
+    assert token.balanceOf(requester) == 0
+    assert token.balanceOf(claimer1) == 0
+    assert token.balanceOf(claimer2) == transfer_amount
+    assert token.balanceOf(request_manager.address) == 0
+
+    assert web3.eth.get_balance(request_manager.address) == 0
+    assert web3.eth.get_balance(claimer1.address) == claimer1_eth_balance - claim_stake
+    assert web3.eth.get_balance(claimer2.address) == claimer2_eth_balance
     assert web3.eth.get_balance(challenger.address) == challenger_eth_balance + claim_stake
 
 


### PR DESCRIPTION
Imagine a claim happens by Bob who did NOT fill the request. Now Charlie sees
that and challenges the claim. Non of them should get the request money on the
source chain, as it is currently done.

So the change is done so that only the claimer receives the request funds when a
claim is withdrawn. If Chalie would have been the filler, he would need to
create a seperate claim, which wouldn't be a problem.