### PR TITLE
contracts: Rename RequestManager.{request -> createRequest}

### DIFF
--- a/contracts/contracts/RequestManager.sol
+++ b/contracts/contracts/RequestManager.sol
@@ -121,7 +121,7 @@ contract RequestManager {
         cancellationPeriod = _cancellationPeriod;
     }
 
-    function request(
+    function createRequest(
         uint256 targetChainId,
         address sourceTokenAddress,
         address targetTokenAddress,

--- a/contracts/tests/test_request_manager.py
+++ b/contracts/tests/test_request_manager.py
@@ -149,7 +149,7 @@ def test_withdraw_without_challenge(request_manager, token, claim_stake, claim_p
     assert web3.eth.get_balance(request_manager.address) == 0
 
     token.approve(request_manager.address, transfer_amount, {"from": requester})
-    request_tx = request_manager.request(
+    request_tx = request_manager.createRequest(
         1,
         token.address,
         token.address,
@@ -207,7 +207,7 @@ def test_withdraw_with_challenge(request_manager, token, claim_stake, challenge_
     assert web3.eth.get_balance(request_manager.address) == 0
 
     token.approve(request_manager.address, transfer_amount, {"from": requester})
-    request_tx = request_manager.request(
+    request_tx = request_manager.createRequest(
         1,
         token.address,
         token.address,
@@ -277,7 +277,7 @@ def test_withdraw_with_two_claims(request_manager, token, claim_stake, claim_per
     assert web3.eth.get_balance(request_manager.address) == 0
 
     token.approve(request_manager.address, transfer_amount, {"from": requester})
-    request_tx = request_manager.request(
+    request_tx = request_manager.createRequest(
         1,
         token.address,
         token.address,
@@ -357,7 +357,7 @@ def test_withdraw_with_two_claims_and_challenge(
     assert web3.eth.get_balance(request_manager.address) == 0
 
     token.approve(request_manager.address, transfer_amount, {"from": requester})
-    request_tx = request_manager.request(
+    request_tx = request_manager.createRequest(
         1,
         token.address,
         token.address,
@@ -451,7 +451,7 @@ def test_withdraw_with_two_claims_first_unsuccessful_then_successful(
     assert web3.eth.get_balance(request_manager.address) == 0
 
     token.approve(request_manager.address, transfer_amount, {"from": requester})
-    request_tx = request_manager.request(
+    request_tx = request_manager.createRequest(
         1,
         token.address,
         token.address,
@@ -530,7 +530,7 @@ def test_claim_after_withdraw(request_manager, token, claim_stake, claim_period)
 
     token.mint(requester, transfer_amount, {"from": requester})
     token.approve(request_manager.address, transfer_amount, {"from": requester})
-    request_tx = request_manager.request(
+    request_tx = request_manager.createRequest(
         1,
         token.address,
         token.address,

--- a/contracts/tests/utils.py
+++ b/contracts/tests/utils.py
@@ -2,7 +2,7 @@ def make_request(request_manager, token, requester, amount) -> int:
     token.mint(requester, amount, {"from": requester})
 
     token.approve(request_manager.address, amount, {"from": requester})
-    request_tx = request_manager.request(
+    request_tx = request_manager.createRequest(
         1,
         token.address,
         token.address,

--- a/raisync/tests/test_request.py
+++ b/raisync/tests/test_request.py
@@ -14,7 +14,7 @@ def test_request(request_manager, token, node):
     target_address = accounts[1]
 
     assert not brownie.history.of_address(request_manager.address)
-    request_manager.request(1337, token.address, token.address, target_address, 1)
+    request_manager.createRequest(1337, token.address, token.address, target_address, 1)
     txs = brownie.history.of_address(request_manager.address)
     assert len(txs) == 1
     tx = txs[0]
@@ -81,7 +81,7 @@ def test_fill_and_claim(request_manager, token, node, allow_unlisted_pairs):
     token.approve(request_manager.address, 1, {"from": accounts[0]})
     target_address = accounts[1]
 
-    tx = request_manager.request(1337, token.address, token.address, target_address, 1)
+    tx = request_manager.createRequest(1337, token.address, token.address, target_address, 1)
     request_id = tx.return_value
 
     timeout = 5.0
@@ -112,7 +112,7 @@ def test_withdraw(request_manager, token, node):
     token.approve(request_manager.address, 1, {"from": accounts[0]})
     target_address = accounts[1]
 
-    tx = request_manager.request(1337, token.address, token.address, target_address, 1)
+    tx = request_manager.createRequest(1337, token.address, token.address, target_address, 1)
     request_id = tx.return_value
 
     while (request := node.request_tracker.get(request_id)) is None:


### PR DESCRIPTION
This fixes some warnings in `solc`:

```
Warning: This declaration has the same name as another declaration.
   --> contracts/RequestManager.sol:160:9:
    |
160 |         Request storage request = requests[requestId];
    |         ^^^^^^^^^^^^^^^^^^^^^^^
Note: The other declaration is here:
   --> contracts/RequestManager.sol:124:5:
    |
124 |     function request(
    |     ^ (Relevant source part starts here and spans across multiple lines).


Warning: This declaration has the same name as another declaration.
   --> contracts/RequestManager.sol:172:9:
    |
172 |         Request storage request = requests[requestId];
    |         ^^^^^^^^^^^^^^^^^^^^^^^
Note: The other declaration is here:
   --> contracts/RequestManager.sol:124:5:
    |
124 |     function request(
    |     ^ (Relevant source part starts here and spans across multiple lines).


Warning: This declaration has the same name as another declaration.
   --> contracts/RequestManager.sol:188:9:
    |
188 |         Request storage request = requests[requestId];
    |         ^^^^^^^^^^^^^^^^^^^^^^^
Note: The other declaration is here:
   --> contracts/RequestManager.sol:124:5:
    |
124 |     function request(
    |     ^ (Relevant source part starts here and spans across multiple lines).


Warning: This declaration has the same name as another declaration.
   --> contracts/RequestManager.sol:261:9:
    |
261 |         Request storage request = requests[claim.requestId];
    |         ^^^^^^^^^^^^^^^^^^^^^^^
Note: The other declaration is here:
   --> contracts/RequestManager.sol:124:5:
    |
124 |     function request(
    |     ^ (Relevant source part starts here and spans across multiple lines).


Warning: This declaration has the same name as another declaration.
   --> contracts/RequestManager.sol:302:9:
    |
302 |         Request storage request,
    |         ^^^^^^^^^^^^^^^^^^^^^^^
Note: The other declaration is here:
   --> contracts/RequestManager.sol:124:5:
    |
124 |     function request(
    |     ^ (Relevant source part starts here and spans across multiple lines).
