### PR TITLE
forward request hash instead of request id in resolution

### DIFF
--- a/contracts/contracts/FillManager.sol
+++ b/contracts/contracts/FillManager.sol
@@ -52,7 +52,7 @@ contract FillManager is Ownable {
         require(token.transferFrom(msg.sender, targetReceiverAddress, amount), "Transfer failed");
 
         require(
-            proofSubmitter.submitProof(l1Resolver, requestId, sourceChainId, msg.sender),
+            proofSubmitter.submitProof(l1Resolver, requestHash, sourceChainId, msg.sender),
             "Submitting proof data failed"
         );
     }

--- a/contracts/contracts/OptimismProofSubmitter.sol
+++ b/contracts/contracts/OptimismProofSubmitter.sol
@@ -15,7 +15,7 @@ contract OptimismProofSubmitter is IProofSubmitter, RestrictedCalls {
         messenger = ICrossDomainMessenger(_messenger);
     }
 
-    function submitProof(address l1Resolver, uint256 requestId, uint256 sourceChainId, address eligibleClaimer)
+    function submitProof(address l1Resolver, bytes32 requestHash, uint256 sourceChainId, address eligibleClaimer)
         external restricted(block.chainid, msg.sender) returns (bool)
     {
 
@@ -27,7 +27,7 @@ contract OptimismProofSubmitter is IProofSubmitter, RestrictedCalls {
             l1Resolver,
             abi.encodeWithSelector(
                 Resolver.resolve.selector,
-                requestId,
+                requestHash,
                 block.chainid,
                 sourceChainId,
                 eligibleClaimer

--- a/contracts/contracts/RequestManager.sol
+++ b/contracts/contracts/RequestManager.sol
@@ -284,7 +284,12 @@ contract RequestManager is Ownable {
         address claimReceiver;
         bool depositWithdrawn = request.depositWithdrawn;
 
-        address eligibleClaimer = resolutionRegistry.eligibleClaimers(claim.requestId);
+        bytes32 requestHash = keccak256(
+            abi.encodePacked(
+                claim.requestId, block.chainid, request.targetTokenAddress, request.sender, request.amount
+            )
+        );
+        address eligibleClaimer = resolutionRegistry.eligibleClaimers(requestHash);
         if (eligibleClaimer != address(0)) {
             // L1 resolution has been triggered, the filler is known
             claimReceiver = eligibleClaimer;

--- a/contracts/contracts/ResolutionRegistry.sol
+++ b/contracts/contracts/ResolutionRegistry.sol
@@ -6,20 +6,20 @@ import "./RestrictedCalls.sol";
 contract ResolutionRegistry is RestrictedCalls {
 
     event RequestResolved(
-        uint256 requestId,
+        bytes32 requestHash,
         address resolvedClaimer
     );
 
-    mapping(uint256 => address) public eligibleClaimers;
+    mapping(bytes32 => address) public eligibleClaimers;
 
-    function resolveRequest(uint256 requestId, address eligibleClaimer)
+    function resolveRequest(bytes32 requestHash, address eligibleClaimer)
         external restricted(block.chainid, msg.sender) {
 
-        require(eligibleClaimers[requestId] == address(0), "Resolution already recorded");
-        eligibleClaimers[requestId] = eligibleClaimer;
+        require(eligibleClaimers[requestHash] == address(0), "Resolution already recorded");
+        eligibleClaimers[requestHash] = eligibleClaimer;
 
         emit RequestResolved(
-            requestId,
+            requestHash,
             eligibleClaimer
         );
     }

--- a/contracts/contracts/Resolver.sol
+++ b/contracts/contracts/Resolver.sol
@@ -10,7 +10,7 @@ contract Resolver is Ownable, RestrictedCalls {
     event Resolution(
         uint256 sourceChainId,
         uint256 fillChainId,
-        uint256 requestId,
+        bytes32 requestHash,
         address eligibleClaimer
     );
 
@@ -22,7 +22,7 @@ contract Resolver is Ownable, RestrictedCalls {
         messenger = ICrossDomainMessenger(_messenger);
     }
 
-    function resolve(uint256 requestId, uint256 fillChainId, uint256 sourceChainId, address eligibleClaimer)
+    function resolve(bytes32 requestHash, uint256 fillChainId, uint256 sourceChainId, address eligibleClaimer)
         external restricted(fillChainId, msg.sender) {
 
         address l2RegistryAddress = resolutionRegistries[sourceChainId];
@@ -30,13 +30,13 @@ contract Resolver is Ownable, RestrictedCalls {
 
         bytes memory resolveData = abi.encodeWithSelector(
             ResolutionRegistry.resolveRequest.selector,
-            requestId,
+            requestHash,
             eligibleClaimer
         );
 
         messenger.sendMessage(l2RegistryAddress, resolveData, 1_000_000);
 
-        emit Resolution(sourceChainId, fillChainId, requestId, eligibleClaimer);
+        emit Resolution(sourceChainId, fillChainId, requestHash, eligibleClaimer);
     }
 
     function addRegistry(uint256 chainId, address resolutionRegistry) external onlyOwner {

--- a/contracts/interfaces/IProofSubmitter.sol
+++ b/contracts/interfaces/IProofSubmitter.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.7;
 interface IProofSubmitter {
     function submitProof(
         address l1Resolver,
-        uint256 requestId,
+        bytes32 requestHash,
         uint256 sourceChainId,
         address eligibleClaimer
     ) external returns (bool);

--- a/contracts/tests/test_l1_resolution.py
+++ b/contracts/tests/test_l1_resolution.py
@@ -1,14 +1,24 @@
 import brownie
+import pytest
 from brownie import accounts, web3
 from web3.constants import ADDRESS_ZERO
 
+from contracts.tests.utils import create_request_hash
 
-def test_l1_end_to_end(fill_manager, deployer, resolution_registry, token, resolver):
-    amount = 100
+
+@pytest.mark.parametrize("amount", [100, 99, 101])
+def test_l1_resolution_correct_amount(
+    fill_manager, deployer, resolution_registry, token, resolver, amount
+):
+    requested_amount = 100
     request_id = 23
     filler = accounts[1]
     receiver = accounts[2]
     chain_id = web3.eth.chain_id
+
+    correct_request_hash = create_request_hash(
+        request_id, chain_id, token.address, receiver.address, requested_amount
+    )
 
     fill_manager.addAllowedLP(filler, {"from": deployer})
     resolver.addRegistry(chain_id, resolution_registry.address, {"from": deployer})
@@ -16,12 +26,15 @@ def test_l1_end_to_end(fill_manager, deployer, resolution_registry, token, resol
     token.mint(filler, amount, {"from": filler})
     token.approve(fill_manager.address, amount, {"from": filler})
 
-    assert resolution_registry.eligibleClaimers(request_id) == ADDRESS_ZERO
+    assert resolution_registry.eligibleClaimers(correct_request_hash) == ADDRESS_ZERO
 
     fill_manager.fillRequest(
         chain_id, request_id, token.address, receiver, amount, {"from": filler}
     )
-    assert resolution_registry.eligibleClaimers(request_id) == filler
+    if amount == requested_amount:
+        assert resolution_registry.eligibleClaimers(correct_request_hash) == filler
+    else:
+        assert resolution_registry.eligibleClaimers(correct_request_hash) == ADDRESS_ZERO
 
 
 def test_restricted_calls(contracts, resolver):

--- a/contracts/tests/test_request_manager.py
+++ b/contracts/tests/test_request_manager.py
@@ -1,7 +1,7 @@
 import brownie
 from brownie import accounts, chain, web3
 
-from contracts.tests.utils import make_request
+from contracts.tests.utils import make_request, create_request_hash
 
 
 def test_claim_with_different_stakes(token, request_manager, claim_stake):
@@ -545,9 +545,15 @@ def test_withdraw_without_challenge_with_resolution(
     assert web3.eth.get_balance(request_manager.address) == claim_stake
     assert web3.eth.get_balance(claimer.address) == claimer_eth_balance - claim_stake
 
+    request_hash = create_request_hash(
+        request_id, web3.eth.chain_id, token.address, requester.address, transfer_amount
+    )
+
     # Register a L1 resolution
-    resolution_registry.resolveRequest(request_id, claimer.address, {"from": contracts.messenger2})
-    # The claim pariod is not over, but the resolution must allow withdrawal now
+    resolution_registry.resolveRequest(
+        request_hash, claimer.address, {"from": contracts.messenger2}
+    )
+    # The claim period is not over, but the resolution must allow withdrawal now
     withdraw_tx = request_manager.withdraw(claim_id, {"from": claimer})
     assert "ClaimWithdrawn" in withdraw_tx.events
 

--- a/contracts/tests/utils.py
+++ b/contracts/tests/utils.py
@@ -1,3 +1,7 @@
+from eth_abi.packed import encode_abi_packed
+from eth_utils import keccak, to_canonical_address
+
+
 def make_request(
     request_manager, token, requester, amount, zero_fees=True, validity_period=3600
 ) -> int:
@@ -20,3 +24,18 @@ def make_request(
         {"from": requester, "value": total_fee},
     )
     return request_tx.return_value
+
+
+def create_request_hash(request_id, chain_id, token_address, receiver_address, amount):
+    return keccak(
+        encode_abi_packed(
+            ["uint256", "uint256", "address", "address", "uint256"],
+            [
+                request_id,
+                chain_id,
+                to_canonical_address(token_address),
+                to_canonical_address(receiver_address),
+                amount,
+            ],
+        )
+    )


### PR DESCRIPTION
- forward request hash instead of request id in resolution path.
- identify eligible claimer by request hash

```
bytes32 requestHash = keccak256(
            abi.encodePacked(
                requestId, sourceChainId, targetTokenAddress, targetReceiverAddress, amount
            )
        );
``` 

fixes: #187  