### PR TITLE
CrossDomainRestrictedCalls

### DIFF
--- a/contracts/contracts/CrossDomainRestrictedCalls.sol
+++ b/contracts/contracts/CrossDomainRestrictedCalls.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.7;
+
+import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/access/Ownable.sol";
+import "../interfaces/ICrossDomainMessenger.sol";
+
+
+contract CrossDomainRestrictedCalls is Ownable {
+    struct MessengerSource {
+        ICrossDomainMessenger crossDomainMessenger;
+        address sender;
+    }
+
+    mapping (uint256 => MessengerSource) public messengers;
+
+    function addCaller(uint256 chainId, address messenger, address proofSubmitter) external onlyOwner {
+        messengers[chainId] = MessengerSource(ICrossDomainMessenger(messenger), proofSubmitter);
+    }
+
+    modifier restricted(uint256 chainId, address caller) {
+        MessengerSource storage s = messengers[chainId];
+        require(
+            caller == address(s.crossDomainMessenger), "XRestrictedCalls: unknown caller"
+        );
+        require(
+            s.crossDomainMessenger.xDomainMessageSender() == s.sender,
+            "XRestrictedCalls: unknown caller"
+        );
+        _;
+    }
+}

--- a/contracts/contracts/ResolutionRegistry.sol
+++ b/contracts/contracts/ResolutionRegistry.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import "./RestrictedCalls.sol";
+import "./CrossDomainRestrictedCalls.sol";
 
-contract ResolutionRegistry is RestrictedCalls {
+contract ResolutionRegistry is CrossDomainRestrictedCalls {
 
     event RequestResolved(
         bytes32 requestHash,

--- a/contracts/contracts/Resolver.sol
+++ b/contracts/contracts/Resolver.sol
@@ -4,9 +4,10 @@ pragma solidity ^0.8.7;
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/access/Ownable.sol";
 import "../interfaces/ICrossDomainMessenger.sol";
 import "./ResolutionRegistry.sol";
-import "./RestrictedCalls.sol";
+import "./CrossDomainRestrictedCalls.sol";
 
-contract Resolver is Ownable, RestrictedCalls {
+
+contract Resolver is Ownable, CrossDomainRestrictedCalls {
     event Resolution(
         uint256 sourceChainId,
         uint256 fillChainId,

--- a/contracts/contracts/TestCrossDomainMessenger.sol
+++ b/contracts/contracts/TestCrossDomainMessenger.sol
@@ -2,9 +2,8 @@
 pragma solidity ^0.8.7;
 
 import "../interfaces/ICrossDomainMessenger.sol";
-import "./RestrictedCalls.sol";
 
-contract TestCrossDomainMessenger is ICrossDomainMessenger, RestrictedCalls {
+contract TestCrossDomainMessenger is ICrossDomainMessenger {
     address lastSender;
     bool forwardMessages;
 
@@ -16,13 +15,16 @@ contract TestCrossDomainMessenger is ICrossDomainMessenger, RestrictedCalls {
         address _target,
         bytes calldata _message,
         uint32 _gasLimit
-    ) external restricted(block.chainid, msg.sender) {
-
+    ) external {
         if (forwardMessages) {
             lastSender = msg.sender;
             (bool success, ) = _target.call{gas: _gasLimit}(_message);
             require(success, "tx failed");
         }
+    }
+
+    function setLastSender(address sender) external {
+        lastSender = sender;
     }
 
     function setForwardState(bool _forward) external {

--- a/contracts/tests/conftest.py
+++ b/contracts/tests/conftest.py
@@ -87,10 +87,8 @@ def contracts(deployer, claim_stake, claim_period, challenge_period, challenge_p
     l1_chain_id = l2_chain_id = brownie.chain.id
 
     proof_submitter.addCaller(l2_chain_id, fill_manager.address)
-    messenger1.addCaller(l2_chain_id, proof_submitter.address)
-    resolver.addCaller(l2_chain_id, messenger1.address)
-    messenger2.addCaller(l1_chain_id, resolver.address)
-    resolution_registry.addCaller(l1_chain_id, messenger2.address)
+    resolver.addCaller(l2_chain_id, messenger1.address, proof_submitter.address)
+    resolution_registry.addCaller(l1_chain_id, messenger2.address, resolver.address)
 
     return Contracts(
         messenger1=messenger1,

--- a/contracts/tests/test_l1_resolution.py
+++ b/contracts/tests/test_l1_resolution.py
@@ -48,14 +48,8 @@ def test_restricted_calls(contracts, resolver):
             resolver, 0, brownie.chain.id, caller, {"from": caller}
         )
 
-    with brownie.reverts("RestrictedCalls: unknown caller"):
-        contracts.messenger1.sendMessage(resolver, b"\x00", 1_000_000, {"from": caller})
-
-    with brownie.reverts("RestrictedCalls: unknown caller"):
+    with brownie.reverts("XRestrictedCalls: unknown caller"):
         contracts.resolver.resolve(0, brownie.chain.id, brownie.chain.id, caller, {"from": caller})
 
-    with brownie.reverts("RestrictedCalls: unknown caller"):
-        contracts.messenger2.sendMessage(resolver, b"\x00", 1_000_000, {"from": caller})
-
-    with brownie.reverts("RestrictedCalls: unknown caller"):
+    with brownie.reverts("XRestrictedCalls: unknown caller"):
         contracts.resolution_registry.resolveRequest(0, caller, {"from": caller})

--- a/contracts/tests/test_request_manager.py
+++ b/contracts/tests/test_request_manager.py
@@ -1,7 +1,7 @@
 import brownie
 from brownie import accounts, chain, web3
 
-from contracts.tests.utils import make_request, create_request_hash
+from contracts.tests.utils import create_request_hash, make_request
 
 
 def test_claim_with_different_stakes(token, request_manager, claim_stake):
@@ -550,10 +550,11 @@ def test_withdraw_without_challenge_with_resolution(
     )
 
     # Register a L1 resolution
+    contracts.messenger2.setLastSender(contracts.resolver.address)
     resolution_registry.resolveRequest(
         request_hash, claimer.address, {"from": contracts.messenger2}
     )
-    # The claim period is not over, but the resolution must allow withdrawal now
+    # The claim pariod is not over, but the resolution must allow withdrawal now
     withdraw_tx = request_manager.withdraw(claim_id, {"from": claimer})
     assert "ClaimWithdrawn" in withdraw_tx.events
 

--- a/raisync/tests/conftest.py
+++ b/raisync/tests/conftest.py
@@ -88,10 +88,8 @@ def contracts(deployer):
     l1_chain_id = l2_chain_id = brownie.chain.id
 
     proof_submitter.addCaller(l2_chain_id, fill_manager.address)
-    messenger1.addCaller(l2_chain_id, proof_submitter.address)
-    resolver.addCaller(l2_chain_id, messenger1.address)
-    messenger2.addCaller(l1_chain_id, resolver.address)
-    resolution_registry.addCaller(l1_chain_id, messenger2.address)
+    resolver.addCaller(l2_chain_id, messenger1.address, proof_submitter.address)
+    resolution_registry.addCaller(l1_chain_id, messenger2.address, resolver.address)
 
     return Contracts(
         messenger1=messenger1,


### PR DESCRIPTION
This makes it possible to check if cross chain messages have whitelisted
senders.

Also, remove the whitelisting on the `TestCrossDomainMessenger`. As we cannot control those contracts in reality, we shouldn't in the tests either.