### PR TITLE
Use SafeERC20 for ERC20 token transfers

### DIFF
--- a/contracts/contracts/FillManager.sol
+++ b/contracts/contracts/FillManager.sol
@@ -2,11 +2,13 @@
 pragma solidity ^0.8.7;
 
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/token/ERC20/IERC20.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/token/ERC20/utils/SafeERC20.sol";
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/access/Ownable.sol";
 import "../interfaces/IProofSubmitter.sol";
 
 
 contract FillManager is Ownable {
+    using SafeERC20 for IERC20;
 
     event RequestFilled(
         uint256 indexed requestId,
@@ -49,7 +51,7 @@ contract FillManager is Ownable {
         emit RequestFilled(requestId, sourceChainId, targetTokenAddress, msg.sender, amount);
 
         IERC20 token = IERC20(targetTokenAddress);
-        require(token.transferFrom(msg.sender, targetReceiverAddress, amount), "Transfer failed");
+        token.safeTransferFrom(msg.sender, targetReceiverAddress, amount);
 
         require(
             proofSubmitter.submitProof(l1Resolver, requestId, sourceChainId, msg.sender),

--- a/contracts/contracts/RequestManager.sol
+++ b/contracts/contracts/RequestManager.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.7;
 
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/token/ERC20/IERC20.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/token/ERC20/utils/SafeERC20.sol";
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/utils/math/Math.sol";
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/access/Ownable.sol";
 
@@ -9,6 +10,7 @@ import "./ResolutionRegistry.sol";
 
 contract RequestManager is Ownable {
     using Math for uint256;
+    using SafeERC20 for IERC20;
 
     // Structs
     // TODO: check if we can use a smaller type for `targetChainId`, so that the
@@ -177,7 +179,7 @@ contract RequestManager is Ownable {
         );
 
         IERC20 token = IERC20(sourceTokenAddress);
-        require(token.transferFrom(msg.sender, address(this), amount), "Transfer failed");
+        token.safeTransferFrom(msg.sender, address(this), amount);
 
         return requestCounter;
     }
@@ -194,7 +196,7 @@ contract RequestManager is Ownable {
         emit DepositWithdrawn(requestId);
 
         IERC20 token = IERC20(request.sourceTokenAddress);
-        require(token.transfer(request.sender, request.amount), "Transfer failed");
+        token.safeTransfer(request.sender, request.amount);
 
         (bool sent,) = request.sender.call{value: request.lpFee + request.raisyncFee}("");
         require(sent, "Failed to send Ether");
@@ -324,7 +326,7 @@ contract RequestManager is Ownable {
         );
 
         IERC20 token = IERC20(request.sourceTokenAddress);
-        require(token.transfer(claimReceiver, request.amount), "Transfer failed");
+        token.safeTransfer(claimReceiver, request.amount);
 
         (bool sent,) = claimReceiver.call{value: request.lpFee}("");
         require(sent, "Failed to send Ether");


### PR DESCRIPTION
This PR introduces the Wrapper Library [SafeERC20](https://docs.openzeppelin.com/contracts/2.x/api/token/erc20) for safe ERC 20 token transfers.

More information in #183 

fixes: #183 