### PR TITLE
Introduce fill hash

### DIFF
--- a/contracts/contracts/FillManager.sol
+++ b/contracts/contracts/FillManager.sol
@@ -5,6 +5,7 @@ import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/token/ERC20/IERC20.s
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/token/ERC20/utils/SafeERC20.sol";
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/access/Ownable.sol";
 import "../interfaces/IProofSubmitter.sol";
+import "./RaisyncUtils.sol";
 
 
 contract FillManager is Ownable {
@@ -32,8 +33,8 @@ contract FillManager is Ownable {
     }
 
     function fillRequest(
-        uint256 sourceChainId,
         uint256 requestId,
+        uint256 sourceChainId,
         address targetTokenAddress,
         address targetReceiverAddress,
         uint256 amount
@@ -42,11 +43,10 @@ contract FillManager is Ownable {
     returns (uint256)
     {
         require(allowedLPs[msg.sender], "Sender not whitelisted");
-        bytes32 requestHash = keccak256(
-            abi.encodePacked(
+        bytes32 requestHash = RaisyncUtils.createRequestHash(
                 requestId, sourceChainId, targetTokenAddress, targetReceiverAddress, amount
-            )
-        );
+            );
+
         require(!fills[requestHash], "Already filled");
         fills[requestHash] = true;
 

--- a/contracts/contracts/OptimismProofSubmitter.sol
+++ b/contracts/contracts/OptimismProofSubmitter.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.7;
 import "../interfaces/IProofSubmitter.sol";
 import "../interfaces/ICrossDomainMessenger.sol";
 
+import "./RaisyncUtils.sol";
 import "./Resolver.sol";
 import "./RestrictedCalls.sol";
 
@@ -16,7 +17,7 @@ contract OptimismProofSubmitter is IProofSubmitter, RestrictedCalls {
     }
 
     function submitProof(address l1Resolver, bytes32 requestHash, uint256 sourceChainId, address eligibleClaimer)
-        external restricted(block.chainid, msg.sender)  returns (uint256)
+        external restricted(block.chainid, msg.sender) returns (uint256)
     {
         // Questions
         // - what gas limit
@@ -26,8 +27,7 @@ contract OptimismProofSubmitter is IProofSubmitter, RestrictedCalls {
             l1Resolver,
             abi.encodeWithSelector(
                 Resolver.resolve.selector,
-                requestHash,
-                block.number,
+                RaisyncUtils.createFillHash(requestHash, block.number),
                 block.chainid,
                 sourceChainId,
                 eligibleClaimer

--- a/contracts/contracts/RaisyncUtils.sol
+++ b/contracts/contracts/RaisyncUtils.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.7;
+
+
+library RaisyncUtils {
+
+    function createRequestHash(
+        uint256 requestId,
+        uint256 sourceChainId,
+        address targetTokenAddress,
+        address targetReceiverAddress,
+        uint256 amount
+    ) internal pure returns (bytes32){
+        return keccak256(
+            abi.encodePacked(
+                requestId, sourceChainId, targetTokenAddress, targetReceiverAddress, amount
+            )
+        );
+    }
+
+    function createFillHash(bytes32 requestHash, uint256 fillId) internal pure returns (bytes32){
+        return keccak256(abi.encodePacked(requestHash, fillId));
+    }
+
+    function createFillHash(
+        uint256 requestId,
+        uint256 sourceChainId,
+        address targetTokenAddress,
+        address targetReceiverAddress,
+        uint256 amount,
+        uint256 fillId
+    ) internal pure returns (bytes32){
+        return createFillHash(
+            createRequestHash(
+                requestId, sourceChainId, targetTokenAddress, targetReceiverAddress, amount
+            ),
+                fillId
+        );
+    }
+
+}

--- a/contracts/contracts/ResolutionRegistry.sol
+++ b/contracts/contracts/ResolutionRegistry.sol
@@ -3,31 +3,24 @@ pragma solidity ^0.8.7;
 
 import "./CrossDomainRestrictedCalls.sol";
 
-struct ProvedFill {
-    address filler;
-    uint256 fillId;
-}
-
 contract ResolutionRegistry is CrossDomainRestrictedCalls {
 
     event RequestResolved(
-        bytes32 requestHash,
-        uint256 fillId,
-        address resolvedClaimer
+        bytes32 fillHash,
+        address filler
     );
 
-    // mapping from requestHash to (filler, fillId)
-    mapping(bytes32 => ProvedFill) public provedFills;
+    // mapping from fillHash to eligible claimer
+    mapping(bytes32 => address) public fillers;
 
-    function resolveRequest(bytes32 requestHash, uint256 fillId, uint256 resolutionChainId, address filler)
+    function resolveRequest(bytes32 fillHash, uint256 resolutionChainId, address filler)
         external restricted(resolutionChainId, msg.sender) {
 
-        require(provedFills[requestHash].filler == address(0), "Resolution already recorded");
-        provedFills[requestHash] = ProvedFill(filler, fillId);
+        require(fillers[fillHash] == address(0), "Resolution already recorded");
+        fillers[fillHash] = filler;
 
         emit RequestResolved(
-            requestHash,
-            fillId,
+            fillHash,
             filler
         );
     }

--- a/contracts/contracts/Resolver.sol
+++ b/contracts/contracts/Resolver.sol
@@ -11,8 +11,8 @@ contract Resolver is Ownable, CrossDomainRestrictedCalls {
     event Resolution(
         uint256 sourceChainId,
         uint256 fillChainId,
-        bytes32 requestHash,
-        address eligibleClaimer
+        bytes32 fillHash,
+        address filler
     );
 
     ICrossDomainMessenger l2Messenger;
@@ -23,7 +23,7 @@ contract Resolver is Ownable, CrossDomainRestrictedCalls {
         l2Messenger = ICrossDomainMessenger(_l2Messenger);
     }
 
-    function resolve(bytes32 requestHash, uint256 fillId, uint256 fillChainId, uint256 sourceChainId, address filler)
+    function resolve(bytes32 fillHash, uint256 fillChainId, uint256 sourceChainId, address filler)
         external restricted(fillChainId, msg.sender) {
 
         address l2RegistryAddress = resolutionRegistries[sourceChainId];
@@ -33,15 +33,14 @@ contract Resolver is Ownable, CrossDomainRestrictedCalls {
             l2RegistryAddress,
             abi.encodeWithSelector(
                 ResolutionRegistry.resolveRequest.selector,
-                requestHash,
-                fillId,
+                fillHash,
                 block.chainid,
                 filler
             ),
             1_000_000
         );
 
-        emit Resolution(sourceChainId, fillChainId, requestHash, filler);
+        emit Resolution(sourceChainId, fillChainId, fillHash, filler);
     }
 
     function addRegistry(uint256 chainId, address resolutionRegistry) external onlyOwner {

--- a/contracts/tests/test_fill_manager.py
+++ b/contracts/tests/test_fill_manager.py
@@ -16,8 +16,8 @@ def test_fill_request(fill_manager, token, deployer, resolver, resolution_regist
 
     token.approve(fill_manager.address, amount, {"from": deployer})
     fill_manager.fillRequest(
-        chain_id,
         1,
+        chain_id,
         token.address,
         receiver,
         amount,
@@ -26,8 +26,8 @@ def test_fill_request(fill_manager, token, deployer, resolver, resolution_regist
 
     with brownie.reverts("Already filled"):
         fill_manager.fillRequest(
-            chain_id,
             1,
+            chain_id,
             token.address,
             receiver,
             amount,
@@ -37,8 +37,8 @@ def test_fill_request(fill_manager, token, deployer, resolver, resolution_regist
     fill_manager.removeAllowedLP(deployer, {"from": deployer})
     with brownie.reverts("Sender not whitelisted"):
         fill_manager.fillRequest(
-            chain_id,
             1,
+            chain_id,
             token.address,
             receiver,
             amount,

--- a/contracts/tests/test_request_manager.py
+++ b/contracts/tests/test_request_manager.py
@@ -1,7 +1,7 @@
 import brownie
 from brownie import accounts, chain, web3
 
-from contracts.tests.utils import create_request_hash, make_request
+from contracts.tests.utils import make_request, create_fill_hash
 
 
 def test_claim(token, request_manager, claim_stake):
@@ -597,15 +597,16 @@ def test_withdraw_without_challenge_with_resolution(
     assert web3.eth.get_balance(request_manager.address) == claim_stake
     assert web3.eth.get_balance(claimer.address) == claimer_eth_balance - claim_stake
 
-    request_hash = create_request_hash(
-        request_id, web3.eth.chain_id, token.address, requester.address, transfer_amount
+    fill_hash = create_fill_hash(
+        request_id, web3.eth.chain_id, token.address, requester.address, transfer_amount, fill_id
     )
 
     # Register a L1 resolution
     contracts.messenger2.setLastSender(contracts.resolver.address)
     resolution_registry.resolveRequest(
-        request_hash, fill_id, web3.eth.chain_id, claimer.address, {"from": contracts.messenger2}
+        fill_hash, web3.eth.chain_id, claimer.address, {"from": contracts.messenger2}
     )
+
     # The claim period is not over, but the resolution must allow withdrawal now
     withdraw_tx = request_manager.withdraw(claim_id, {"from": claimer})
     assert "ClaimWithdrawn" in withdraw_tx.events

--- a/contracts/tests/utils.py
+++ b/contracts/tests/utils.py
@@ -18,7 +18,7 @@ def make_request(
         1,
         token.address,
         token.address,
-        "0x5d5640575161450A674a094730365A223B226649",
+        requester,
         amount,
         validity_period,
         {"from": requester, "value": total_fee},
@@ -36,6 +36,18 @@ def create_request_hash(request_id, chain_id, token_address, receiver_address, a
                 to_canonical_address(token_address),
                 to_canonical_address(receiver_address),
                 amount,
+            ],
+        )
+    )
+
+
+def create_fill_hash(request_id, chain_id, token_address, receiver_address, amount, fill_id):
+    return keccak(
+        encode_abi_packed(
+            ["bytes32", "uint256"],
+            [
+                create_request_hash(request_id, chain_id, token_address, receiver_address, amount),
+                fill_id,
             ],
         )
     )

--- a/raisync/chain.py
+++ b/raisync/chain.py
@@ -330,8 +330,8 @@ class EventProcessor:
 
         try:
             txn_hash = self._fill_manager.functions.fillRequest(
-                sourceChainId=request.source_chain_id,
                 requestId=request.id,
+                sourceChainId=request.source_chain_id,
                 targetTokenAddress=request.target_token_address,
                 targetReceiverAddress=request.target_address,
                 amount=request.amount,


### PR DESCRIPTION
This PR builds on #193 


As in #174 we need a fillID which is created during a fill by the `IProofSubmitter` of the corresponding roll up and is ideally "non-deterministic".
We need this in order to make it impossible (or at least less likely) to claim an unfilled request. We prevent the following malicious behavior

### malicious behavior
1) malicious alice claims an unfilled request
2) honest bob challenges the request
3) malicious alice fills the request afterwards
4) malicious alice wins the challenge as the eligible claimer and gets bob's stake

this possibility disincentivizes bob to challenge an unfilled request.

### Fill ID
The fill id is generated at the moment of `fillRequest`
Each claim is only valid for a specific fill id. If malicious alice claims without having filled yet she must guess a fill id to add to the claim. The less deterministic a fill id is the less likely it is to guess the fill id in advance. 


## Introducing the notion of `requestHash` and `fillHash`

In order to identify exactly a request and a fill two hashes to identify either a request or a fill are introduced. 

### requestHash
The `requestHash` is a keccak hash of the following information: 
```
- request id
- source chain id
- target token address
- target token receiver
- amount
```
These information hashed together create a unique hash for each request.

#### Why do we need this?
In the fill manager we need to revert on multiple fills for the same request. We can mark a request at the first fill by remembering the requestHash.


### fillHash
The `requestHash` is a keccak hash of the following information: 
```
- requestHash
- fillId
```
These information hashed together create a unique hash for a specific fill for a request.
#### Why do we need this?
Each fill receives a unique fill ID. The unique fill id can be generated differently on each roll up implementation. In order to guarantee the chronological order of `[fill, claim]`, the fill id must be passed upon claiming. To ultimately check whether the claim includes the fill id of the correct fill for this request, L1 resolution must pass this information as well.
This means that there is only a successful L1 resolution if the source chain has stored the same information as they are passed through L1.
This can be done by hashing the request hash and fill id together, creating a unique hash for a given request with a specific fill id.


## additional changes
- outsourcing creation of hashes to a library which is reused by `Request- and FillManager`





