### PR TITLE
contracts: Update to solc 0.8.12

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -12,7 +12,7 @@ dependencies:
 compiler:
   evm_version: london
   solc:
-    version: 0.8.11
+    version: 0.8.12
 
 dev_deployment_artifacts: true
 

--- a/contracts/contracts/CrossDomainRestrictedCalls.sol
+++ b/contracts/contracts/CrossDomainRestrictedCalls.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.12;
 
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/access/Ownable.sol";
 import "../interfaces/ICrossDomainMessenger.sol";

--- a/contracts/contracts/FillManager.sol
+++ b/contracts/contracts/FillManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.12;
 
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/token/ERC20/IERC20.sol";
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/contracts/MintableToken.sol
+++ b/contracts/contracts/MintableToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.12;
 
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/contracts/RaisyncUtils.sol
+++ b/contracts/contracts/RaisyncUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.12;
 
 
 library RaisyncUtils {

--- a/contracts/contracts/RequestManager.sol
+++ b/contracts/contracts/RequestManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.12;
 
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/token/ERC20/IERC20.sol";
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/contracts/ResolutionRegistry.sol
+++ b/contracts/contracts/ResolutionRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.12;
 
 import "./CrossDomainRestrictedCalls.sol";
 

--- a/contracts/contracts/Resolver.sol
+++ b/contracts/contracts/Resolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.12;
 
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/access/Ownable.sol";
 import "../interfaces/ICrossDomainMessenger.sol";
@@ -32,11 +32,13 @@ contract Resolver is Ownable, CrossDomainRestrictedCalls {
         ICrossDomainMessenger messenger = ICrossDomainMessenger(info.messenger);
         messenger.sendMessage(
             info.resolutionRegistry,
-            abi.encodeWithSelector(
-                ResolutionRegistry.resolveRequest.selector,
-                fillHash,
-                block.chainid,
-                filler
+            abi.encodeCall(
+                ResolutionRegistry.resolveRequest,
+                (
+                    fillHash,
+                    block.chainid,
+                    filler
+                )
             ),
             1_000_000
         );

--- a/contracts/contracts/RestrictedCalls.sol
+++ b/contracts/contracts/RestrictedCalls.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.12;
 
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/access/Ownable.sol";
 

--- a/contracts/contracts/StandardToken.sol
+++ b/contracts/contracts/StandardToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.12;
 
 import "OpenZeppelin/openzeppelin-contracts@4.4.2/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/contracts/TestCrossDomainMessenger.sol
+++ b/contracts/contracts/TestCrossDomainMessenger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.12;
 
 import "../interfaces/ICrossDomainMessenger.sol";
 

--- a/contracts/interfaces/ICrossDomainMessenger.sol
+++ b/contracts/interfaces/ICrossDomainMessenger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.12;
 
 /**
  * @title ICrossDomainMessenger

--- a/contracts/interfaces/IProofSubmitter.sol
+++ b/contracts/interfaces/IProofSubmitter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.12;
 
 interface IProofSubmitter {
     function submitProof(


### PR DESCRIPTION
This allows us to use the type checked `abi.encodeCall` instead of
`abi.encodeWithSelector`.