### PR TITLE
contracts: Support multiple source rollups in resolver

### DIFF
--- a/contracts/scripts/deploy.py
+++ b/contracts/scripts/deploy.py
@@ -17,7 +17,7 @@ def main() -> None:
     deployer = accounts.at("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266")
 
     messenger = TestCrossDomainMessenger.deploy({"from": deployer})
-    resolver = Resolver.deploy(messenger.address, {"from": deployer})
+    resolver = Resolver.deploy({"from": deployer})
     resolution_registry = ResolutionRegistry.deploy({"from": deployer})
 
     MintableToken.deploy(int(1e18), {"from": deployer})
@@ -39,4 +39,6 @@ def main() -> None:
     f = FillManager.deploy(resolver.address, proof_submitter.address, {"from": deployer})
     f.addAllowedLP(deployer.address, {"from": deployer})
 
-    resolver.addRegistry(web3.eth.chain_id, resolution_registry.address, {"from": deployer})
+    resolver.addRegistry(
+        web3.eth.chain_id, resolution_registry.address, messenger.address, {"from": deployer}
+    )

--- a/contracts/tests/conftest.py
+++ b/contracts/tests/conftest.py
@@ -63,11 +63,11 @@ def contracts(deployer, claim_stake, claim_period, challenge_period, challenge_p
     # L1 contracts
     messenger2 = deployer.deploy(TestCrossDomainMessenger)
     messenger2.setForwardState(True)
-    resolver = deployer.deploy(Resolver, messenger2.address)
+    resolver = deployer.deploy(Resolver)
 
     # L2b contracts, again
     proof_submitter = deployer.deploy(OptimismProofSubmitter, messenger1.address)
-    fill_manager = deployer.deploy(FillManager, resolver, proof_submitter.address)
+    fill_manager = deployer.deploy(FillManager, resolver.address, proof_submitter.address)
 
     # L2a contracts
     resolution_registry = deployer.deploy(ResolutionRegistry)
@@ -90,6 +90,7 @@ def contracts(deployer, claim_stake, claim_period, challenge_period, challenge_p
     resolver.addCaller(l2_chain_id, messenger1.address, proof_submitter.address)
     resolution_registry.addCaller(l1_chain_id, messenger2.address, resolver.address)
 
+    resolver.addRegistry(l2_chain_id, resolution_registry.address, messenger2.address)
     return Contracts(
         messenger1=messenger1,
         messenger2=messenger2,

--- a/contracts/tests/test_fill_manager.py
+++ b/contracts/tests/test_fill_manager.py
@@ -2,12 +2,10 @@ import brownie
 from brownie import accounts, web3
 
 
-def test_fill_request(fill_manager, token, deployer, resolver, resolution_registry):
+def test_fill_request(fill_manager, token, deployer):
     chain_id = web3.eth.chain_id
     amount = 100
     receiver = accounts[2]
-
-    resolver.addRegistry(chain_id, resolution_registry.address, {"from": deployer})
 
     with brownie.reverts("Ownable: caller is not the owner"):
         fill_manager.addAllowedLP(deployer, {"from": accounts[1]})

--- a/contracts/tests/test_l1_resolution.py
+++ b/contracts/tests/test_l1_resolution.py
@@ -8,7 +8,7 @@ from contracts.tests.utils import create_fill_hash
 @pytest.mark.parametrize("amount", [100, 99, 101])
 @pytest.mark.parametrize("use_correct_fill_id", [True, False])
 def test_l1_resolution_correct_hash(
-    fill_manager, deployer, resolution_registry, token, resolver, amount, use_correct_fill_id
+    fill_manager, deployer, resolution_registry, token, amount, use_correct_fill_id
 ):
     requested_amount = 100
     request_id = 23
@@ -17,7 +17,6 @@ def test_l1_resolution_correct_hash(
     chain_id = web3.eth.chain_id
 
     fill_manager.addAllowedLP(filler, {"from": deployer})
-    resolver.addRegistry(chain_id, resolution_registry.address, {"from": deployer})
 
     token.mint(filler, amount, {"from": filler})
     token.approve(fill_manager.address, amount, {"from": filler})

--- a/contracts/tests/test_request_manager.py
+++ b/contracts/tests/test_request_manager.py
@@ -1,7 +1,7 @@
 import brownie
 from brownie import accounts, chain, web3
 
-from contracts.tests.utils import make_request, create_fill_hash
+from contracts.tests.utils import create_fill_hash, make_request
 
 
 def test_claim(token, request_manager, claim_stake):

--- a/raisync/tests/conftest.py
+++ b/raisync/tests/conftest.py
@@ -59,11 +59,11 @@ def contracts(deployer):
     # L1 contracts
     messenger2 = deployer.deploy(TestCrossDomainMessenger)
     messenger2.setForwardState(False)
-    resolver = deployer.deploy(Resolver, messenger2.address)
+    resolver = deployer.deploy(Resolver)
 
     # L2b contracts, again
     proof_submitter = deployer.deploy(OptimismProofSubmitter, messenger1.address)
-    fill_manager = deployer.deploy(FillManager, resolver, proof_submitter.address)
+    fill_manager = deployer.deploy(FillManager, resolver.address, proof_submitter.address)
     fill_manager.addAllowedLP(_LOCAL_ACCOUNT)
 
     # L2a contracts
@@ -90,6 +90,8 @@ def contracts(deployer):
     proof_submitter.addCaller(l2_chain_id, fill_manager.address)
     resolver.addCaller(l2_chain_id, messenger1.address, proof_submitter.address)
     resolution_registry.addCaller(l1_chain_id, messenger2.address, resolver.address)
+
+    resolver.addRegistry(l2_chain_id, resolution_registry.address, messenger2.address)
 
     return Contracts(
         messenger1=messenger1,

--- a/raisync/tests/test_request.py
+++ b/raisync/tests/test_request.py
@@ -47,11 +47,7 @@ def test_read_timeout(config):
 
 
 @pytest.mark.parametrize("allow_unlisted_pairs", (True, False))
-def test_fill_and_claim(
-    request_manager, token, node, allow_unlisted_pairs, resolver, resolution_registry
-):
-    resolver.addRegistry(brownie.chain.id, resolution_registry.address, {"from": accounts[0]})
-
+def test_fill_and_claim(request_manager, token, node, allow_unlisted_pairs):
     target_address = accounts[1]
     request_id = make_request(request_manager, token, accounts[0], target_address, 1)
 
@@ -77,9 +73,7 @@ def test_fill_and_claim(
     assert claims[0].claimer == node.address
 
 
-def test_withdraw(request_manager, token, node, resolver, resolution_registry):
-    resolver.addRegistry(brownie.chain.id, resolution_registry.address, {"from": accounts[0]})
-
+def test_withdraw(request_manager, token, node):
     target_address = accounts[1]
     request_id = make_request(request_manager, token, accounts[0], target_address, 1)
 


### PR DESCRIPTION
Resolves https://github.com/raisync-project/raisync/issues/189

This isn't rollup agnostic yet, but I don't see a point in spending time on this now.