### PR TITLE
contracts: include target chain id in request hash

### DIFF
--- a/contracts/contracts/FillManager.sol
+++ b/contracts/contracts/FillManager.sol
@@ -44,7 +44,7 @@ contract FillManager is Ownable {
     {
         require(allowedLPs[msg.sender], "Sender not whitelisted");
         bytes32 requestHash = RaisyncUtils.createRequestHash(
-                requestId, sourceChainId, targetTokenAddress, targetReceiverAddress, amount
+                requestId, sourceChainId, block.chainid, targetTokenAddress, targetReceiverAddress, amount
             );
 
         require(!fills[requestHash], "Already filled");

--- a/contracts/contracts/RaisyncUtils.sol
+++ b/contracts/contracts/RaisyncUtils.sol
@@ -7,13 +7,14 @@ library RaisyncUtils {
     function createRequestHash(
         uint256 requestId,
         uint256 sourceChainId,
+        uint256 targetChainId,
         address targetTokenAddress,
         address targetReceiverAddress,
         uint256 amount
     ) internal pure returns (bytes32){
         return keccak256(
             abi.encodePacked(
-                requestId, sourceChainId, targetTokenAddress, targetReceiverAddress, amount
+                requestId, sourceChainId, targetChainId, targetTokenAddress, targetReceiverAddress, amount
             )
         );
     }
@@ -25,6 +26,7 @@ library RaisyncUtils {
     function createFillHash(
         uint256 requestId,
         uint256 sourceChainId,
+        uint256 targetChainId,
         address targetTokenAddress,
         address targetReceiverAddress,
         uint256 amount,
@@ -32,7 +34,7 @@ library RaisyncUtils {
     ) internal pure returns (bytes32){
         return createFillHash(
             createRequestHash(
-                requestId, sourceChainId, targetTokenAddress, targetReceiverAddress, amount
+                requestId, sourceChainId, targetChainId, targetTokenAddress, targetReceiverAddress, amount
             ),
                 fillId
         );

--- a/contracts/contracts/RequestManager.sol
+++ b/contracts/contracts/RequestManager.sol
@@ -294,6 +294,7 @@ contract RequestManager is Ownable {
         bytes32 fillHash = RaisyncUtils.createFillHash(
                 claim.requestId,
                 block.chainid,
+                request.targetChainId,
                 request.targetTokenAddress,
                 request.targetAddress,
                 request.amount,

--- a/contracts/tests/test_l1_resolution.py
+++ b/contracts/tests/test_l1_resolution.py
@@ -34,6 +34,7 @@ def test_l1_resolution_correct_hash(
     fill_hash = create_fill_hash(
         request_id,
         chain_id,
+        chain_id,
         token.address,
         receiver.address,
         requested_amount,

--- a/contracts/tests/test_request_manager.py
+++ b/contracts/tests/test_request_manager.py
@@ -599,7 +599,13 @@ def test_withdraw_without_challenge_with_resolution(
     assert web3.eth.get_balance(claimer.address) == claimer_eth_balance - claim_stake
 
     fill_hash = create_fill_hash(
-        request_id, web3.eth.chain_id, token.address, requester.address, transfer_amount, fill_id
+        request_id,
+        web3.eth.chain_id,
+        web3.eth.chain_id,
+        token.address,
+        requester.address,
+        transfer_amount,
+        fill_id,
     )
 
     # Register a L1 resolution

--- a/contracts/tests/utils.py
+++ b/contracts/tests/utils.py
@@ -1,3 +1,4 @@
+from brownie import web3
 from eth_abi.packed import encode_abi_packed
 from eth_utils import keccak, to_canonical_address
 
@@ -15,7 +16,7 @@ def make_request(
 
     total_fee = request_manager.totalFee()
     request_tx = request_manager.createRequest(
-        1,
+        web3.eth.chain_id,
         token.address,
         token.address,
         requester,
@@ -26,14 +27,17 @@ def make_request(
     return request_tx.return_value
 
 
-def create_request_hash(request_id, chain_id, token_address, receiver_address, amount):
+def create_request_hash(
+    request_id, source_chain_id, target_chain_id, target_token_address, receiver_address, amount
+):
     return keccak(
         encode_abi_packed(
-            ["uint256", "uint256", "address", "address", "uint256"],
+            ["uint256", "uint256", "uint256", "address", "address", "uint256"],
             [
                 request_id,
-                chain_id,
-                to_canonical_address(token_address),
+                source_chain_id,
+                target_chain_id,
+                to_canonical_address(target_token_address),
                 to_canonical_address(receiver_address),
                 amount,
             ],
@@ -41,12 +45,27 @@ def create_request_hash(request_id, chain_id, token_address, receiver_address, a
     )
 
 
-def create_fill_hash(request_id, chain_id, token_address, receiver_address, amount, fill_id):
+def create_fill_hash(
+    request_id,
+    source_chain_id,
+    target_chain_id,
+    target_token_address,
+    receiver_address,
+    amount,
+    fill_id,
+):
     return keccak(
         encode_abi_packed(
             ["bytes32", "bytes32"],
             [
-                create_request_hash(request_id, chain_id, token_address, receiver_address, amount),
+                create_request_hash(
+                    request_id,
+                    source_chain_id,
+                    target_chain_id,
+                    target_token_address,
+                    receiver_address,
+                    amount,
+                ),
                 fill_id,
             ],
         )


### PR DESCRIPTION
we need to add target chain id in the request hash to have uniqueness of request hash from different roll ups

fixes: #202 