### PR TITLE
extends requests.py to also be able to call fill

### DIFF
--- a/contracts/contracts/RequestManager.sol
+++ b/contracts/contracts/RequestManager.sol
@@ -15,7 +15,7 @@ contract RequestManager is Ownable {
 
     // Structs
     // TODO: check if we can use a smaller type for `targetChainId`, so that the
-    // fileds can be packed into one storage slot
+    // fields can be packed into one storage slot
     struct Request {
         address sender;
         address sourceTokenAddress;


### PR DESCRIPTION
- Changes `scripts/requests.py` to `scripts/call_contracts.py`  

Extends the current script to have two subcommands `fill` and `request` to either execute one of those.

## Usage

`python scripts/call_contracts.py --help` output:

```
Usage: call_contracts.py [OPTIONS] COMMAND [ARGS]...

Options:
  --contracts-deployment DIR  The directory that stores contract deployment
                              files.
  --keystore-file FILE        Path to a keystore file.  [required]
  --password TEXT             Password to unlock the keystore file.
  --eth-rpc TEXT              Ethereum node RPC URI
  --help                      Show this message and exit.

Commands:
  fill     fill a RaiSync request
  request  Register a RaiSync request
```

### Example fill
```
python scripts/call_contracts.py \
--keystore-file UTC--2022-02-23T14-06-54.327Z--0x17d366725e7e8e9cf89ffde6bf017b1fde478cae \
--password xxx \
--eth-rpc https://stardust.metis.io/?owner=588 \
--contracts-deployment contracts/build/deployments/588/ \
fill  \
--source-chain-id 28 \
--target-address 0xF8f84a64011b77d0876f3C401a56Bf0D20bcbbD8 \
--amount 1
```