### PR TITLE
beamer: agent: use the RPC gas strategy

### DIFF
--- a/beamer/agent.py
+++ b/beamer/agent.py
@@ -6,6 +6,7 @@ import structlog
 import web3
 from eth_account.signers.local import LocalAccount
 from eth_typing import Address
+from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.middleware import construct_sign_and_send_raw_middleware, geth_poa_middleware
 
 from beamer.chain import ContractEventMonitor, EventProcessor, RequestTracker
@@ -27,6 +28,7 @@ class Config:
 
 def _make_web3(url: URL, account: LocalAccount) -> web3.Web3:
     w3 = web3.Web3(web3.HTTPProvider(url, request_kwargs=dict(timeout=5)))
+    w3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
     # Add POA middleware for geth POA chains, no/op for other chains
     w3.middleware_onion.inject(geth_poa_middleware, layer=0)
     w3.middleware_onion.add(construct_sign_and_send_raw_middleware(account))


### PR DESCRIPTION
This avoids the following error when running the agent in a Boba -> Metis scenario:

    ValueError: {'code': -32601, 'message': 'the method eth_maxPriorityFeePerGas does not exist/is not available'}