### PR TITLE
Add chain names to configuration

### DIFF
--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -4,6 +4,7 @@
       "requestManagerAddress": "0x5E0494Ab942cCE4ee11bb95afDc1CaDcE7A7b876",
       "explorerTransactionUrl": "https://blockexplorer.rinkeby.boba.network/tx/",
       "fillManagerAddress": "0xd98F0aFaC17480971492a40db0fd72227936bbF8",
+      "name": "Boba Rinkeby",
       "tokens": [
         {
           "address": "0x7F994318a1757aA20D0376683E51BFD8523E0A58",
@@ -15,6 +16,7 @@
       "requestManagerAddress": "0x7851506925D3b276614759eE1BB1a742118620F3",
       "explorerTransactionUrl": "https://stardust-explorer.metis.io/tx/",
       "fillManagerAddress": "0xed3Ac93E8f0cE59d499B2d931F3901A4B9D59556",
+      "name": "Metis Stardust",
       "tokens": [
         {
           "address": "0xF4BeDD719224107eF1103efDA039D392FdAdA32b",

--- a/frontend/src/components/RequestFormInputs.vue
+++ b/frontend/src/components/RequestFormInputs.vue
@@ -64,7 +64,7 @@
 </template>
 
 <script setup lang="ts">
-import { getNetwork } from '@ethersproject/providers';
+import { FormKit } from '@formkit/vue';
 
 import { EthereumProviderKey, RaisyncConfigKey } from '@/symbols';
 import type { SelectorOption } from '@/types/form';
@@ -79,21 +79,19 @@ interface Props {
 
 defineProps<Props>();
 
+const chainsConfiguration = raisyncConfig.value.chains;
 const CHAINS: SelectorOption[] = [];
-Object.keys(raisyncConfig.value.chains).forEach((chain) => {
-  const chainId = Number(chain);
-  const { name } = getNetwork(chainId);
-  CHAINS.push({ value: chainId, label: name });
+
+Object.keys(chainsConfiguration).forEach((chainId) => {
+  CHAINS.push({ value: Number(chainId), label: chainsConfiguration[chainId].name });
 });
 
 const TOKENS: SelectorOption[] = [];
-raisyncConfig.value.chains[String(ethereumProvider.value.chainId.value)].tokens.forEach(
-  (token) => {
-    TOKENS.push({ value: token.address, label: token.symbol });
-  },
-);
+chainsConfiguration[String(ethereumProvider.value.chainId.value)].tokens.forEach((token) => {
+  TOKENS.push({ value: token.address, label: token.symbol });
+});
 
-const switchChain = (chainId) => {
+const switchChain = (chainId: any) => {
   if (chainId !== ethereumProvider.value.chainId.value && ethereumProvider.value.switchChain) {
     ethereumProvider.value.switchChain(chainId.value);
   }

--- a/frontend/src/services/web3-provider/metamask-provider.ts
+++ b/frontend/src/services/web3-provider/metamask-provider.ts
@@ -77,7 +77,7 @@ export class MetaMaskProvider implements EthereumProvider {
     return contract.connect(this.web3Provider);
   }
 
-  private async getChainId(): Promise<number> {
+  async getChainId(): Promise<number> {
     const { chainId } = await this.web3Provider.getNetwork();
     return chainId;
   }
@@ -96,10 +96,10 @@ export class MetaMaskProvider implements EthereumProvider {
   }
 
   private listenToEvents(): void {
-    this.web3Provider.provider.on('accountsChanged', (accounts) =>
+    this.web3Provider.provider.on('accountsChanged', (accounts: string[]) =>
       this.newDefaultSigner(accounts),
     );
-    this.web3Provider.provider.on('chainChanged', (chainId) => {
+    this.web3Provider.provider.on('chainChanged', (chainId: string) => {
       this.chainId.value = BigNumber.from(chainId).toNumber();
     });
   }

--- a/frontend/src/services/web3-provider/types.ts
+++ b/frontend/src/services/web3-provider/types.ts
@@ -10,4 +10,5 @@ export interface EthereumProvider {
   getLatestBlock(): Promise<Block>;
   connectContract(contract: Contract): Contract;
   switchChain?(newChainId: number, rpcUrl?: string): Promise<void>;
+  getChainId(): Promise<number>;
 }

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -8,7 +8,8 @@ export type ChainConfig = {
   requestManagerAddress: string;
   fillManagerAddress: string;
   explorerTransactionUrl: string;
-  tokens: Token[];
+  name: string;
+  tokens: readonly Token[];
 };
 
 export type Token = {


### PR DESCRIPTION
As per the fact that not all chains are available in ethers.js  
providers list, we add chain name to config file instead. That would  
be useful as well in choosing a certain custom name of chain.

Resolves:  
#315