### PR TITLE
Map amount with token decimals

### DIFF
--- a/frontend/src/components/RequestDialog.vue
+++ b/frontend/src/components/RequestDialog.vue
@@ -69,7 +69,7 @@
 <script setup lang="ts">
 import { FormKitFrameworkContext } from '@formkit/core';
 import { FormKit } from '@formkit/vue';
-import { BigNumber, utils } from 'ethers';
+import { utils } from 'ethers';
 import { computed, ref, watch } from 'vue';
 
 import Card from '@/components/layout/Card.vue';
@@ -128,7 +128,7 @@ const submitRequestTransaction = async (formResult: {
     sourceChainId: Number(formResult.fromChainId.value),
     targetTokenAddress: formResult.tokenAddress.value,
     targetAddress: formResult.toAddress,
-    amount: BigNumber.from(formResult.amount),
+    amount: formResult.amount,
   };
 
   requestMetadata.value = {

--- a/frontend/src/composables/useRequestTransaction.ts
+++ b/frontend/src/composables/useRequestTransaction.ts
@@ -1,9 +1,10 @@
 import { JsonRpcSigner } from '@ethersproject/providers';
+import { ethers } from 'ethers';
 import { Ref, ref, ShallowRef, watch } from 'vue';
 
 import { listenOnFulfillment } from '@/services/transactions/fill-manager';
 import { getRequestFee, sendRequestTransaction } from '@/services/transactions/request-manager';
-import { ensureTokenAllowance } from '@/services/transactions/token';
+import { ensureTokenAllowance, getTokenDecimals } from '@/services/transactions/token';
 import { EthereumProvider } from '@/services/web3-provider';
 import { RaisyncConfig } from '@/types/config';
 import { Request, RequestState } from '@/types/data';
@@ -64,6 +65,8 @@ export function useRequestTransaction(
       const chainConfig = raisyncConfig.value.chains[String(chainId)];
       request.sourceChainId = chainId;
       request.requestManagerAddress = chainConfig.requestManagerAddress;
+      const decimals = await getTokenDecimals(signer, request.sourceTokenAddress);
+      request.amount = ethers.utils.parseUnits(request.amount.toString(), decimals);
       await ensureTokenAllowance(
         signer,
         request.sourceTokenAddress,

--- a/frontend/src/services/transactions/token.ts
+++ b/frontend/src/services/transactions/token.ts
@@ -1,5 +1,5 @@
 import { JsonRpcSigner } from '@ethersproject/providers';
-import { BigNumber, Contract } from 'ethers';
+import { BigNumber, BigNumberish, Contract } from 'ethers';
 import { DeepReadonly } from 'vue';
 
 import StandardToken from '@/assets/StandardToken.json';
@@ -17,4 +17,13 @@ export async function ensureTokenAllowance(
     const transaction = await tokenContract.approve(allowedSpender, amount);
     await transaction.wait();
   }
+}
+
+export async function getTokenDecimals(
+  signer: DeepReadonly<JsonRpcSigner>,
+  tokenAddress: string,
+): Promise<BigNumberish> {
+  const tokenContract = new Contract(tokenAddress, StandardToken.abi, signer);
+  const decimals = await tokenContract.decimals();
+  return decimals;
 }

--- a/frontend/src/types/data.ts
+++ b/frontend/src/types/data.ts
@@ -14,7 +14,7 @@ export enum RequestState {
 }
 
 export interface Request {
-  amount: BigNumber;
+  amount: string | BigNumber;
   sourceChainId: number;
   sourceTokenAddress: string;
   targetAddress: string;


### PR DESCRIPTION
We are trying to reflect the real amount sent from frontend. So if the  
user puts 1 TST to send, a really 1 TST is sent and not mapped to the  
number of decimals. This allows also the use of decimals in numbers,  
like a value of 3.243, it is laso converted into its proper value.

Resolves:  
#261