### PR TITLE
agent: Restructure state machine

### DIFF
--- a/beamer/chain.py
+++ b/beamer/chain.py
@@ -5,31 +5,17 @@ import sys
 import threading
 import time
 import traceback
-from dataclasses import dataclass
 from typing import Any, Callable, Optional, cast
 
 import requests.exceptions
 import structlog
 import web3
-from hexbytes import HexBytes
-from statemachine.exceptions import TransitionNotAllowed
-from web3.constants import ADDRESS_ZERO
-from web3.contract import Contract
 from web3.types import TxParams
 
-import beamer.events
-from beamer.events import (
-    ClaimMade,
-    ClaimWithdrawn,
-    DepositWithdrawn,
-    Event,
-    EventFetcher,
-    RequestCreated,
-    RequestFilled,
-)
-from beamer.request import Claim, Request, Tracker
-from beamer.typing import BlockNumber, ChainId, ChecksumAddress, ClaimId, RequestId
-from beamer.util import TokenMatchChecker
+from beamer.events import Event, EventFetcher
+from beamer.request import Claim, Request
+from beamer.state_machine import Context, process_event
+from beamer.typing import BlockNumber, ChainId
 
 log = structlog.get_logger(__name__)
 
@@ -108,28 +94,8 @@ class ContractEventMonitor:
         self._log.info("ContractEventMonitor stopped", chain_id=chain_id)
 
 
-@dataclass
-class Context:
-    requests: Tracker[RequestId, Request]
-    claims: Tracker[ClaimId, Claim]
-    request_manager: Contract
-    fill_manager: Contract
-    match_checker: TokenMatchChecker
-    fill_wait_time: int
-    address: ChecksumAddress
-
-
 class EventProcessor:
-    def __init__(
-        self,
-        request_tracker: Tracker[RequestId, Request],
-        claim_tracker: Tracker[ClaimId, Claim],
-        request_manager: Contract,
-        fill_manager: Contract,
-        match_checker: TokenMatchChecker,
-        fill_wait_time: int,
-        address: ChecksumAddress,
-    ):
+    def __init__(self, context: Context):
         # This lock protects the following objects:
         #   - self._events
         #   - self._num_syncs_done
@@ -144,15 +110,7 @@ class EventProcessor:
         # 2 = both chains synced
         self._num_syncs_done = 0
 
-        self._context = Context(
-            request_tracker,
-            claim_tracker,
-            request_manager,
-            fill_manager,
-            match_checker,
-            fill_wait_time,
-            address,
-        )
+        self._context = context
 
     @property
     def _synced(self) -> bool:
@@ -312,28 +270,6 @@ def _transact(func: web3.contract.ContractFunction, **kwargs: Any) -> web3.types
     return tx_hash
 
 
-def process_event(event: Event, context: Context) -> bool:
-    log.debug("Processing event", _event=event)
-
-    if isinstance(event, beamer.events.RequestCreated):
-        return _handle_request_created(event, context)
-
-    elif isinstance(event, beamer.events.RequestFilled):
-        return _handle_request_filled(event, context)
-
-    elif isinstance(event, beamer.events.DepositWithdrawn):
-        return _handle_deposit_withdrawn(event, context)
-
-    elif isinstance(event, beamer.events.ClaimMade):
-        return _handle_claim_made(event, context)
-
-    elif isinstance(event, beamer.events.ClaimWithdrawn):
-        return _handle_claim_withdrawn(event, context)
-
-    else:
-        raise RuntimeError("Unrecognized event type")
-
-
 def fill_request(request: Request, context: Context) -> None:
     block = context.request_manager.web3.eth.get_block("latest")
     if block["timestamp"] >= request.valid_until:
@@ -468,114 +404,3 @@ def withdraw(claim: Claim, context: Context) -> None:
     context.request_manager.web3.eth.wait_for_transaction_receipt(txn_hash)
     claim.transaction_pending = True
     log.debug("Withdrew", claim=claim.id, txn_hash=txn_hash.hex())
-
-
-def _handle_request_created(event: RequestCreated, context: Context) -> bool:
-    # Check if the address points to a valid token
-    if context.fill_manager.web3.eth.get_code(event.target_token_address) == HexBytes("0x"):
-        log.info(
-            "Request unfillable, invalid token contract",
-            request_event=event,
-            token_address=event.target_token_address,
-        )
-        return True
-
-    is_valid_request = context.match_checker.is_valid_pair(
-        event.chain_id,
-        event.source_token_address,
-        event.target_chain_id,
-        event.target_token_address,
-    )
-    if not is_valid_request:
-        log.debug("Invalid token pair in request", _event=event)
-        return True
-
-    request = Request(
-        request_id=event.request_id,
-        source_chain_id=event.chain_id,
-        target_chain_id=event.target_chain_id,
-        source_token_address=event.source_token_address,
-        target_token_address=event.target_token_address,
-        target_address=event.target_address,
-        amount=event.amount,
-        valid_until=event.valid_until,
-    )
-    context.requests.add(request.id, request)
-    return True
-
-
-def _handle_request_filled(event: RequestFilled, context: Context) -> bool:
-    request = context.requests.get(event.request_id)
-    if request is None:
-        return False
-
-    fill_matches_request = (
-        request.id == event.request_id
-        and request.amount == event.amount
-        and request.source_chain_id == event.source_chain_id
-        and request.target_token_address == event.target_token_address
-    )
-    if not fill_matches_request:
-        log.warn("Fill not matching request. Ignoring.", request=request, fill=event)
-        return True
-
-    try:
-        request.fill(filler=event.filler, fill_id=event.fill_id)
-    except TransitionNotAllowed:
-        return False
-
-    log.info("Request filled", request=request)
-    return True
-
-
-def _handle_deposit_withdrawn(event: DepositWithdrawn, context: Context) -> bool:
-    request = context.requests.get(event.request_id)
-    if request is None:
-        return False
-
-    try:
-        request.withdraw()
-    except TransitionNotAllowed:
-        return False
-
-    log.info("Deposit withdrawn", request=request)
-    return True
-
-
-def _handle_claim_made(event: ClaimMade, context: Context) -> bool:
-    claim = context.claims.get(event.claim_id)
-    request = context.requests.get(event.request_id)
-    if request is None:
-        return False
-
-    if claim is None:
-        challenge_back_off_timestamp = int(time.time())
-        # if fill event is not fetched yet, wait `_fill_wait_time`
-        # to give the target chain time to sync before challenging
-        # additionally, if we are already in the challenge game, no need to back off
-        if request.filler is None and event.challenger_stake == 0:
-            challenge_back_off_timestamp += context.fill_wait_time
-        claim = Claim(event, challenge_back_off_timestamp)
-        context.claims.add(claim.id, claim)
-
-        return True
-
-    # this is at least the second ClaimMade event for this claim id
-    assert event.challenger != ADDRESS_ZERO, "Second ClaimMade event must contain challenger"
-    try:
-        # Agent is not part of ongoing challenge
-        if context.address not in {event.claimer, event.challenger}:
-            claim.ignore(event)
-        claim.challenge(event)
-    except TransitionNotAllowed:
-        return False
-
-    log.info("Request claimed", request=request, claim_id=event.claim_id)
-    return True
-
-
-def _handle_claim_withdrawn(event: ClaimWithdrawn, context: Context) -> bool:
-    claim = context.claims.get(event.claim_id)
-    assert claim is not None
-    claim.withdraw()
-    return True

--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -1,0 +1,167 @@
+import time
+from dataclasses import dataclass
+
+import structlog
+from eth_typing import ChecksumAddress
+from hexbytes import HexBytes
+from statemachine.exceptions import TransitionNotAllowed
+from web3.constants import ADDRESS_ZERO
+from web3.contract import Contract
+
+from beamer.events import (
+    ClaimMade,
+    ClaimWithdrawn,
+    DepositWithdrawn,
+    Event,
+    RequestCreated,
+    RequestFilled,
+)
+from beamer.request import Claim, Request, Tracker
+from beamer.typing import ClaimId, RequestId
+from beamer.util import TokenMatchChecker
+
+log = structlog.get_logger(__name__)
+
+
+@dataclass
+class Context:
+    requests: Tracker[RequestId, Request]
+    claims: Tracker[ClaimId, Claim]
+    request_manager: Contract
+    fill_manager: Contract
+    match_checker: TokenMatchChecker
+    fill_wait_time: int
+    address: ChecksumAddress
+
+
+def process_event(event: Event, context: Context) -> bool:
+    log.debug("Processing event", _event=event)
+
+    if isinstance(event, RequestCreated):
+        return _handle_request_created(event, context)
+
+    elif isinstance(event, RequestFilled):
+        return _handle_request_filled(event, context)
+
+    elif isinstance(event, DepositWithdrawn):
+        return _handle_deposit_withdrawn(event, context)
+
+    elif isinstance(event, ClaimMade):
+        return _handle_claim_made(event, context)
+
+    elif isinstance(event, ClaimWithdrawn):
+        return _handle_claim_withdrawn(event, context)
+
+    else:
+        raise RuntimeError("Unrecognized event type")
+
+
+def _handle_request_created(event: RequestCreated, context: Context) -> bool:
+    # Check if the address points to a valid token
+    if context.fill_manager.web3.eth.get_code(event.target_token_address) == HexBytes("0x"):
+        log.info(
+            "Request unfillable, invalid token contract",
+            request_event=event,
+            token_address=event.target_token_address,
+        )
+        return True
+
+    is_valid_request = context.match_checker.is_valid_pair(
+        event.chain_id,
+        event.source_token_address,
+        event.target_chain_id,
+        event.target_token_address,
+    )
+    if not is_valid_request:
+        log.debug("Invalid token pair in request", _event=event)
+        return True
+
+    request = Request(
+        request_id=event.request_id,
+        source_chain_id=event.chain_id,
+        target_chain_id=event.target_chain_id,
+        source_token_address=event.source_token_address,
+        target_token_address=event.target_token_address,
+        target_address=event.target_address,
+        amount=event.amount,
+        valid_until=event.valid_until,
+    )
+    context.requests.add(request.id, request)
+    return True
+
+
+def _handle_request_filled(event: RequestFilled, context: Context) -> bool:
+    request = context.requests.get(event.request_id)
+    if request is None:
+        return False
+
+    fill_matches_request = (
+        request.id == event.request_id
+        and request.amount == event.amount
+        and request.source_chain_id == event.source_chain_id
+        and request.target_token_address == event.target_token_address
+    )
+    if not fill_matches_request:
+        log.warn("Fill not matching request. Ignoring.", request=request, fill=event)
+        return True
+
+    try:
+        request.fill(filler=event.filler, fill_id=event.fill_id)
+    except TransitionNotAllowed:
+        return False
+
+    log.info("Request filled", request=request)
+    return True
+
+
+def _handle_deposit_withdrawn(event: DepositWithdrawn, context: Context) -> bool:
+    request = context.requests.get(event.request_id)
+    if request is None:
+        return False
+
+    try:
+        request.withdraw()
+    except TransitionNotAllowed:
+        return False
+
+    log.info("Deposit withdrawn", request=request)
+    return True
+
+
+def _handle_claim_made(event: ClaimMade, context: Context) -> bool:
+    claim = context.claims.get(event.claim_id)
+    request = context.requests.get(event.request_id)
+    if request is None:
+        return False
+
+    if claim is None:
+        challenge_back_off_timestamp = int(time.time())
+        # if fill event is not fetched yet, wait `_fill_wait_time`
+        # to give the target chain time to sync before challenging
+        # additionally, if we are already in the challenge game, no need to back off
+        if request.filler is None and event.challenger_stake == 0:
+            challenge_back_off_timestamp += context.fill_wait_time
+        claim = Claim(event, challenge_back_off_timestamp)
+        context.claims.add(claim.id, claim)
+
+        return True
+
+    # this is at least the second ClaimMade event for this claim id
+    assert event.challenger != ADDRESS_ZERO, "Second ClaimMade event must contain challenger"
+    try:
+        # Agent is not part of ongoing challenge
+        if context.address not in {event.claimer, event.challenger}:
+            claim.ignore(event)
+        claim.challenge(event)
+    except TransitionNotAllowed:
+        return False
+
+    log.info("Request claimed", request=request, claim_id=event.claim_id)
+    return True
+
+
+def _handle_claim_withdrawn(event: ClaimWithdrawn, context: Context) -> bool:
+    claim = context.claims.get(event.claim_id)
+    assert claim is not None
+    claim.withdraw()
+    return True

--- a/beamer/tests/test_handlers.py
+++ b/beamer/tests/test_handlers.py
@@ -1,0 +1,72 @@
+from unittest.mock import MagicMock
+from beamer.agent import Config
+from beamer.chain import Context, claim_request
+from beamer.request import Request, Tracker
+from beamer.typing import ChainId, RequestId, TokenAmount
+from beamer.util import TokenMatchChecker
+
+
+class MockEth:
+    def __init__(self, chain_id):
+        self.chain_id = chain_id
+
+    def get_block(self, _block_identifier):  # pylint: disable=unused-argument, no-self-use
+        return {
+            "number": 42,
+            "timestamp": 457,
+        }
+
+
+class MockWeb3:
+    def __init__(self, chain_id):
+        self.eth = MockEth(chain_id=chain_id)
+
+
+def make_request(token):
+    return Request(
+        request_id=RequestId(1),
+        source_chain_id=ChainId(2),
+        target_chain_id=ChainId(4),
+        source_token_address=token.address,
+        target_token_address=token.address,
+        target_address=token.address,
+        amount=TokenAmount(123),
+        valid_until=456,
+    )
+
+
+def make_context(config, request_manager=None):
+    if request_manager is None:
+        request_manager = MagicMock()
+
+    checker = TokenMatchChecker([])
+
+    return Context(
+        Tracker(), Tracker(), request_manager, MagicMock(), checker, 5, config.account.address
+    )
+
+
+def test_skip_not_self_filled(token, config: Config):
+    request = make_request(token)
+    context = make_context(config)
+
+    context.requests.add(request.id, request)
+
+    assert request.is_pending  # pylint:disable=no-member
+    claim_request(request, context)
+    assert request.is_pending  # pylint:disable=no-member
+
+
+def test_ignore_expired(token, config: Config):
+    request = make_request(token)
+    request.filler = config.account.address
+
+    request_manager = MagicMock(web3=MockWeb3(2))
+    context = make_context(config, request_manager)
+    context.requests.add(request.id, request)
+
+    assert request.is_pending  # pylint:disable=no-member
+    claim_request(request, context)
+    assert request.is_ignored  # pylint:disable=no-member
+
+    assert not request_manager.functions.called

--- a/beamer/tests/test_request.py
+++ b/beamer/tests/test_request.py
@@ -107,9 +107,8 @@ def test_challenge_own_claim(config, request_manager, token):
         ),
         int(time.time()),
     )
-
     assert not maybe_challenge(
-        claim, request_manager, to_checksum_address(agent.address)
+        claim, agent._event_processor._context
     ), "Tried to challenge own claim"
 
 


### PR DESCRIPTION
@istankovic @fredo A first WIP for the state machine restructuring.

- [x] Make all state change handlers operate on an event or request (we can further improve this later if we think it's worth the effort).
- [x] Make all state change handlers free functions for better testability.
- [x] Pack all dependencies of the handlers in the `Context` class. They aren't used in the `EventProcessor`.
- [x] Move the `request.filler == self._address` condition into the `claim_request` handler.

Let me know what you think.