### PR TITLE
Stop hiding form for unsupported chain

### DIFF
--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="home flex justify-center pt-56">
-    <div class="max-w-2xl flex justify-center items-center">
-      <Card v-if="criticalErrorMessage" class="text-center text-orange-dark">
+    <div class="max-w-2xl flex flex-col justify-center items-center">
+      <Card v-if="criticalErrorMessage" class="text-center text-orange-dark p-2 text-lg">
         {{ criticalErrorMessage }}
       </Card>
       <RequestDialog
-        v-else-if="ethereumProvider"
+        v-if="ethereumProvider"
         :key="requestDialogReloadKey"
         @reload="resetRequestDialog"
       />


### PR DESCRIPTION
When user chooses an unsupported chain from metamask, an error message  
was appearing instaed of the form. This behavior doesn't allow the user  
to know what are supported chains or what should do with the app.  
Message appears now on top of the form instead. It isn't optimum, but  
it will be there until a notification system is implemented for the app.

Resolves:  
#360