### PR TITLE
.github: ci: add CNAME file when deploying docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
           publish_dir: ./docs/build/html
           personal_token: ${{ secrets.REPO_ACCESS_TOKEN }}
           external_repository: beamer-bridge/docs
+          cname: docs.beamerbridge.com
 
       - name: Install solhint
         run: npm install solhint --global


### PR DESCRIPTION
Otherwise github will remove the existing file and access to
docs.beamerbridge.com will no longer work.