### PR TITLE
Fix progress steps logic

### DIFF
--- a/frontend/src/components/RequestDialog.vue
+++ b/frontend/src/components/RequestDialog.vue
@@ -103,7 +103,7 @@ const requestForm = ref<FormKitFrameworkContext>();
 const { fee, executeGetFee } = useGetFee(ethereumProvider, beamerConfig);
 const { requestTransactionActive, requestState, transactionError, executeRequestTransaction } =
   useRequestTransaction(ethereumProvider, beamerConfig);
-const { executeWaitFulfilled } = useWaitRequestFilled(ethereumProvider, beamerConfig);
+const { executeWaitFulfilled } = useWaitRequestFilled(beamerConfig);
 const { requestSigner, requestSignerActive, requestSignerError } =
   useRequestSigner(ethereumProvider);
 
@@ -150,7 +150,7 @@ const submitRequestTransaction = async (formResult: {
 
   await executeRequestTransaction(request, ethereumProvider.value.signer.value);
 
-  await executeWaitFulfilled(request, requestState, ethereumProvider.value.signer.value);
+  await executeWaitFulfilled(request, requestState);
 };
 
 watch(ethereumProvider.value.chainId, async () => {

--- a/frontend/src/components/RequestProcessing.vue
+++ b/frontend/src/components/RequestProcessing.vue
@@ -1,9 +1,9 @@
 <template>
-  <Card class="bg-teal-light p-10">
+  <Card class="bg-teal-light p-10 mb-14 mt-2">
     <div class="flex flex-col justify-center items-center gap-4 text-black text-lg">
       <div class="flex flex-col justify-center items-center">
         <div>
-          Sending <span>{{ requestMetadata.amount }}</span>
+          Sending <span>{{ Number(requestMetadata.amount).toFixed(2) }}&nbsp;</span>
           <span>{{ requestMetadata.tokenSymbol }}</span>
         </div>
         <div>
@@ -19,34 +19,20 @@
       </div>
     </div>
   </Card>
-  <div class="flex flex-col justify-center items-center">
+  <div class="flex flex-col justify-center items-center text-xl">
     <div>
       <ul class="steps steps-vertical">
         <ProgressStep
           :current-state="requestMetadata.state"
           :trigger-state="RequestState.WaitConfirm"
         >
-          Please confirm on Metamask
+          Please confirm your request on Metamask
         </ProgressStep>
         <ProgressStep
           :current-state="requestMetadata.state"
           :trigger-state="RequestState.WaitTransaction"
         >
           Waiting for transaction receipt
-        </ProgressStep>
-        <ProgressStep
-          :current-state="requestMetadata.state"
-          :trigger-state="RequestState.WaitSwitchChain"
-        >
-          <div class="flex flex-col justify-start items-start">
-            <div>Please switch chain connection to verify funds reception</div>
-            <div
-              v-if="requestMetadata.state === RequestState.FailedSwitchChain"
-              class="text-orange-light"
-            >
-              Chain switch failed. Try again.
-            </div>
-          </div>
         </ProgressStep>
         <ProgressStep
           :current-state="requestMetadata.state"

--- a/frontend/src/components/layout/ProgressStep.vue
+++ b/frontend/src/components/layout/ProgressStep.vue
@@ -35,3 +35,29 @@ const classObject = computed(() => {
   return obj;
 });
 </script>
+
+<style lang="css">
+.steps .step:before {
+  @apply bg-light;
+}
+.steps .step:after {
+  @apply border-light bg-teal;
+  height: 1.5rem;
+  width: 1.5rem;
+  border-width: 2px;
+}
+.steps .step-success:after {
+  @apply border-teal bg-green;
+  border-width: 2px;
+}
+.steps .step-success + .step-success:before {
+  @apply bg-light;
+}
+.steps-vertical .step:before {
+  width: 0.2rem;
+}
+.steps-vertical .step {
+  gap: 1.5rem;
+  min-height: 5rem;;
+}
+</style>

--- a/frontend/src/services/transactions/fill-manager.ts
+++ b/frontend/src/services/transactions/fill-manager.ts
@@ -1,28 +1,44 @@
-import { JsonRpcSigner } from '@ethersproject/providers';
-import { BigNumber, Contract } from 'ethers';
-import { DeepReadonly } from 'vue';
+import { JsonRpcProvider } from '@ethersproject/providers';
+import { Contract } from 'ethers';
 
 import FillManager from '@/assets/FillManager.json';
 import { Request } from '@/types/data';
 
 export async function listenOnFulfillment(
-  signer: DeepReadonly<JsonRpcSigner>,
+  targetNetworkProvider: JsonRpcProvider,
   request: Request,
+  fillManagerAddress: string,
   currentBlockNumber: number,
-): Promise<void> {
-  const fillManagerContract = new Contract(request.fillManagerAddress, FillManager.abi, signer);
-
-  const eventFilter = fillManagerContract.filters.RequestFilled(
-    BigNumber.from(request.requestId),
-    BigNumber.from(request.sourceChainId),
-    request.targetTokenAddress,
+): Promise<any> {
+  const fillManagerContract = new Contract(
+    fillManagerAddress,
+    FillManager.abi,
+    targetNetworkProvider,
   );
-  const events = await fillManagerContract.queryFilter(eventFilter, currentBlockNumber - 1000);
-  if (events.length > 0) {
-    return;
-  }
 
-  return new Promise((resolve) => {
-    fillManagerContract.on(eventFilter, () => resolve());
+  const eventFilter = fillManagerContract.filters.RequestFilled(request.requestId);
+  const events = await fillManagerContract.queryFilter(eventFilter, currentBlockNumber - 500);
+  if (events.length > 0) return;
+
+  const eventListeningTimeout = 1000 * 30;
+
+  const fulfillmentPromise = new Promise((resolve) => {
+    fillManagerContract.on(eventFilter, (fullRequestId) => {
+      resolve(fullRequestId);
+    });
   });
+
+  const timeoutPromise = new Promise((_resolve, reject) => {
+    setTimeout(() => {
+      reject(new Error('Timeout!'));
+    }, eventListeningTimeout);
+  });
+
+  return Promise.race([fulfillmentPromise, timeoutPromise])
+    .then((fullRequestId) => {
+      return fullRequestId;
+    })
+    .catch((err) => {
+      throw err;
+    });
 }

--- a/frontend/src/services/transactions/request-manager.ts
+++ b/frontend/src/services/transactions/request-manager.ts
@@ -68,8 +68,7 @@ export async function sendRequestTransaction(
 
   const transactionReceipt = await transaction.wait();
   request.receipt = transactionReceipt;
-
-  //events is addded dynamically when wait method called!
+  //events is added dynamically when wait method called!
   // TODO verification of other args?
   const event = findFirstEvent(request.receipt, 'RequestCreated');
   if (!event) {

--- a/frontend/src/types/data.ts
+++ b/frontend/src/types/data.ts
@@ -6,7 +6,6 @@ export enum RequestState {
   Init,
   WaitConfirm,
   WaitTransaction,
-  WaitSwitchChain,
   FailedSwitchChain,
   WaitFulfill,
   RequestSuccessful,


### PR DESCRIPTION
In the processing screen, user was asked to switch to target network on  
metamask to be able to listen to fulfillment event and see the full  
result on processing screen. For now, user doesn't need to make this, as  
we create anotehr instance of ethereum provider for the target network  
that doesn't need metamask involvement in that. This has lead to removal  
of switch network step from UI, progress state and the logic behind.  
Some UI changes has been provided as well to processing screen.

Resolves:  
#348  
#277  
#257  
#292