### PR TITLE
frontend: Limit permission for token transactions

### DIFF
--- a/frontend/src/services/transactions/token.ts
+++ b/frontend/src/services/transactions/token.ts
@@ -12,9 +12,10 @@ export async function ensureTokenAllowance(
 ): Promise<void> {
   const tokenContract = new Contract(tokenAddress, StandardToken.abi, signer);
   const signerAddress = await signer.getAddress();
+  const signerTokenBalance = await tokenContract.balanceOf(signerAddress);
   const allowance: BigNumber = await tokenContract.allowance(signerAddress, allowedSpender);
   if (allowance.lt(amount)) {
-    const transaction = await tokenContract.approve(allowedSpender, amount);
+    const transaction = await tokenContract.approve(allowedSpender, signerTokenBalance);
     await transaction.wait();
   }
 }


### PR DESCRIPTION
For every request, user was asked to make first a transaction for
giving permission to access token balance. This was happening because
everytime the persmission was given over the amount going to be sent.
We changed that to give the permission over the whole token balance
instead. By that, the permission transaction will happend once, unless
the user has made a request for a sum more than the initial balance

Resolves:
https://github.com/beamer-bridge/beamer/issues/353