### PR TITLE
deploy: Store deployment args in deployment file

### DIFF
--- a/beamer/contracts.py
+++ b/beamer/contracts.py
@@ -38,10 +38,14 @@ def load_deployment_info(deployment_dir: Path) -> DeploymentInfo:
 
     for chain_id, deployed_contracts in deployment["L2"].items():
         infos = {}
-        for name, (address, deployment_block) in deployed_contracts.items():
+        for name, deployment_data in deployed_contracts.items():
             if name not in abis:
                 abis[name] = load_contract_abi(deployment_dir, name)
             abi = abis[name]
-            infos[name] = ContractInfo(address=address, deployment_block=deployment_block, abi=abi)
+            infos[name] = ContractInfo(
+                address=deployment_data["address"],
+                deployment_block=deployment_data["deployment_block"],
+                abi=abi,
+            )
         deployment_info[ChainId(int(chain_id))] = infos
     return deployment_info

--- a/beamer/tests/test_cli.py
+++ b/beamer/tests/test_cli.py
@@ -17,8 +17,11 @@ def _generate_deployment_dir(output_dir, root, contracts):
         "beamer_commit": "0" * 40,
         "L2": {
             str(brownie.chain.id): {
-                "RequestManager": [contracts.request_manager.address, 1],
-                "FillManager": [contracts.fill_manager.address, 1],
+                "RequestManager": {
+                    "address": contracts.request_manager.address,
+                    "deployment_block": 1,
+                },
+                "FillManager": {"address": contracts.fill_manager.address, "deployment_block": 1},
             }
         },
     }


### PR DESCRIPTION
This will make it easier to check depolyments later.

⚠️ As this changes the format of the deployment file, this will make the agent not work until a new depolyment.