### PR TITLE
contracts: add valid until to event

### DIFF
--- a/beamer/chain.py
+++ b/beamer/chain.py
@@ -17,7 +17,7 @@ from web3.contract import Contract
 from web3.types import TxParams
 import beamer.events
 from beamer.events import ClaimEvent, Event, EventFetcher, RequestEvent
-from beamer.request import Claim, Request, RequestData, Tracker
+from beamer.request import Claim, Request, Tracker
 from beamer.typing import BlockNumber, ChainId, ChecksumAddress, ClaimId, RequestId
 from beamer.util import TokenMatchChecker
 
@@ -232,18 +232,15 @@ class EventProcessor:
                 self._log.debug("Invalid token pair in request", _event=event)
                 return True
 
-            data = self._request_manager.functions.requests(event.request_id).call()
-            request_data = RequestData.from_chain_data(data)
-
             req = Request(
                 request_id=event.request_id,
                 source_chain_id=event.chain_id,
-                target_chain_id=request_data.targetChainId,
-                source_token_address=request_data.sourceTokenAddress,
-                target_token_address=request_data.targetTokenAddress,
-                target_address=request_data.targetAddress,
-                amount=request_data.amount,
-                valid_until=request_data.validUntil,
+                target_chain_id=event.target_chain_id,
+                source_token_address=event.source_token_address,
+                target_token_address=event.target_token_address,
+                target_address=event.target_address,
+                amount=event.amount,
+                valid_until=event.valid_until,
             )
             self._request_tracker.add(req.id, req)
             return True

--- a/beamer/events.py
+++ b/beamer/events.py
@@ -38,6 +38,7 @@ class RequestCreated(RequestEvent):
     target_token_address: ChecksumAddress
     target_address: ChecksumAddress
     amount: TokenAmount
+    valid_until: Termination
 
 
 @dataclass(frozen=True)

--- a/beamer/request.py
+++ b/beamer/request.py
@@ -1,6 +1,4 @@
 import threading
-from collections.abc import Sequence
-from dataclasses import dataclass
 from typing import Any, Generator, Generic, Optional, TypeVar
 
 from eth_typing import ChecksumAddress as Address
@@ -54,30 +52,6 @@ class Request(StateMachine):
     def __repr__(self) -> str:
         state = self.current_state.identifier
         return f"<Request id={self.id} state={state} filler={self.filler}>"
-
-
-@dataclass
-class RequestData:
-    # The order and types of these fields must always correspond to the order
-    # and types of RequestManager's Request structure.
-    sender: Address
-    sourceTokenAddress: Address
-    targetChainId: ChainId
-    targetTokenAddress: Address
-    targetAddress: Address
-    amount: TokenAmount
-    depositReceiver: Address
-    activeClaims: int
-    validUntil: int
-    lpFee: TokenAmount
-    beamerFee: TokenAmount
-
-    @staticmethod
-    def from_chain_data(data: Sequence) -> "RequestData":
-        fields = tuple(RequestData.__annotations__)  # pylint: disable=no-member
-        assert len(fields) == len(data)
-        kwargs = dict(zip(fields, data))
-        return RequestData(**kwargs)
 
 
 class Claim(StateMachine):

--- a/contracts/contracts/RequestManager.sol
+++ b/contracts/contracts/RequestManager.sol
@@ -48,7 +48,8 @@ contract RequestManager is Ownable {
         address sourceTokenAddress,
         address targetTokenAddress,
         address targetAddress,
-        uint256 amount
+        uint256 amount,
+        uint256 validUntil
     );
 
     event DepositWithdrawn(
@@ -178,7 +179,8 @@ contract RequestManager is Ownable {
             sourceTokenAddress,
             targetTokenAddress,
             targetAddress,
-            amount
+            amount,
+            newRequest.validUntil
         );
 
         IERC20 token = IERC20(sourceTokenAddress);


### PR DESCRIPTION
While we are about to change the contracts, I would like to squeeze this PR in and add the `validUntil` to the `RequestCreated` Event so that it presents complete information over the request.

As an optimization, we don't need to fetch request data after we have received the event with the necessary infromation anyway and safe us a RPC call. We all know how unforeseeable RPC calls can behave, and can delay processing the events by quite some bit.