### PR TITLE
frontend: Add button to add token to metamask

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -11,7 +11,7 @@
   <feedback></feedback>
   <imprint-modal></imprint-modal>
   <footer class="my-8 text-lg text-center text-teal-light">
-    Powered by Beamer .
+    Powered by Beamer &bull;
     <label for="imprint-modal" class="btn-link modal-button">Imprint</label>
   </footer>
 </template>

--- a/frontend/src/services/web3-provider/metamask-provider.ts
+++ b/frontend/src/services/web3-provider/metamask-provider.ts
@@ -102,7 +102,7 @@ export class MetaMaskProvider implements EthereumProvider {
               options: {
                 address: tokenData.address,
                 symbol: tokenData.symbol,
-                decimals: tokenData.decimals || 18,
+                decimals: tokenData.decimals,
               },
             },
           })

--- a/frontend/src/services/web3-provider/types.ts
+++ b/frontend/src/services/web3-provider/types.ts
@@ -13,10 +13,18 @@ export interface EthereumProvider {
   switchChain(newChainId: number): Promise<boolean | null>;
   addChain(chainData: ChainData): Promise<boolean>;
   getChainId(): Promise<number>;
+  addToken(tokenData: TokenData): Promise<void>;
 }
 
 export type ChainData = {
   chainId: number | string;
   rpcUrl: string;
   name: string;
+};
+
+export type TokenData = {
+  address: string;
+  symbol?: string;
+  decimals?: number;
+  image?: string;
 };


### PR DESCRIPTION
Because user doesn't have an information about the token going to be  
used in testing, so it will be hard to see how the system is working,  
a button to add the token to metamask is available for the user to  
easily watch the token in metamask.  
A small fix for the imprint link repalcing the dot separator with a  
bullet.

Resolves:  
#463