### PR TITLE
Fix uncompleted request on frontend

### DIFF
--- a/frontend/src/components/RequestDialog.vue
+++ b/frontend/src/components/RequestDialog.vue
@@ -106,6 +106,11 @@ const { requestTransactionActive, requestState, transactionError, executeRequest
 const { executeWaitFulfilled } = useWaitRequestFilled(beamerConfig);
 const { requestSigner, requestSignerActive, requestSignerError } =
   useRequestSigner(ethereumProvider);
+const getTargetTokenAddress = (targetChainId: any, tokenSymbol: string) => {
+  return beamerConfig.value.chains[targetChainId].tokens.find(
+    (token) => token.symbol === tokenSymbol,
+  )?.address as string;
+};
 
 const feesEther = computed(() => {
   if (fee.value) {
@@ -132,7 +137,10 @@ const submitRequestTransaction = async (formResult: {
     targetChainId: Number(formResult.toChainId.value),
     sourceTokenAddress: formResult.tokenAddress.value,
     sourceChainId: Number(formResult.fromChainId.value),
-    targetTokenAddress: formResult.tokenAddress.value,
+    targetTokenAddress: getTargetTokenAddress(
+      formResult.toChainId.value,
+      formResult.tokenAddress.label,
+    ),
     targetAddress: formResult.toAddress,
     amount: formResult.amount,
   };

--- a/frontend/src/services/transactions/request-manager.ts
+++ b/frontend/src/services/transactions/request-manager.ts
@@ -1,21 +1,10 @@
-import { JsonRpcSigner, TransactionReceipt, TransactionResponse } from '@ethersproject/providers';
+import { JsonRpcSigner, TransactionResponse } from '@ethersproject/providers';
 import { Contract } from 'ethers';
 import { DeepReadonly, Ref } from 'vue';
 
 import RequestManager from '@/assets/RequestManager.json';
 import { EthereumProvider } from '@/services/web3-provider';
 import { Request, RequestState } from '@/types/data';
-
-function findFirstEvent(receipt: TransactionReceipt, eventName: string) {
-  const isRequestCreated = (e) => {
-    if ('undefined' === typeof e['event']) {
-      return false;
-    }
-    console.log(e.event);
-    return e.event === eventName;
-  };
-  return receipt.events.find(isRequestCreated);
-}
 
 export async function getRequestFee(
   ethereumProvider: Readonly<EthereumProvider>,
@@ -40,7 +29,7 @@ export async function sendRequestTransaction(
   }
 
   const requestManagerContract = new Contract(
-    request.requestManagerAddress,
+    request.requestManagerAddress as string,
     RequestManager.abi,
     signer,
   );
@@ -68,12 +57,6 @@ export async function sendRequestTransaction(
 
   const transactionReceipt = await transaction.wait();
   request.receipt = transactionReceipt;
-  //events is added dynamically when wait method called!
-  // TODO verification of other args?
-  const event = findFirstEvent(request.receipt, 'RequestCreated');
-  if (!event) {
-    //TODO error
-  }
-  request.requestId = event.args.requestId;
+
   return request;
 }


### PR DESCRIPTION
After changing configuration it appears that we were using the same  
token address of source rollup for both source and target token address,  
as they were equal anyway, so the issue didn't appear before they are  
different in new condiguration. As there's no way to map source and  
target token addresses, we used the token symbol temporarily for this  
mapping until we figure out another proepr way to make this.  
Also the unnecassry event check at the request end was causing issue,  
it has been removed anyway.