### PR TITLE
agent: Skip token contract code check when using match checker

### DIFF
--- a/beamer/util.py
+++ b/beamer/util.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import sys
 from typing import List, TextIO
 
@@ -88,9 +87,6 @@ class TokenMatchChecker:
         target_chain_id: ChainId,
         target_token_address: ChecksumAddress,
     ) -> bool:
-        if os.environ.get("BEAMER_ALLOW_UNLISTED_PAIRS") is not None:
-            return True
-
         source_token = source_chain_id, source_token_address
         target_token = target_chain_id, target_token_address
         return target_token in self._tokens.get(source_token, frozenset())


### PR DESCRIPTION
This allows us to get rid of a lot of `eth_getCode` requests, namely one request (~0.2s each) per incoming request.

Part of #477