### PR TITLE
frontend: Remove traget chain event listener after finishing

### DIFF
--- a/frontend/src/services/transactions/fill-manager.ts
+++ b/frontend/src/services/transactions/fill-manager.ts
@@ -40,5 +40,8 @@ export async function listenOnFulfillment(
     })
     .catch((err) => {
       throw err;
+    })
+    .finally(() => {
+      fillManagerContract.removeAllListeners(eventFilter);
     });
 }


### PR DESCRIPTION
We turn on event listener on target chain after a successful transaction  
to listen to fulfillment event, event listener keeps working and send  
unnecessary requests to RPC. It is now removed after sucessful event  
listening or timout.