### PR TITLE
agent: Allow request transition from filled to ignored 

### DIFF
--- a/beamer/request.py
+++ b/beamer/request.py
@@ -6,7 +6,7 @@ from statemachine import State, StateMachine
 from web3.types import Wei
 
 from beamer.events import ClaimMade
-from beamer.typing import ChainId, ClaimId, RequestId, Termination, TokenAmount
+from beamer.typing import ChainId, ClaimId, FillId, RequestId, Termination, TokenAmount
 
 
 class Request(StateMachine):
@@ -45,7 +45,7 @@ class Request(StateMachine):
     withdraw = claimed.to(withdrawn) | filled.to(withdrawn) | ignored.to(withdrawn)
     ignore = pending.to(ignored)
 
-    def on_fill(self, filler: Address, fill_id: int) -> None:
+    def on_fill(self, filler: Address, fill_id: FillId) -> None:
         self.filler = filler
         self.fill_id = fill_id
 

--- a/beamer/request.py
+++ b/beamer/request.py
@@ -43,7 +43,7 @@ class Request(StateMachine):
     try_to_fill = pending.to(filled)
     try_to_claim = filled.to(claimed)
     withdraw = claimed.to(withdrawn) | filled.to(withdrawn) | ignored.to(withdrawn)
-    ignore = pending.to(ignored)
+    ignore = pending.to(ignored) | filled.to(ignored)
 
     def on_fill(self, filler: Address, fill_id: FillId) -> None:
         self.filler = filler


### PR DESCRIPTION
Resolves https://github.com/beamer-bridge/beamer/issues/518

This is a strange case where the agent filled a request but didn't claim
in time.
This has been seen on testnet.