### PR TITLE
frontend: Fix network change error in progress screen

### DIFF
--- a/frontend/src/components/RequestDialog.vue
+++ b/frontend/src/components/RequestDialog.vue
@@ -162,7 +162,7 @@ const submitRequestTransaction = async (formResult: {
 };
 
 watch(ethereumProvider.value.chainId, async () => {
-  await executeGetFee();
+  location.reload();
 });
 executeGetFee();
 

--- a/frontend/src/components/RequestFormInputs.vue
+++ b/frontend/src/components/RequestFormInputs.vue
@@ -193,10 +193,6 @@ const addToken = async () => {
   }
 };
 
-watch(ethereumProvider.value.chainId, () => {
-  location.reload();
-});
-
 const faucetUsedForChain: Record<string, boolean> = reactive({});
 const faucetUsed = computed(() =>
   Boolean(faucetUsedForChain[(fromChainId.value as SelectorOption).value]),


### PR DESCRIPTION
If user was in progress screen and then changed network from metamask,  
when trying to make a new transfer, a change network error occurs. This  
happens because once network is changed, page should be reloaded, and  
we are applying this action only in form screen. We moved the watcher to  
the parent RequestDialog component and it should work on both screens  
now. The side effect of this is that, progress screen reloads to form  
screen on changing networks, but I think this's acceptable for the sake  
of avoiding the error. In future, once we have a proper state managemnet  
, we can use it to keep the UI state as well so we avoid this reload  
side effects.