### PR TITLE
agent: Cache latest block data

### DIFF
--- a/beamer/agent.py
+++ b/beamer/agent.py
@@ -71,6 +71,7 @@ class Agent:
             match_checker=match_checker,
             fill_wait_time=config.fill_wait_time,
             address=config.account.address,
+            latest_blocks={},
         )
         self._event_processor = EventProcessor(self.context)
 

--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -1,5 +1,6 @@
 import time
 from dataclasses import dataclass
+from typing import Dict
 
 import structlog
 from eth_typing import ChecksumAddress
@@ -7,19 +8,21 @@ from hexbytes import HexBytes
 from statemachine.exceptions import TransitionNotAllowed
 from web3.constants import ADDRESS_ZERO
 from web3.contract import Contract
+from web3.types import BlockData
 
 from beamer.events import (
     ClaimMade,
     ClaimWithdrawn,
     DepositWithdrawn,
     Event,
+    LatestBlockUpdatedEvent,
     RequestCreated,
     RequestFilled,
 )
 from beamer.models.claim import Claim
 from beamer.models.request import Request
 from beamer.tracker import Tracker
-from beamer.typing import ClaimId, RequestId
+from beamer.typing import ChainId, ClaimId, RequestId
 from beamer.util import TokenMatchChecker
 
 log = structlog.get_logger(__name__)
@@ -34,12 +37,16 @@ class Context:
     match_checker: TokenMatchChecker
     fill_wait_time: int
     address: ChecksumAddress
+    latest_blocks: Dict[ChainId, BlockData]
 
 
 def process_event(event: Event, context: Context) -> bool:
     log.debug("Processing event", _event=event)
 
-    if isinstance(event, RequestCreated):
+    if isinstance(event, LatestBlockUpdatedEvent):
+        return _handle_latest_block_updated(event, context)
+
+    elif isinstance(event, RequestCreated):
         return _handle_request_created(event, context)
 
     elif isinstance(event, RequestFilled):
@@ -56,6 +63,11 @@ def process_event(event: Event, context: Context) -> bool:
 
     else:
         raise RuntimeError("Unrecognized event type")
+
+
+def _handle_latest_block_updated(event: LatestBlockUpdatedEvent, context: Context) -> bool:
+    context.latest_blocks[event.chain_id] = event.block_data
+    return True
 
 
 def _handle_request_created(event: RequestCreated, context: Context) -> bool:


### PR DESCRIPTION
Currently black data are queried from RPC in handlers when required.
This is ineffective, as most of these requests will get the same return
value.

Instead, we add a mapping from chain id to block data to the `Context`,
in which the latest known block for each chain is stored. It is updated
via the new `LatestBlockUpdated` event.

Part of https://github.com/beamer-bridge/beamer/issues/477