### PR TITLE
frontend: Left align all form fields

### DIFF
--- a/frontend/src/components/RequestFormInputs.vue
+++ b/frontend/src/components/RequestFormInputs.vue
@@ -256,9 +256,6 @@ const { showTokenBalance, formattedTokenBalance } = useTokenBalance(
 .form-tooltip {
   @apply tooltip tooltip-left md:tooltip-right tooltip-primary bg-transparent text-justify z-50;
 }
-#tokenAddress.selector .vs__search::placeholder {
-  @apply text-right;
-}
 .tooltip:before {
   @apply p-4;
 }

--- a/frontend/src/components/inputs/Selector.vue
+++ b/frontend/src/components/inputs/Selector.vue
@@ -65,11 +65,11 @@ const props = defineProps<Props>();
 .selector .vs__dropdown-option,
 .selector .vs__selected,
 .selector.vs--open .vs__search {
-  @apply h-18 w-full m-0 pl-4 py-3 border-0 text-2xl text-teal flex flex-row gap-2 items-center justify-between overflow-hidden;
+  @apply h-18 w-full m-0 pl-8 py-3 border-0 text-2xl text-teal flex flex-row gap-2 items-center overflow-hidden text-left;
 }
 
 .selector .vs__search {
-  @apply m-0 p-0 border-0 text-2xl text-teal;
+  @apply mt-0 pl-8 border-0 text-2xl text-teal;
 }
 
 .selector .vs__dropdown-option {
@@ -81,7 +81,7 @@ const props = defineProps<Props>();
 }
 
 .selector .vs__selected-options {
-  @apply p-0 m-0 pl-4 flex-nowrap;
+  @apply p-0 m-0 flex-nowrap;
 }
 
 .selector .vs__option-image {
@@ -89,7 +89,7 @@ const props = defineProps<Props>();
 }
 
 .selector .vs__search::placeholder {
-  @apply opacity-25 text-black text-left pl-4;
+  @apply opacity-25 text-black text-left pl-8;
 }
 
 .selector .vs__no-options {

--- a/frontend/src/formkitTheme.ts
+++ b/frontend/src/formkitTheme.ts
@@ -19,7 +19,7 @@ function rootClasses(sectionKey: string, node: FormKitNode): Record<string, bool
         return 'py-6 px-14 rounded-xl bg-green shadow text-teal text-2xl disabled:bg-dark disabled:text-teal-light-35';
       }
       if (type === 'text') {
-        return 'h-18 w-full px-8 rounded-xl bg-teal-light shadow-inner text-teal text-2xl text-right placeholder:opacity-25 placeholder:text-black';
+        return 'h-18 w-full px-8 rounded-xl bg-teal-light shadow-inner text-teal text-2xl text-left placeholder:opacity-25 placeholder:text-black';
       }
     },
   };


### PR DESCRIPTION
Close #526 

Fixes the text of all form fields to be aligned on the same side. I decided for the right side as it is in Olympe's design.