### PR TITLE
chore: Disable dependabot for frontend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,11 +14,11 @@ updates:
       - "istankovic"
       - "palango"
 
-  - package-ecosystem: "npm"
-    directory: "/frontend/"
-    schedule:
-      interval: "weekly"
-      day: "thursday"
-    reviewers:
-      - "nekhaly"
-      - "manuelwedler"
+  # - package-ecosystem: "npm"
+  #   directory: "/frontend/"
+  #   schedule:
+  #     interval: "weekly"
+  #     day: "thursday"
+  #   reviewers:
+  #     - "nekhaly"
+  #     - "manuelwedler"


### PR DESCRIPTION
There are no tests yet, so we don't know if stuff breaks.

@weilbith As discussed.