### PR TITLE
add new base workflow to block fixup commit merges

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -1,0 +1,14 @@
+name: Base CI
+
+on:
+  pull_request:
+    branches: 
+      - main
+
+jobs:
+  block-fixup-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.0.0
+      - name: 'Block Merging Fixup Commits'
+        uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
Using Git's feature of fixup commits is a good practice for pull requests. But all fixup commits must be always resolved first before merging the pull request finally. To ensure nobody can forget this, it is always very useful to have the continuous integration pipeline to verify this.

I'm completely open to rename the workflow from `base` to anything else. No strong opinion here. I thought about something like `shared` or so. 🤷🏾 