### PR TITLE
agent: GC ignored requests as well

### DIFF
--- a/beamer/chain.py
+++ b/beamer/chain.py
@@ -216,10 +216,10 @@ def process_requests(context: Context) -> None:
         elif request.is_filled:
             claim_request(request, context)
 
-        elif request.is_withdrawn:
+        elif request.is_withdrawn or request.is_ignored:
             active_claims = any(claim.request_id == request.id for claim in context.claims)
             if not active_claims:
-                log.debug("Removing withdrawn request", request=request)
+                log.debug("Removing request", request=request)
                 to_remove.append(request.id)
 
     for request_id in to_remove:

--- a/beamer/tests/agent/test_handlers.py
+++ b/beamer/tests/agent/test_handlers.py
@@ -129,6 +129,14 @@ def test_request_garbage_collection_without_claim(token, config: Config):
     process_requests(context)
     assert len(context.requests) == 0
 
+    request = make_request(token)
+    request.ignore()
+    context.requests.add(request.id, request)
+
+    assert len(context.requests) == 1
+    process_requests(context)
+    assert len(context.requests) == 0
+
 
 def test_request_garbage_collection_with_claim(token, config: Config):
     request = make_request(token)


### PR DESCRIPTION
This was forgotten when implementing GC and brings us from 3000 active
requests down to 20 requests on testnet.