### PR TITLE
docs: update state machine diagram

### DIFF
--- a/docs/source/request_state_machine.dot
+++ b/docs/source/request_state_machine.dot
@@ -7,5 +7,6 @@ digraph request_state_machine {
     filled -> claimed [label = try_to_claim];
     claimed -> withdrawn [label = withdraw];
     filled -> withdrawn [label = withdraw];
+    filled -> ignored [label = ignore];
     ignored -> withdrawn [label = withdraw];
 }


### PR DESCRIPTION
A transition from filled to ignored was added in
b0a78ea653340da1ac4c12c79e795fdc232aa62e, but the docs haven't been
updated.