### PR TITLE
.github: tag container images with git commit IDs

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -29,10 +29,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate container metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=sha,format=long
+        flavor: |
+          latest=true
+
       - name: Build and push container image
         uses: docker/build-push-action@v2.10.0
         with:
           context: .
           file: docker/Dockerfile.agent
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This will allow us to trace back an image to the relevant source tree, as well as pick "known-good" images in case the latest image ends up being broken.