### PR TITLE
Add non-fill proofs to whitepaper

### DIFF
--- a/docs/source/protocol.rst
+++ b/docs/source/protocol.rst
@@ -9,13 +9,13 @@ Summary
 
 .. code::
 
-    claimStake =
-    claimPeriod = 1 day
-    challengePeriod = finalizationTime[l2b] + 1 day
+    claimStake = k * avg\_gp\_l2a * (gas_{challenge} + gas_{withdraw})
+    counterChallengeStake = gas_{non-fill proof}
+    claimPeriod = max(offline rollup) = 1 day
+    challengePeriod = finalizationTime[targetRollup] + buffer = 8 days
     challengePeriodExtension = 1 day
     minValidityPeriod = 5 minutes
     maxValidityPeriod = 52 weeks
-
 
 claimStake
 ----------
@@ -26,23 +26,26 @@ misbehavior, which is not having fulfilled the claim as stated, the claimer risk
 If following the protocol, an honest claimer will always be able to withdraw at least the stake
 after the claim expired.
 
-Rationale
-^^^^^^^^^
+A lower boundary can be defined as the minimum value to cover the cost of challenging. Otherwise
+there would be no financial incentive for challengers to secure the protocol.
+
+The higher ``claimStake`` is chosen, the more capital an honest claimer must lock for the period
+``claimPeriod``.  This can be reflected in opportunity costs for each LP. This being said, the
+higher the chosen ``claimStake``, the higher the incentivization to challenge dishonest claims.
+For a sustainable business model, each LP would reflect those costs in the fees he would accept.
+The protocol costs for the end user would increase.
+
+Proposed Values
+^^^^^^^^^^^^^^^
 
 .. math::
 
-   X = k * avg\_gp\_l2a * (max(gas_{challenge}, gas_{claim}) + gas_{withdraw})
+   claimStake = k * avg\_gp\_l2a * (gas_{challenge} + gas_{withdraw})
 
 .. glossary::
 
-    :math:`X`
-       initial claim stake.
-
     :math:`gas_{challenge}`
         gas cost of a challenge
-
-    :math:`gas_{claim}`
-        gas cost of a claim
 
     :math:`gas_{withdraw}`
         gas cost of a withdraw
@@ -53,111 +56,81 @@ Rationale
     :math:`avg\_gp\_l2a`
        average gas price over a period of time of source rollup where claim and challenge happens
 
-A lower boundary can be defined as the minimum value to cover the cost of challenging. Otherwise
-there would be no financial incentive to secure the protocol. This would happen with :math:`k <= 1`.
+We propose a value of ``k = 1.3`` so that honest challengers are rewarded with a minimum of 30% of the challenge gas
+costs. The other parameters should be determined at time of deployment.
 
-The higher :math:`k` is chosen, the more capital an honest claimer must lock for the period
-``claimPeriod``.  This can be reflected in opportunity costs for each LP. This being said, the
-higher the chosen :math:`k`, the higher the opportunity cost for the LP. For a sustainable business
-model, each LP would reflect those costs in the fees he charges. The protocol costs for the end user
-would increase.
+counterChallengeStake
+---------------------
 
-Proposed Values
-^^^^^^^^^^^^^^^
+The ``counterChallengeStake`` is the minimum stake that a claimer must deposit to respond to a challenge. Upon seeing a
+claim to a non-filled request, honest users will challenge them. If they want to reduce their opportunity costs, they
+will challenge with a stake of ``claimStake + 1``. To which the dishonest claimer can respond with a ``claimStake + 2``
+and little progress is made towards reaching a sufficient stake for the L1 non-fill proof.
 
-Current proposed values are
+The honest challenger will be tempted to stake enough for the L1 non-fill proof. If he does so, the claimer can stop
+participating in the challenge and the honest challenger will solely bear the opportunity cost of a high stake. This is
+a griefing attack.
 
-:math:`k = 1.3` -> A minimum of 30% reward for each challenger based on average gas prices, if the claim
-is false.
+To prevent it, we need to enforce that the first counter challenge by the claimer has a stake sufficient for the L1
+non-fill proof.
 
-:math:`avg_gp_l2a`
-:math:`gas_{challenge}`
-:math:`gas_{claim}`
-:math:`gas_{withdraw}`
+.. math::
 
+    counterChallengeStake = gas_{non-fill proof}
 
 claimPeriod
 -----------
 
-``claimPeriod`` defines the period until a claim is considered to be finalized and cannot be
-challenged anymore. If not challenged, an expired claim entitles the claimer to withdraw the funds
-from the underlying request. The amount can only be withdrawn once. Note that it is technically
-possible that there are multiple valid claims by different claimers. This case would only happen if
-false claims are not challenged, which comes from protocol violation.
-
-
-Rationale
-^^^^^^^^^
+``claimPeriod`` defines the period after which a claim expires if not challenged.
 
 The minimum claim period must ensure that at least one honest challenger is able to challenge a
 false claim before it expires. Practical influencing factors also include experienced downtimes of
 existing rollups. Experienced downtimes were as high as 17 hours.
 
-As described above, a higher claim period increases the opportunity costs for honest claimers.
+A higher claim period increases the opportunity costs for honest claimers.
 
 
 Proposed Values
 ^^^^^^^^^^^^^^^
 
-``X = 1 day``
+``claimPeriod = 1 day``
 
 
 challengePeriod
 ---------------
 
-The ``challengePeriod`` describes the minimum time a challenge game is open. This value depends on
-the finalization parameter of the target rollup and thus may differ for each rollup instance. The
-challenge game might be open longer than the challenge period defines.
+The ``challengePeriod`` describes the initial period of a challenge. This period has to be long enough to allow for the
+L1 resolution proof to be transmitted from the target rollup to the source rollup. It takes at minimum
+``finalizationTime[targetRollup]`` for the proof to be available for transmission. For optimistic rollups this value is
+typically defined as 7 days but this might change in the future and differ for each rollup implementation. That each
+challenged claim can be L1 resolved is a hard requirement.
 
+Additionally, the ``challengePeriod`` must include a time buffer after the finalization of the target rollup happened.
+There must be enough time to actually execute L1 resolution before ``challengePeriod`` ends. The rationale for
+choosing the exact value of the buffer can be derived from ``claimPeriod``.
 
-Rationale
-^^^^^^^^^
-
-.. math:: X = finalization_{l2b} + c
-
-Once a claim is challenged, it must be possible to resolve the dispute via L1 resolution. In order
-to fulfill this requirement, ``challengePeriod`` must be higher than the finalization parameter of
-the target rollup instance. For optimistic rollups this value is typically defined as 7 days but
-this might change in the future and differ for each rollup implementation.  The reason behind this
-is that the L1 resolver contract only sees fills on the target rollup after the finalization period
-is over. That each challenged claim can be L1 resolved is a hard requirement. Otherwise, a challenge
-could be won by placing enough stake in the challenge. This would limit the set of challengers which
-are able to participate in the challenge game.
-
-Additionally, the ``challengePeriod`` must include a time buffer :math:`c` after the finalization of
-the target rollup happened. It avoids race conditions. After the finalization period of the target
-rollup is reached, L1 resolution is possible. There must be enough time to actually execute L1
-resolution before ``challengePeriod`` ends. This time is reflected in :math:`c`. The rationale for
-choosing the exact value can be derived from ``claimPeriod``.
-
+.. math:: challengePeriod = finalizationTime[targetRollup] + buffer
 
 Proposed Values
 ^^^^^^^^^^^^^^^
 
 .. code::
 
-    finalization[l2b] = 7 days for all l2bs
-    c = 1 day -> challengePeriod = 8 days
-
+    finalizationTime[targetRollup] = 7 days for most rollups
+    buffer = 1 day
+    challengePeriod = 8 days
 
 challengePeriodExtension
 ------------------------
 
-``challengePeriodExtension`` defines the value for which the challenge period should be extended
-after an event (challenge or counter challenge) happened. Each opponent should always have the time
-to react in the challenge game, thus there must be enough time left for him to do so.
-
-
-Rationale
-^^^^^^^^^
-
-To decide on the value we can refer to the same rationale as for ``claimPeriod``. Note that the
-calculation for the new finalization of the current challenge is calculated as ``X = max(current
-challenge end, time.now() + challengePeriodExtension)`` This is necessary to ensure that there is at
-least ``challengePeriodExtension`` for the participant to react, but it might be possible that there
-is even more time left. This comes from the initial ``challengePeriod`` value which depends on the
-finalization period of the target rollup.
-
+``challengePeriodExtension`` defines the value for which the challenge period should be extended after an event
+(challenge or counter challenge) happened. Each opponent should always have the time to react in the challenge game,
+thus there must be enough time left for him to do so. To decide on the value we can refer to the same rationale as for
+``claimPeriod``. Note that the calculation for the new finalization of the current challenge is calculated as
+``end time = max(current challenge end, time.now() + challengePeriodExtension)`` This is necessary to ensure that there
+is at least ``challengePeriodExtension`` for the participant to react, but it might be possible that there is more time
+left. This comes from the initial ``challengePeriod`` value which depends on the finalization period of the target
+rollup.
 
 Proposed Value
 ^^^^^^^^^^^^^^
@@ -166,7 +139,6 @@ Proposed Value
 
     challengePeriod = claimPeriod = 1 day
 
-
 Expiration time
 ---------------
 
@@ -174,17 +146,12 @@ Each request will have an expiration time set after which, if not claimed, the u
 withdraw the funds back. This mechanism ensures that no funds will be locked forever if nobody wants
 or is able to fill the request.
 
-
-Rationale
-^^^^^^^^^
-
 In order to prevent (accidental) misbehavior by the user, we can restrict expiration times by lower
 and upper boundaries. Each LP has to decide within its own strategy how to react on certain
-expiration times.  While setting a very low expiration time most likely leads to not being fulfilled
-by any LP, an upper boundary ensures that funds can be withdrawn eventually.  With the current setup
+expiration times. While setting a very low expiration time most likely leads to not being fulfilled
+by any LP, an upper boundary ensures that funds can eventually be withdrawn. With the current setup
 of fixed fees and a race between LPs, we introduce a safety net for LPs to ensure that there is
 enough time to register a claim of a filled request *before* it expires.
-
 
 Proposed Values
 ^^^^^^^^^^^^^^^
@@ -193,7 +160,3 @@ Proposed Values
 
     minValidityPeriod = 5 minutes
     maxValidityPeriod = 52 weeks
-
-
-Default Strategy
-----------------

--- a/docs/source/whitepaper.rst
+++ b/docs/source/whitepaper.rst
@@ -323,7 +323,7 @@ Self challenges
 +++++++++++++++
 
 In the previous explanation, we only talked about two participants to the challenges, Bob and Charles. What if, after
-submitting his false claim, Charles challenges himself. This would let Charles control the state of his challenge and
+submitting his false claim, Charles challenges himself? This would let Charles control the state of his challenge and
 he would be able to let it expire with his claim successful as an outcome.
 
 To prevent this successful ``self-challenged claim`` to allow Charles to withdraw Alice's deposit, Bob can fill Alice's request
@@ -340,31 +340,34 @@ Claims that cannot be filled
 ++++++++++++++++++++++++++++
 
 In both the regular ``false claim`` and ``self-challenge claim`` cases, we assumed that Bob could fill Alice's request in
-order to prove that the false claimer Charles was not the correct filler. However, If Alice's request cannot be filled
-for any reason (e.g. transfer value too high), instead of proving that someone other than Charles filled a request,
+order to prove that the false claimer Charles was not the correct filler. However, Alice's request might not be able to
+be filled (e.g. transfer value too high). Instead of proving that someone other than Charles filled a request,
 Bob will need to prove that Charles did not fill the request as claimed. For that, Bob needs to create and submit an
 ``L1 non-fill proof`` from rollup B to rollup A.
 
-When called, the fill manager contract on rollup B recomputes the fill hash from the request hash, and fill ID,
-and checks that no fills exists for the corresponding request hash and fill hash. It then submits a proof
-to the outbox of rollup B indicating that the fill hash is invalid, i.e. that the request hash cannot be mapped to the
-fill hash.
+When called, the fill manager contract on rollup B recomputes the fill hash from the request hash, and fill ID which
+were made public during the claim, and checks that no fills exists for the corresponding request hash and fill hash.
+It then submits a proof to the outbox of rollup B indicating that the fill hash is invalid, i.e. that the request hash
+cannot be mapped to the fill hash.
 
 Similarly to the filled L1 resolution case, Bob can then trigger a call on L1 to forward this message to rollup A. This
-message will store in the ``resolution registry`` that the ``fill hash`` is invalid and make any claim from Charles with
-the corresponding hash an invalid claim.
+message will store a flag in the ``resolution registry`` stating that the ``fill hash`` is invalid. This invalidates any
+claim with the corresponding ``fill hash``.
 
 To make sure the proof arrives in time on rollup A, Bob will need to call the ``fill manager`` as soon as he notices a
 false claim for a non-filled request. It takes ``finalization time of rollup B`` after Bob's call to be able to send the
-proof, while the challenge period is defined to be ``finalization time of rollup B + challenge period extension``.
+proof to the resolution registry, while the challenge period is defined to be
+``finalization time of rollup B + challenge period extension``.
+
+:TODO: rewrite paragraph below if we explain the challenge extension earlier
 
 In the case where someone challenges Charles on the false claim at the same time as Bob sends the transaction for the
 proof on rollup B, Bob will not be able to challenge Charles and will not receive any financial reward from having sent
 this transaction. The situation being unlikely to happen and the costs of rollup transactions being low, we believe this
 not to be too big of a problem.
 
-The costly L1 transaction can however be sent only when Bob is properly incentivized, that is he is at stake in the
-challenge against Charles.
+Bob can however wait to be properly incentivized before sending the costly L1 transaction, that is he can wait to be at
+stake in the challenge against Charles.
 
 Non-fill proofs and self challenges
 +++++++++++++++++++++++++++++++++++

--- a/docs/source/whitepaper.rst
+++ b/docs/source/whitepaper.rst
@@ -54,7 +54,7 @@ First concern: service provision
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The process starts with the actual service provision to the user. The end user, further called Alice, will send a
-request on the source rollup (A) by locking up the tokens in the `RequestManager` contract specifying how the
+request on the source rollup (A) by locking up the tokens in the ``RequestManager`` contract specifying how the
 request can be filled.
 
 The parameters that need to be specified by the users are:
@@ -67,7 +67,7 @@ The parameters that need to be specified by the users are:
 - validity period of request
 
 A liquidity provider, later called Bob, provides the service by directly filling the request on target rollup (B).
-He now pays Alice upfront through a contract called `FillManager` and Alice receives the tokens without having to
+He now pays Alice upfront through a contract called ``FillManager`` and Alice receives the tokens without having to
 send any subsequent transactions.
 
 Alice will pay a fee for bridging her tokens. This fee needs to cover the expense of the liquidity provider and reward
@@ -83,7 +83,7 @@ explained in the next section.
 In any case, once she received tokens on rollup B, Alice can ignore the rest of the protocol and enjoy her bridged tokens!
 
 If her request cannot be fulfilled by liquidity providers (e.g. amount too high, rollups sequencers offline for some time, ...),
-the `validity period` argument she specified will determine for how long the request will remain open on rollup A. After
+the ``validity period`` argument she specified will determine for how long the request will remain open on rollup A. After
 this period, the request can no longer be filled and she can withdraw her locked tokens.
 
 Second concern: claim and challenge
@@ -99,7 +99,7 @@ this is our second concern. When filling the request, Bob submits the following 
 - amount
 
 These parameters are useful to let other liquidity providers (or any observer) know that a request they saw on rollup A
-is properly filled. The hash of these parameters, as well as the rollup B's chain ID, constitutes the `request hash`
+is properly filled. The hash of these parameters, as well as the rollup B's chain ID, constitutes the ``request hash``
 that can later serve to prove that the request was properly filled.
 
 ::
@@ -107,12 +107,12 @@ that can later serve to prove that the request was properly filled.
     request hash = Hash(request ID, source chain ID, target chain ID,
                         target token address, recipient address, amount)
 
-When filling the request, a `fill ID` is also computed, that serves to identify a fill. Detailed information on the
-`fill ID` can be found in section :ref:`fill_id`.
+When filling the request, a ``fill ID`` is also computed, that serves to identify a fill. Detailed information on the
+``fill ID`` can be found in section :ref:``fill_id``.
 
-After filling the request, Bob will immediately claim the refund on rollup A. In doing so, he submits the `request ID`,
-and `fill ID` to rollup A. This initiates a `claim period` during which the validity of the fill by
-Bob can be contested. Bob is required to send a deposit `claim stake` in rollup A's coin, that will be lost if
+After filling the request, Bob will immediately claim the refund on rollup A. In doing so, he submits the ``request ID``,
+and ``fill ID`` to rollup A. This initiates a ``claim period`` during which the validity of the fill by
+Bob can be contested. Bob is required to send a deposit ``claim stake`` in rollup A's coin, that will be lost if
 his claim is proven to be eventually incorrect.
 
 If any participant contests Bob's claim, the protocol will immediately enter the challenge game. This
@@ -126,14 +126,14 @@ putting financial pressure on the dishonest participant. If the optimistic appro
 a proof of the fill for the corresponding request can be passed from rollup B to rollup A via L1.
 
 We use a cheap optimistic approach that does not require L1 to drastically reduce the costs of bridging the tokens for
-Bob, and only use the more costly `L1 resolution` in case of an attack to ensure the security of the protocol. By
+Bob, and only use the more costly ``L1 resolution`` in case of an attack to ensure the security of the protocol. By
 implementing L1 resolution we can guarantee Layer 1 security if at least one honest participant follows the protocol.
 Additionally, as we will see later, the cost of the L1 resolution will be paid by the attacker.
 
 Rightful claims resolutions
 +++++++++++++++++++++++++++
 
-In the game theoretic case, rightful claims will not be contested. After `claim period`, Bob can withdraw his stake,
+In the game theoretic case, rightful claims will not be contested. After ``claim period``, Bob can withdraw his stake,
 the tokens locked, and the LP fee paid by Alice.
 
 .. mermaid::
@@ -154,14 +154,14 @@ the tokens locked, and the LP fee paid by Alice.
     note over Rollup A: wait for `claim period`
     Bob->>Rollup A: withdraws tokens
 
-The rightful claim of Bob can however be challenged by anyone during its `claim period`. This will start a challenge between
-him and the challenger, Charles. Charles needs to stake a deposit higher than `claim stake` to challenge Bob's claim.
-The challenge will be on-going until the end of the `challenge period`.
+The rightful claim of Bob can however be challenged by anyone during its ``claim period``. This will start a challenge between
+him and the challenger, Charles. Charles needs to stake a deposit higher than ``claim stake`` to challenge Bob's claim.
+The challenge will be on-going until the end of the ``challenge period``.
 
 During the challenge, the contested participant (in turn Bob, then Charles), can submit a transaction to confirm its
 position and contest the other party. It is required that the new stake of the participant is higher than the current
 stake of the opponent. Everytime a participant responds to the challenge, the termination time of the challenge and
-underlying claim is extended to be at least `challenge period extension`, to give time for the other party to respond.
+underlying claim is extended to be at least ``challenge period extension``, to give time for the other party to respond.
 
 At the end of the challenge period, the last non-contested participant, and thus the participant with the highest stake, wins. The claim
 will be seen as valid if the winner of the challenge game is the original claimer. This means that he will be able to
@@ -189,13 +189,13 @@ withdraw Alice's deposit.
     Bob->>Rollup A: withdraws tokens
 
 To avoid this challenge to go on forever, or reach a point where Bob no longer has the funds to out-stake Charles,
-Bob can trigger the `L1 resolution`.
+Bob can trigger the ``L1 resolution``.
 
 L1 resolutions
 ++++++++++++++
 
-When Bob filled Alice's request, a proof was sent by the `fill manager` contract on rollup B to the outbox of
-rollup B on L1. This proof is a call to a `resolver` contract on L1 and contains the following fields:
+When Bob filled Alice's request, a proof was sent by the ``fill manager`` contract on rollup B to the outbox of
+rollup B on L1. This proof is a call to a ``resolver`` contract on L1 and contains the following fields:
 
 - fill hash = Hash(request hash, fill ID)
 - rollup B's chain ID
@@ -203,15 +203,15 @@ rollup B on L1. This proof is a call to a `resolver` contract on L1 and contains
 - Bob's address
 
 To trigger L1 resolution is to apply this call on L1 using the data from the rollup B's outbox. This will forward the
-information from the resolver to the inbox of rollup A in the form of a call to the `resolution registry`.
-This registry will store in its state a mapping from `fill hash` to `Bob`, allowing the `request manager`
+information from the resolver to the inbox of rollup A in the form of a call to the ``resolution registry``.
+This registry will store in its state a mapping from ``fill hash`` to ``Bob``, allowing the ``request manager``
 to verify that a claim to fill a certain request with a certain fill ID is honest. Rollup A's chain ID is necessary for
-the `resolver` contract to know to which `resolution registry` to forward the proof to. Rollup B's chain ID is used to
-restrict the call to authenticated `fill manager` and `cross domain messenger` contracts.
+the ``resolver`` contract to know to which ``resolution registry`` to forward the proof to. Rollup B's chain ID is used to
+restrict the call to authenticated ``fill manager`` and ``cross domain messenger`` contracts.
 
-After L1 resolution has transferred the fill information from rollup B to rollup A, Bob can directly call `withdraw` on
-the `request manager` on rollup A. This will compute a `fill hash` and query the `resolution registry` for the filler
-address corresponding to `fill hash`, which will return Bob's address. Bob will immediately be considered the winner of
+After L1 resolution has transferred the fill information from rollup B to rollup A, Bob can directly call ``withdraw`` on
+the ``request manager`` on rollup A. This will compute a ``fill hash`` and query the ``resolution registry`` for the filler
+address corresponding to ``fill hash``, which will return Bob's address. Bob will immediately be considered the winner of
 the challenge and receive his stake as well as Charles' stake, the tokens locked by Alice, and the fees paid by Alice for the service.
 
 .. mermaid::
@@ -245,35 +245,35 @@ the challenge and receive his stake as well as Charles' stake, the tokens locked
 Why do we need the fill ID?
 +++++++++++++++++++++++++++
 
-The reason a claimer needs to submit a `fill ID` is to make a statement as to when the related request was filled. It is
-returned by the `FillManager` contract on rollup B and there will always be only one valid `fill ID` to a fill of a
+The reason a claimer needs to submit a ``fill ID`` is to make a statement as to when the related request was filled. It is
+returned by the ``FillManager`` contract on rollup B and there will always be only one valid ``fill ID`` to a fill of a
 requests. Enforcing a submission of an ID, certain attacks on honest challengers are prevented. Without this ID, an
 evildoer could claim an unfilled request and only fill it once its claim is challenged thus turning it into a rightful
-claim and gaining the challenger's stake. The `fill ID` is defined as:
+claim and gaining the challenger's stake. The ``fill ID`` is defined as:
 
 ::
 
     fill_id = hash(previous block)
 
-When seeing a claim with a certain `fill ID`, observers can verify if a fill with corresponding ID has been made. If they
+When seeing a claim with a certain ``fill ID``, observers can verify if a fill with corresponding ID has been made. If they
 know of no fill with this fill ID, they are guaranteed the claim is wrongful, as long as the claimer did not guess the hash
 of a block in the future correctly.
 
-Any claim with a different `fill ID` than the generated value upon filling the request is considered to be a false claim.
+Any claim with a different ``fill ID`` than the generated value upon filling the request is considered to be a false claim.
 
 Challenging false claims
 ++++++++++++++++++++++++
 
 We saw that if Bob filled Alice's claim, he will always be able to prove correctness of the fill in order to withdraw
-its due from the `request manager` contract. However, if Charles falsely claims and withdraws rewards from the contract,
+its due from the ``request manager`` contract. However, if Charles falsely claims and withdraws rewards from the contract,
 there will be no funds left for Bob. In order to prevent that, Bob also needs to challenge Charles' false claims.
 
-As we saw in the previous part, Bob can use the `fill ID` provided by Charles during his claim to find out if the claim is
+As we saw in the previous part, Bob can use the ``fill ID`` provided by Charles during his claim to find out if the claim is
 rightful or not. Upon seeing that it is not, Bob can challenge Charles' claim. The process will be the same as described
 in the previous part about rightful claims resolutions, except that Charles will not be able to prove via L1 resolution
 that his claim is rightful.
 
-The first possible outcome is that the `challenge period` ends while Bob is ahead. In that case Bob will gain Charles'
+The first possible outcome is that the ``challenge period`` ends while Bob is ahead. In that case Bob will gain Charles'
 stake and Charles will not be able to withdraw anything. In the event that Charles keeps on contesting Bob's challenges
 and reaches a point where Bob no longer has enough funds to stake, Bob (or anyone else) will need to fill Alice's request
 on rollup A and trigger L1 resolution for it. This will prove that the request was filled by someone other
@@ -284,9 +284,9 @@ Note that we have a time constraint until when it is safe for Bob to fill the re
 that Charles is able to win the challenge by bidding an amount high enough which Bob is not capable of outbidding
 anymore. While this is the very use case for L1 resolution, Bob must make sure that his fill proof arrives at the
 source rollup before Charles wins the false claim and thus becomes able to withdraw the deposit.
-To find a value until when it is safe for Bob to fill the request, we consider the end of `challengePeriod` of Charles'
-false claim called `false claim termination`. Transferring Bob's fill proof to the rollup A will take at least
-`finalization time[rollup B]`. We derive the following condition:
+To find a value until when it is safe for Bob to fill the request, we consider the end of ``challengePeriod`` of Charles'
+false claim called ``false claim termination``. Transferring Bob's fill proof to the rollup A will take at least
+``finalization time[rollup B]``. We derive the following condition:
 
 ::
 
@@ -326,8 +326,8 @@ In the previous explanation, we only talked about two participants to the challe
 submitting his false claim, Charles challenges himself. This would let Charles control the state of his challenge and
 he would be able to let it expire with his claim successful as an outcome.
 
-To prevent this successful `self-challenged claim` to allow Charles to withdraw Alice's deposit, Bob can fill Alice's request
-and do his own claim in parallel. If Bob's claim is not challenged and `claim period` is lower than the `challenge period`,
+To prevent this successful ``self-challenged claim`` to allow Charles to withdraw Alice's deposit, Bob can fill Alice's request
+and do his own claim in parallel. If Bob's claim is not challenged and ``claim period`` is lower than the ``challenge period``,
 Bob will be able to withdraw Alice's deposit before Charles, leaving nothing for Charles to gain.
 
 Charles can attempt to delay Bob's withdrawal by challenging Bob's rightful claim. If Charles' stake on the rightful claim
@@ -339,11 +339,11 @@ Charles' claim reach the end of its period. The time constraint described in the
 Claims that cannot be filled
 ++++++++++++++++++++++++++++
 
-In both the regular `false claim` and `self-challenge claim` cases, we assumed that Bob could fill Alice's request in
+In both the regular ``false claim`` and ``self-challenge claim`` cases, we assumed that Bob could fill Alice's request in
 order to prove that the false claimer Charles was not the correct filler. However, If Alice's request cannot be filled
 for any reason (e.g. transfer value too high), instead of proving that someone other than Charles filled a request,
 Bob will need to prove that Charles did not fill the request as claimed. For that, Bob needs to create and submit an
-`L1 non-fill proof` from rollup B to rollup A.
+``L1 non-fill proof`` from rollup B to rollup A.
 
 When called, the fill manager contract on rollup B recomputes the fill hash from the request hash, and fill ID,
 and checks that no fills exists for the corresponding request hash and fill hash. It then submits a proof
@@ -351,12 +351,12 @@ to the outbox of rollup B indicating that the fill hash is invalid, i.e. that th
 fill hash.
 
 Similarly to the filled L1 resolution case, Bob can then trigger a call on L1 to forward this message to rollup A. This
-message will store in the `resolution registry` that the `fill hash` is invalid and make any claim from Charles with
+message will store in the ``resolution registry`` that the ``fill hash`` is invalid and make any claim from Charles with
 the corresponding hash an invalid claim.
 
-To make sure the proof arrives in time on rollup A, Bob will need to call the `fill manager` as soon as he notices a
-false claim for a non-filled request. It takes `finalization time of rollup B` after Bob's call to be able to send the
-proof, while the challenge period is defined to be `finalization time of rollup B + challenge period extension`.
+To make sure the proof arrives in time on rollup A, Bob will need to call the ``fill manager`` as soon as he notices a
+false claim for a non-filled request. It takes ``finalization time of rollup B`` after Bob's call to be able to send the
+proof, while the challenge period is defined to be ``finalization time of rollup B + challenge period extension``.
 
 In the case where someone challenges Charles on the false claim at the same time as Bob sends the transaction for the
 proof on rollup B, Bob will not be able to challenge Charles and will not receive any financial reward from having sent
@@ -381,14 +381,14 @@ The rationale behind the book keeping is that anybody who entered into a challen
 rewarded when his position wins, depending on the amount they had to put in. When the challenge ends, if the claimer is
 ahead, he will earn the stakes of every challenger. If a challenger is ahead, each non-last challenger earns a value
 equal to their total stake. The stake of the last challenger being only partially covered by the claimer, he will only
-earn `stake claimer - stake other challengers`, i.e. the remaining tokens.
+earn ``stake claimer - stake other challengers``, i.e. the remaining tokens.
 
 In the case where the dishonest party was leading and the L1 resolution proved him to be incorrect, there will be an
 excess of stake that can be redistributed to the last bidder, or, if known, to the one responsible for the L1 transaction.
 
 This allows honest watchers to enter into any challenge at any point in time, provoking the dishonest counterpart to
 either bid more (and thus lose more) or to end the challenge game. The potential minimum gain for each bid is
-`stake winning party - stake losing party`, if not overbid.
+``stake winning party - stake losing party``, if not overbid.
 
 For example, if Charles makes a claim with a stake of 5, and David challenges with a stake of 6, the bookkeeping will
 look like so:
@@ -442,7 +442,7 @@ price of the rollup as well as a fixed margin for liquidity providers.
 Agent strategy
 --------------
 
-`Agents` is the term we use for the software run by liquidity providers to observe the rollups, fill users' requests,
+``Agents`` is the term we use for the software run by liquidity providers to observe the rollups, fill users' requests,
 and participate in challenges. The protocol defines some rules and demonstrates how honest participation is incentivized.
 However, the agent could still implement different strategies to follow the protocol. For example, the agent is free to
 choose the value with which it will bid in challenges. It is also allowed to decide when to stop out-bidding opponents
@@ -450,11 +450,11 @@ in challenges and go through L1 resolution or open parallel claims.
 
 The current implementation of the agent follows this strategy:
 
-* Challenge a false claim with `claim stake + 1`
-* Challenge a claim with no filler with `cost of L1 non-fill proof`
-* Join a challenged non-filled claim with `cost of L1 non-fill proof`
+* Challenge a false claim with ``claim stake + 1``
+* Challenge a claim with no filler with ``cost of L1 non-fill proof``
+* Join a challenged non-filled claim with ``cost of L1 non-fill proof``
 * Subsequent counter challenge should cover the cost of L1 resolution
-* Immediately send `non-fill proof call` on target rollup for claims with no corresponding fills
+* Immediately send ``non-fill proof call`` on target rollup for claims with no corresponding fills
 * Proceed with L1 resolution only when the stake of the opponent covers the cost and we are losing a challenge
 * Open a parallel claim to one of our rightful claims if:
     * there is a challenged wrongful claim C for the same request and
@@ -464,7 +464,7 @@ The current implementation of the agent follows this strategy:
 Protocol parameters
 -------------------
 
-The choice of different protocol parameters such as `claim period` or `claim stake` is explained in :ref:`contract_parameters`.
+The choice of different protocol parameters such as ``claim period`` or ``claim stake`` is explained in :ref:``contract_parameters``.
 
 One important decision regarding parameters is not to wait for the inclusion period of rollups to consider an event as successful.
 When liquidity providers fill a user request, the event regarding the successful fill is sent by the target rollup sequencer.
@@ -473,7 +473,7 @@ produced by the sequencer to be committed to L1.
 
 As far as we know, it is allowed for different rollup sequencers to take as long as one week to commit their block to L1.
 It could theoretically occur that after one week, the rollup commits to a block that does not result in a successful fill
-of the request by the liquidity provider. To take that into account, we would need to lengthen the `claim period` parameter by
+of the request by the liquidity provider. To take that into account, we would need to lengthen the ``claim period`` parameter by
 one additional week, which would result in higher opportunity costs for the liquidity provider.
 
 In practice the longest observed delay of block inclusion from a rollup sequencer has been 18 hours, and was exceptional.


### PR DESCRIPTION
See issue #346 and #492 for discussion

Idk if we should keep the idea of parallel claims to solve the "self-challenge" problem in the case the request was honestly filled. We could think about replacing it with the honest filler joining the challenge game as a third party. I'm fine with w/e.