### PR TITLE
Set up a Prometheus metrics endpoint

### DIFF
--- a/beamer/agent.py
+++ b/beamer/agent.py
@@ -1,6 +1,7 @@
 import threading
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 import structlog
 import web3
@@ -9,6 +10,7 @@ from eth_typing import Address
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.middleware import construct_sign_and_send_raw_middleware, geth_poa_middleware
 
+import beamer.metrics
 from beamer.chain import ContractEventMonitor, EventProcessor
 from beamer.contracts import DeploymentInfo, make_contracts
 from beamer.state_machine import Context
@@ -27,6 +29,7 @@ class Config:
     l2b_rpc_url: URL
     token_match_file: Path
     fill_wait_time: int
+    prometheus_metrics_port: Optional[int]
 
 
 def _make_web3(url: URL, account: LocalAccount) -> web3.Web3:
@@ -93,6 +96,7 @@ class Agent:
 
     def start(self) -> None:
         assert self._stopped.is_set()
+        beamer.metrics.init(self._config)
         self._event_processor.start()
         self._contract_monitor_l2a.start()
         self._contract_monitor_l2b.start()

--- a/beamer/cli.py
+++ b/beamer/cli.py
@@ -1,6 +1,7 @@
 import json
 import signal
 from pathlib import Path
+from typing import Optional
 
 import click
 import structlog
@@ -77,6 +78,14 @@ def _sigint_handler(agent: Agent) -> None:
     show_default=True,
     help="The log level.",
 )
+@click.option(
+    "--prometheus-metrics-port",
+    type=int,
+    default=None,
+    metavar="PORT",
+    show_default=True,
+    help="Provide Prometheus metrics on PORT.",
+)
 @click.version_option()
 def main(
     keystore_file: Path,
@@ -87,6 +96,7 @@ def main(
     token_match_file: Path,
     fill_wait_time: int,
     log_level: str,
+    prometheus_metrics_port: Optional[int],
 ) -> None:
     beamer.util.setup_logging(log_level=log_level.upper(), log_json=False)
 
@@ -100,6 +110,7 @@ def main(
         l2b_rpc_url=l2b_rpc_url,
         token_match_file=token_match_file,
         fill_wait_time=fill_wait_time,
+        prometheus_metrics_port=prometheus_metrics_port,
     )
 
     signal.signal(signal.SIGINT, lambda *_unused: _sigint_handler(agent))

--- a/beamer/metrics.py
+++ b/beamer/metrics.py
@@ -1,0 +1,63 @@
+import contextlib
+import threading
+from dataclasses import dataclass
+from typing import Any, Generator
+
+import structlog
+from prometheus_client import Counter, Info, start_http_server
+
+log = structlog.get_logger(__name__)
+
+
+def init(config: Any) -> None:
+    global _DATA
+
+    if _DATA is not None:
+        return
+
+    info = Info("agent_info", "Agent information")
+    info.info(
+        dict(
+            account=config.account.address,
+            l2a_rpc_url=config.l2a_rpc_url,
+            l2b_rpc_url=config.l2b_rpc_url,
+        )
+    )
+    requests_filled = Counter(
+        "requests_filled",
+        "Number of requests filled on the target rollup, regardless of filler",
+    )
+    requests_filled_by_agent = Counter(
+        "requests_filled_by_agent", "Number of requests the agent filled on the target rollup"
+    )
+    requests_created = Counter(
+        "requests_created", "Number of requests created on the source rollup"
+    )
+
+    _DATA = _Data(
+        info=info,
+        requests_filled=requests_filled,
+        requests_filled_by_agent=requests_filled_by_agent,
+        requests_created=requests_created,
+    )
+    if config.prometheus_metrics_port is not None:
+        log.info("Serving Prometheus metrics", port=config.prometheus_metrics_port)
+        start_http_server(config.prometheus_metrics_port)
+
+
+@dataclass
+class _Data:
+    info: Info
+    requests_filled: Counter
+    requests_filled_by_agent: Counter
+    requests_created: Counter
+
+
+_DATA: _Data = None  # type:ignore
+_DATA_LOCK = threading.Lock()
+
+
+@contextlib.contextmanager
+def update() -> Generator[_Data, None, None]:
+    with _DATA_LOCK:
+        yield _DATA

--- a/beamer/tests/conftest.py
+++ b/beamer/tests/conftest.py
@@ -15,6 +15,7 @@ from brownie import (
     accounts,
 )
 
+import beamer.metrics
 from beamer.agent import Agent, Config
 from beamer.contracts import ContractInfo
 from beamer.tests.util import alloc_accounts
@@ -159,7 +160,9 @@ def config(request_manager, fill_manager, token):
         token_match_file=token_match_file,
         account=account,
         fill_wait_time=0,
+        prometheus_metrics_port=None,
     )
+    beamer.metrics.init(config)
     return config
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -926,6 +926,17 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "prometheus-client"
+version = "0.14.1"
+description = "Python client for the Prometheus monitoring system."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+twisted = ["twisted"]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.21"
 description = "Library for building powerful interactive command lines in Python"
@@ -1664,7 +1675,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9, <3.10"
-content-hash = "680092368e495fae94c26d3325b28ab5f61fd85e99858b616d6b2dc69700ad67"
+content-hash = "5aa3e13a48a72d9da2d83b214ee8b39d73fb904175bf1a908823dc96d2d9161c"
 
 [metadata.files]
 aiohttp = [
@@ -2169,6 +2180,10 @@ platformdirs = [
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+prometheus-client = [
+    {file = "prometheus_client-0.14.1-py3-none-any.whl", hash = "sha256:522fded625282822a89e2773452f42df14b5a8e84a86433e3f8a189c1d54dc01"},
+    {file = "prometheus_client-0.14.1.tar.gz", hash = "sha256:5459c427624961076277fdc6dc50540e2bacb98eebde99886e59ec55ed92093a"},
 ]
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.21-py3-none-any.whl", hash = "sha256:62b3d3ea5a3ccee94dc1aac018279cf64866a76837156ebe159b981c42dd20a8"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ shiv = "^1.0.1"
 Sphinx = "^4.5.0"
 furo = "^2022.4.7"
 sphinxcontrib-mermaid = "^0.7.1"
+prometheus-client = "^0.14.1"
 
 [tool.poetry.scripts]
 beamer-agent = 'beamer.cli:main'


### PR DESCRIPTION
This uses the `prometheus_client` Python package to set up an endpoint that serves some simple data about the running agent,
as outlined in #468.

Part of #468.

I've tested the endpoint locally and it seems to work alright. The next step would be to configure our Prometheus server to poll our agents' endpoints periodically. Once that is done, we can close #468.
