### PR TITLE
ci: Make agent tests conditional in pure frontend PRs

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -3,8 +3,11 @@ name: Agent CI
 on:
   push:
     branches: [ main ]
+
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      -  'frontend/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This will avoid running agents tests when jst frontend is touched.

I decided to run in on merges to `main` unconditionally, so we have data there.