### PR TITLE
pyproject.toml: make prometheus-client a regular dependency, not a de…

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -929,7 +929,7 @@ testing = ["pytest", "pytest-benchmark"]
 name = "prometheus-client"
 version = "0.14.1"
 description = "Python client for the Prometheus monitoring system."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -1675,7 +1675,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9, <3.10"
-content-hash = "5aa3e13a48a72d9da2d83b214ee8b39d73fb904175bf1a908823dc96d2d9161c"
+content-hash = "43c2e98ae7c5636c3fe43da6265e4d270f6100eaea14f514e12b5c3bd0507f51"
 
 [metadata.files]
 aiohttp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ web3 = "^5.24.0"
 click = "^8.0.3"
 structlog = "^21.5.0"
 python-statemachine = "^0.8.0"
+prometheus-client = "^0.14.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"
@@ -31,7 +32,6 @@ shiv = "^1.0.1"
 Sphinx = "^4.5.0"
 furo = "^2022.4.7"
 sphinxcontrib-mermaid = "^0.7.1"
-prometheus-client = "^0.14.1"
 
 [tool.poetry.scripts]
 beamer-agent = 'beamer.cli:main'


### PR DESCRIPTION
…v dependency

I mistakenly added this as a dev dependency, which means the lib won't be included in the packaged binary.