### PR TITLE
contracts: Add `invalidateFillHash` to `ResolutionRegistry`

### DIFF
--- a/beamer/tests/contracts/test_l1_resolution.py
+++ b/beamer/tests/contracts/test_l1_resolution.py
@@ -64,3 +64,6 @@ def test_restricted_calls(contracts, resolver):
 
     with brownie.reverts("XRestrictedCalls: unknown caller"):
         contracts.resolution_registry.resolveRequest(0, 0, caller, {"from": caller})
+
+    with brownie.reverts("XRestrictedCalls: unknown caller"):
+        contracts.resolution_registry.invalidateFillHash(0, 0, {"from": caller})

--- a/contracts/contracts/ResolutionRegistry.sol
+++ b/contracts/contracts/ResolutionRegistry.sol
@@ -10,8 +10,14 @@ contract ResolutionRegistry is CrossDomainRestrictedCalls {
         address filler
     );
 
+    event FillHashInvalidated(
+        bytes32 fillHash
+    );
+
     // mapping from fillHash to filler
     mapping(bytes32 => address) public fillers;
+    // mapping from fillHash to validity flag
+    mapping(bytes32 => bool) public invalidFillHashes;
 
     function resolveRequest(bytes32 fillHash, uint256 resolutionChainId, address filler)
         external restricted(resolutionChainId, msg.sender) {
@@ -22,6 +28,17 @@ contract ResolutionRegistry is CrossDomainRestrictedCalls {
         emit RequestResolved(
             fillHash,
             filler
+        );
+    }
+
+    function invalidateFillHash(bytes32 fillHash, uint256 resolutionChainId)
+        external restricted(resolutionChainId, msg.sender) {
+
+        require(invalidFillHashes[fillHash] == false, "FillHash already invalidated");
+        invalidFillHashes[fillHash] = true;
+
+        emit FillHashInvalidated(
+            fillHash
         );
     }
 }


### PR DESCRIPTION
Resolves #563 


In the function I needed to add the `resolutionChainId` parameter, as this is necessary to check the call chain.