### PR TITLE
Update withdraw claim strategy to only withdraw own winning claims

### DIFF
--- a/beamer/tests/agent/test_request.py
+++ b/beamer/tests/agent/test_request.py
@@ -110,6 +110,10 @@ def test_challenge_own_claim(config, request_manager, token):
         ),
         int(time.time()),
     )
+    # Add context so that maybe_challenge verifies that the claim is not expired
+    agent.context.requests.add(request.id, request)
+    agent.context.latest_blocks[brownie.chain.id] = {"timestamp": 0}
+
     assert not maybe_challenge(claim, agent.context), "Tried to challenge own claim"
 
 


### PR DESCRIPTION
I believe that without this, the agent will attempt to withdraw any invalid claim that were contested by someone else:

1- Bob makes wrong claim
2- Charles challenges
3- Claim expires and Charles wins
4- Agent (that did not participate so far) tries to withdraw

Also, without the `continue` in the withdraw `if` clause, the agent will try to challenge a terminated claim.

The withdraw does not fail, and instead sends the funds to Charles because that's how it is in the contracts, but I don't believe the Agent should do that.

I attempted to write a test and could actually verify the behaviour with logs, but since the withdraw tx does not fail, it's hard to write an effective test.

Idk if we should transition the claim to `ignored` state, I don't fully understand this.