### PR TITLE
contracts: add resolveNonFill to L1 Resolver.sol

### DIFF
--- a/beamer/tests/contracts/test_l1_resolution.py
+++ b/beamer/tests/contracts/test_l1_resolution.py
@@ -63,6 +63,9 @@ def test_restricted_calls(contracts, resolver):
         contracts.resolver.resolve(0, brownie.chain.id, brownie.chain.id, caller, {"from": caller})
 
     with brownie.reverts("XRestrictedCalls: unknown caller"):
+        contracts.resolver.resolveNonFill(0, brownie.chain.id, brownie.chain.id, {"from": caller})
+
+    with brownie.reverts("XRestrictedCalls: unknown caller"):
         contracts.resolution_registry.resolveRequest(0, 0, caller, {"from": caller})
 
     with brownie.reverts("XRestrictedCalls: unknown caller"):


### PR DESCRIPTION
fixes: #565 


I reused the `Resolution` event when sending a Non-Fill Proof with `filler = address(0)`. I thought this is sufficient as we have a more expressive event in `ResolutionRegistry.sol`.