### PR TITLE
chore: Specify node version in frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,5 +51,8 @@
     "typescript": "~4.1.5",
     "vite": "^2.9.0",
     "vitest": "^0.9.3"
+  },
+  "engines": {
+    "node": "16.x"
   }
 }


### PR DESCRIPTION
The deployment on DO fails because of an old NodeJS version.

This is solved by specifying a recent version in the package file. I tested this on DO and it works.