### PR TITLE
fix lint errors from previous merge

### DIFF
--- a/beamer/chain.py
+++ b/beamer/chain.py
@@ -360,6 +360,11 @@ def maybe_challenge(claim: Claim, context: Context) -> bool:
     #
     # 2) we participate in the game AND it is our turn
     request = context.requests.get(claim.request_id)
+    # As per definition an invalid or expired request cannot be claimed
+    # This gives us a chronological order. The agent should never garbage collect
+    # a request which has active claims
+    assert request is not None, "Active claim for non-existent request"
+
     block = context.latest_blocks[request.source_chain_id]
     if block["timestamp"] >= claim.termination:
         return False
@@ -393,6 +398,11 @@ def maybe_challenge(claim: Claim, context: Context) -> bool:
 
 def maybe_withdraw(claim: Claim, context: Context) -> None:
     request = context.requests.get(claim.request_id)
+    # As per definition an invalid or expired request cannot be claimed
+    # This gives us a chronological order. The agent should never garbage collect
+    # a request which has active claims
+    assert request is not None, "Active claim for non-existent request"
+
     block = context.latest_blocks[request.source_chain_id]
     if block["timestamp"] < claim.termination:
         # TODO: once L1 resolution is implemented, maybe withdraw before claim is terminated

--- a/beamer/tests/agent/test_challenge.py
+++ b/beamer/tests/agent/test_challenge.py
@@ -339,6 +339,7 @@ def test_withdraw_not_participant(request_manager, token, config):
 
     collector = EventCollector(request_manager, "ClaimMade")
     claim = collector.next_event()
+    assert claim is not None
     request_manager.challengeClaim(claim.claimId, {"from": dave, "value": stake + 1})
     brownie.chain.mine(timestamp=claim.termination)
 

--- a/beamer/tests/agent/test_request.py
+++ b/beamer/tests/agent/test_request.py
@@ -6,7 +6,7 @@ import pytest
 from brownie import ZERO_ADDRESS, accounts
 from eth_utils import to_checksum_address
 from hexbytes import HexBytes
-from web3.types import Wei
+from web3.types import Timestamp, Wei
 
 from beamer.agent import Agent
 from beamer.chain import maybe_challenge
@@ -112,7 +112,7 @@ def test_challenge_own_claim(config, request_manager, token):
     )
     # Add context so that maybe_challenge verifies that the claim is not expired
     agent.context.requests.add(request.id, request)
-    agent.context.latest_blocks[brownie.chain.id] = {"timestamp": 0}
+    agent.context.latest_blocks[brownie.chain.id] = {"timestamp": Timestamp(0)}
 
     assert not maybe_challenge(claim, agent.context), "Tried to challenge own claim"
 


### PR DESCRIPTION
https://github.com/beamer-bridge/beamer/pull/593 had some lint errors which occured during the CI after merging to main. 

I dont know why it did not fail on the PR