### PR TITLE
Add request ID to L1 resolution data

### DIFF
--- a/beamer/events.py
+++ b/beamer/events.py
@@ -90,12 +90,14 @@ class ClaimWithdrawn(ClaimEvent):
 
 @dataclass(frozen=True)
 class RequestResolved(TxEvent):
+    request_id: RequestId
     fill_hash: str
     filler: ChecksumAddress
 
 
 @dataclass(frozen=True)
 class FillHashInvalidated(TxEvent):
+    request_id: RequestId
     fill_hash: str
 
 

--- a/beamer/tests/contracts/test_fill_manager.py
+++ b/beamer/tests/contracts/test_fill_manager.py
@@ -52,6 +52,7 @@ def test_fill_request(fill_manager, token, deployer):
 
 
 def test_invalidate_valid_fill_hash(fill_manager, token, deployer):
+    request_id = 123
     chain_id = brownie.web3.eth.chain_id
     amount = 100
     receiver = alloc_accounts(1)[0]
@@ -78,15 +79,16 @@ def test_invalidate_valid_fill_hash(fill_manager, token, deployer):
         amount,
     )
     with brownie.reverts("Fill hash valid"):
-        fill_manager.invalidateFillHash(request_hash, fill_id, chain_id)
+        fill_manager.invalidateFillHash(request_id, request_hash, fill_id, chain_id)
 
 
 def test_invalidated_fill_hash_event(fill_manager):
+    request_id = 123
     request_hash = "1234" + "00" * 30
     fill_id = "5678" + "00" * 30
     chain_id = brownie.web3.eth.chain_id
 
-    tx = fill_manager.invalidateFillHash(request_hash, fill_id, chain_id)
+    tx = fill_manager.invalidateFillHash(request_id, request_hash, fill_id, chain_id)
 
     fill_hash = keccak(
         encode_abi_packed(

--- a/beamer/tests/contracts/test_request_manager.py
+++ b/beamer/tests/contracts/test_request_manager.py
@@ -657,7 +657,7 @@ def test_withdraw_without_challenge_with_resolution(
     # Register a L1 resolution
     contracts.messenger2.setLastSender(contracts.resolver.address)
     resolution_registry.resolveRequest(
-        fill_hash, web3.eth.chain_id, claimer.address, {"from": contracts.messenger2}
+        request_id, fill_hash, web3.eth.chain_id, claimer.address, {"from": contracts.messenger2}
     )
 
     # The claim period is not over, but the resolution must allow withdrawal now

--- a/contracts/contracts/FillManager.sol
+++ b/contracts/contracts/FillManager.sol
@@ -67,7 +67,13 @@ contract FillManager is Ownable {
         IERC20 token = IERC20(targetTokenAddress);
         token.safeTransferFrom(msg.sender, targetReceiverAddress, amount);
 
-        IProofSubmitter.ProofReceipt memory proofReceipt = proofSubmitter.submitProof(l1Resolver, requestHash, sourceChainId, msg.sender);
+        IProofSubmitter.ProofReceipt memory proofReceipt = proofSubmitter.submitProof(
+            l1Resolver,
+            sourceChainId,
+            requestId,
+            requestHash,
+            msg.sender
+            );
         require(
             proofReceipt.fillId != 0,
             "Submitting proof data failed"
@@ -80,10 +86,15 @@ contract FillManager is Ownable {
         return proofReceipt.fillId;
     }
 
-    function invalidateFillHash(bytes32 requestHash, bytes32 fillId, uint256 sourceChainId) external {
+    function invalidateFillHash(
+        uint256 requestId,
+        bytes32 requestHash,
+        bytes32 fillId,
+        uint256 sourceChainId
+    ) external {
         bytes32 fillHash = BeamerUtils.createFillHash(requestHash, fillId);
         require(fills[requestHash] != fillHash, "Fill hash valid");
-        proofSubmitter.submitNonFillProof(l1Resolver, sourceChainId, fillHash);
+        proofSubmitter.submitNonFillProof(l1Resolver, sourceChainId, requestId, fillHash);
         emit HashInvalidated(requestHash, fillId, fillHash);
     }
 

--- a/contracts/contracts/OptimismProofSubmitter.sol
+++ b/contracts/contracts/OptimismProofSubmitter.sol
@@ -19,7 +19,7 @@ contract OptimismProofSubmitter is IProofSubmitter, RestrictedCalls {
         messenger = ICrossDomainMessenger(_messenger);
     }
 
-    function submitProof(address l1Resolver, bytes32 requestHash, uint256 sourceChainId, address filler)
+    function submitProof(address l1Resolver, uint256 sourceChainId, uint256 requestId, bytes32 requestHash, address filler)
         external restricted(block.chainid, msg.sender) returns (ProofReceipt memory)
     {
         bytes32 fillId = keccak256(abi.encode(block.number));
@@ -30,6 +30,7 @@ contract OptimismProofSubmitter is IProofSubmitter, RestrictedCalls {
             abi.encodeCall(
                 Resolver.resolve,
                 (
+                    requestId,
                     fillHash,
                     block.chainid,
                     sourceChainId,
@@ -42,12 +43,13 @@ contract OptimismProofSubmitter is IProofSubmitter, RestrictedCalls {
         return ProofReceipt(fillId, fillHash);
     }
 
-    function submitNonFillProof(address l1Resolver, uint256 sourceChainId, bytes32 fillHash) external {
+    function submitNonFillProof(address l1Resolver, uint256 sourceChainId, uint256 requestId, bytes32 fillHash) external {
         messenger.sendMessage(
             l1Resolver,
             abi.encodeCall(
                 Resolver.resolveNonFill,
                     (
+                        requestId,
                         fillHash,
                         block.chainid,
                         sourceChainId

--- a/contracts/contracts/ResolutionRegistry.sol
+++ b/contracts/contracts/ResolutionRegistry.sol
@@ -6,11 +6,13 @@ import "./CrossDomainRestrictedCalls.sol";
 contract ResolutionRegistry is CrossDomainRestrictedCalls {
 
     event RequestResolved(
+        uint256 requestId,
         bytes32 fillHash,
         address filler
     );
 
     event FillHashInvalidated(
+        uint256 requestId,
         bytes32 fillHash
     );
 
@@ -19,25 +21,27 @@ contract ResolutionRegistry is CrossDomainRestrictedCalls {
     // mapping from fillHash to validity flag
     mapping(bytes32 => bool) public invalidFillHashes;
 
-    function resolveRequest(bytes32 fillHash, uint256 resolutionChainId, address filler)
+    function resolveRequest(uint256 requestId, bytes32 fillHash, uint256 resolutionChainId, address filler)
         external restricted(resolutionChainId, msg.sender) {
 
         require(fillers[fillHash] == address(0), "Resolution already recorded");
         fillers[fillHash] = filler;
 
         emit RequestResolved(
+            requestId,
             fillHash,
             filler
         );
     }
 
-    function invalidateFillHash(bytes32 fillHash, uint256 resolutionChainId)
+    function invalidateFillHash(uint256 requestId, bytes32 fillHash, uint256 resolutionChainId)
         external restricted(resolutionChainId, msg.sender) {
 
         require(invalidFillHashes[fillHash] == false, "FillHash already invalidated");
         invalidFillHashes[fillHash] = true;
 
         emit FillHashInvalidated(
+            requestId,
             fillHash
         );
     }

--- a/contracts/contracts/Resolver.sol
+++ b/contracts/contracts/Resolver.sol
@@ -22,7 +22,7 @@ contract Resolver is Ownable, CrossDomainRestrictedCalls {
 
     mapping (uint256 => ResolutionInfos) public resolutionInfos;
 
-    function resolve(bytes32 fillHash, uint256 fillChainId, uint256 sourceChainId, address filler)
+    function resolve(uint256 requestId, bytes32 fillHash, uint256 fillChainId, uint256 sourceChainId, address filler)
         external restricted(fillChainId, msg.sender) {
 
         ResolutionInfos storage info = resolutionInfos[sourceChainId];
@@ -35,6 +35,7 @@ contract Resolver is Ownable, CrossDomainRestrictedCalls {
             abi.encodeCall(
                 ResolutionRegistry.resolveRequest,
                 (
+                    requestId,
                     fillHash,
                     block.chainid,
                     filler
@@ -46,7 +47,7 @@ contract Resolver is Ownable, CrossDomainRestrictedCalls {
         emit Resolution(sourceChainId, fillChainId, fillHash, filler);
     }
 
-    function resolveNonFill(bytes32 fillHash, uint256 fillChainId, uint256 sourceChainId)
+    function resolveNonFill(uint256 requestId, bytes32 fillHash, uint256 fillChainId, uint256 sourceChainId)
         external restricted(fillChainId, msg.sender) {
 
         ResolutionInfos storage info = resolutionInfos[sourceChainId];
@@ -59,6 +60,7 @@ contract Resolver is Ownable, CrossDomainRestrictedCalls {
             abi.encodeCall(
                 ResolutionRegistry.invalidateFillHash,
                 (
+                    requestId,
                     fillHash,
                     block.chainid
                 )

--- a/contracts/interfaces/IProofSubmitter.sol
+++ b/contracts/interfaces/IProofSubmitter.sol
@@ -10,10 +10,11 @@ interface IProofSubmitter {
 
     function submitProof(
         address l1Resolver,
-        bytes32 requestHash,
         uint256 sourceChainId,
+        uint256 requestId,
+        bytes32 requestHash,
         address eligibleClaimer
     ) external returns (ProofReceipt memory);
 
-    function submitNonFillProof(address l1Resolver, uint256 sourceChainId, bytes32 fillHash) external;
+    function submitNonFillProof(address l1Resolver, uint256 sourceChainId, uint256 requestId, bytes32 fillHash) external;
 }


### PR DESCRIPTION
Part of #271 

This lets us map the l1 resolution events to the request.