### PR TITLE
Use tx_receipt.gasUsed instead of tx.gas for gas spending calculation in tests

### DIFF
--- a/beamer/tests/agent/test_challenge.py
+++ b/beamer/tests/agent/test_challenge.py
@@ -37,9 +37,7 @@ def test_challenge_1(request_manager, token, config):
     agent.start()
 
     w3 = brownie.web3
-    with earnings(w3, agent, num_fills=1) as agent_earnings, earnings(
-        w3, charlie, num_fills=0
-    ) as charlie_earnings:
+    with earnings(w3, agent) as agent_earnings, earnings(w3, charlie) as charlie_earnings:
         token.approve(request_manager.address, 1, {"from": agent.address})
         make_request(request_manager, token, requester, target_address, 1)
 
@@ -81,9 +79,7 @@ def test_challenge_2(request_manager, token, config):
     agent.start()
 
     w3 = brownie.web3
-    with earnings(w3, agent, num_fills=1) as agent_earnings, earnings(
-        w3, charlie, num_fills=0
-    ) as charlie_earnings:
+    with earnings(w3, agent) as agent_earnings, earnings(w3, charlie) as charlie_earnings:
         token.approve(request_manager.address, 1, {"from": agent.address})
         make_request(request_manager, token, requester, target_address, 1)
 
@@ -135,9 +131,7 @@ def test_challenge_3(request_manager, fill_manager, token, config):
     agent = beamer.agent.Agent(config)
 
     w3 = brownie.web3
-    with earnings(w3, agent, num_fills=0) as agent_earnings, earnings(
-        w3, charlie, num_fills=0
-    ) as charlie_earnings:
+    with earnings(w3, agent) as agent_earnings, earnings(w3, charlie) as charlie_earnings:
         # Submit a request that Bob cannot fill.
         amount = token.balanceOf(agent.address) + 1
         request_id = make_request(request_manager, token, requester, target_address, amount)
@@ -187,9 +181,7 @@ def test_challenge_4(request_manager, fill_manager, token, config):
     agent = beamer.agent.Agent(config)
 
     w3 = brownie.web3
-    with earnings(w3, agent, num_fills=0) as agent_earnings, earnings(
-        w3, charlie, num_fills=0
-    ) as charlie_earnings:
+    with earnings(w3, agent) as agent_earnings, earnings(w3, charlie) as charlie_earnings:
         # Submit a request that Bob cannot fill.
         amount = token.balanceOf(agent.address) + 1
         request_id = make_request(request_manager, token, requester, target_address, amount)

--- a/beamer/tests/util.py
+++ b/beamer/tests/util.py
@@ -133,7 +133,7 @@ class EventCollector:
 
 
 @contextlib.contextmanager
-def earnings(w3, account, num_fills=0):
+def earnings(w3, account):
     address = account.address
     balance_before = w3.eth.get_balance(address)
 
@@ -145,13 +145,10 @@ def earnings(w3, account, num_fills=0):
             block = brownie.web3.eth.get_block(block_number)
             for tx_hash in block.transactions:
                 tx = brownie.web3.eth.get_transaction(tx_hash)
+                tx_receipt = brownie.web3.eth.get_transaction_receipt(tx_hash)
                 if tx["from"] == address:
-                    total += tx.gasPrice * tx.gas
+                    total += tx.gasPrice * tx_receipt.gasUsed
 
-        # We are subtracting 300k gwei here because the token.transferFrom inside
-        # FillManager.fillRequest seems to cost that much, however, ganache does
-        # not reflect that in the account's balance.
-        total -= num_fills * int(300e12)
         return total
 
     yield lambda: w3.eth.get_balance(address) + calculate_gas_spending() - balance_before


### PR DESCRIPTION
a quick fix to calculate the correct gas spending by using tx_receipt.gasUsed