### PR TITLE
L1 resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Finally, still within the virtual environment, run:
 ```
     beamer-agent --keystore-file <keyfile> \
                  --password <keyfile-password> \
+                 --l1-rpc-url <l1-rpc-url> \
                  --l2a-rpc-url <source-l2-rpc-url> \
                  --l2b-rpc-url <target-l2-rpc-url> \
                  --deployment-dir <contract-deployment-dir> \

--- a/beamer/agent.py
+++ b/beamer/agent.py
@@ -35,6 +35,7 @@ class Agent:
         self._stopped = threading.Event()
         self._stopped.set()
 
+        w3_l1 = _make_web3(config.l1_rpc_url, config.account)
         w3_l2a = _make_web3(config.l2a_rpc_url, config.account)
         w3_l2b = _make_web3(config.l2b_rpc_url, config.account)
 
@@ -63,6 +64,7 @@ class Agent:
             address=config.account.address,
             latest_blocks={},
             config=config,
+            web3_l1=w3_l1,
         )
         self._event_processor = EventProcessor(self.context)
 

--- a/beamer/agent.py
+++ b/beamer/agent.py
@@ -71,6 +71,7 @@ class Agent:
             config=config,
             web3_l1=w3_l1,
             resolution_pool=self._resolution_pool,
+            l1_resolutions={},
         )
         self._event_processor = EventProcessor(self.context)
 

--- a/beamer/chain.py
+++ b/beamer/chain.py
@@ -5,6 +5,7 @@ import sys
 import threading
 import time
 import traceback
+from concurrent.futures import Future
 from typing import Any, Callable, Optional, cast
 
 import requests.exceptions
@@ -233,6 +234,15 @@ def process_requests(context: Context) -> None:
     to_remove = []
     for request in context.requests:
         log.debug("Processing request", request=request)
+
+        if request.l1_resolution_tx_handle is not None:
+            handle: Future = request.l1_resolution_tx_handle
+
+            if handle.done():
+                try:
+                    handle.result()
+                except Exception as ex:
+                    log.warning("L1 Resolution failed", ex=ex)
 
         if request.is_pending:
             fill_request(request, context)

--- a/beamer/chain.py
+++ b/beamer/chain.py
@@ -157,7 +157,6 @@ class EventProcessor:
             if self._synced:
                 process_requests(self._context)
                 process_claims(self._context)
-                process_l1_resolutions(self._context)
 
         self._log.info("EventProcessor stopped")
 
@@ -226,22 +225,6 @@ def _transact(func: ContractFunction, **kwargs: Any) -> HexBytes:
 
     func.web3.eth.wait_for_transaction_receipt(txn_hash)
     return txn_hash
-
-
-def process_l1_resolutions(context: Context) -> None:
-    log.debug("Processing L1 resolutions", num_tasks=len(context.l1_resolutions))
-
-    to_remove = []
-    for request_id, future in context.l1_resolutions.items():
-        if future.done():
-            try:
-                future.result()
-                to_remove.append(request_id)
-            except Exception as ex:
-                log.error("L1 Resolution failed", ex=ex)
-
-    for request_id in to_remove:
-        del context.l1_resolutions[request_id]
 
 
 def process_requests(context: Context) -> None:

--- a/beamer/chain.py
+++ b/beamer/chain.py
@@ -433,8 +433,7 @@ def maybe_withdraw(claim: Claim, context: Context) -> None:
     # When request is L1 resolved, the termination isn't important
     if has_l1_resolution:
         # We claimed the request
-        if agent_is_claimer:
-            assert request.l1_resolution_filler == context.address, "We cheated"
+        if agent_is_claimer and request.l1_resolution_filler == context.address:
             _withdraw(claim, context)
 
         # Claimer cheated

--- a/beamer/chain.py
+++ b/beamer/chain.py
@@ -229,7 +229,7 @@ def _transact(func: ContractFunction, **kwargs: Any) -> HexBytes:
 
 
 def process_l1_resolutions(context: Context) -> None:
-    log.info("Processing L1 resolutions", num_tasks=len(context.l1_resolutions))
+    log.debug("Processing L1 resolutions", num_tasks=len(context.l1_resolutions))
 
     to_remove = []
     for request_id, future in context.l1_resolutions.items():
@@ -245,7 +245,7 @@ def process_l1_resolutions(context: Context) -> None:
 
 
 def process_requests(context: Context) -> None:
-    log.info("Processing requests", num_requests=len(context.requests))
+    log.debug("Processing requests", num_requests=len(context.requests))
 
     to_remove = []
     for request in context.requests:
@@ -268,7 +268,7 @@ def process_requests(context: Context) -> None:
 
 
 def process_claims(context: Context) -> None:
-    log.info("Processing claims", num_claims=len(context.claims))
+    log.debug("Processing claims", num_claims=len(context.claims))
 
     to_remove = []
     for claim in context.claims:

--- a/beamer/cli.py
+++ b/beamer/cli.py
@@ -12,6 +12,7 @@ import beamer.contracts
 import beamer.util
 from beamer.agent import Agent
 from beamer.config import Config
+from beamer.l1_resolution import relayer_executable_exists
 from beamer.typing import URL
 
 log = structlog.get_logger(__name__)
@@ -108,6 +109,9 @@ def main(
     prometheus_metrics_port: Optional[int],
 ) -> None:
     beamer.util.setup_logging(log_level=log_level.upper(), log_json=False)
+
+    # TODO: use return value and exit if relayer is not available
+    relayer_executable_exists()
 
     account = _account_from_keyfile(keystore_file, password)
     log.info(f"Using account {account.address}")

--- a/beamer/cli.py
+++ b/beamer/cli.py
@@ -39,6 +39,13 @@ def _sigint_handler(agent: Agent) -> None:
 )
 @click.password_option(required=True, help="The password needed to unlock the account.")
 @click.option(
+    "--l1-rpc-url",
+    type=str,
+    required=True,
+    metavar="URL",
+    help="The URL of the L1 chain RPC server (e.g. http://10.0.0.3:8545).",
+)
+@click.option(
     "--l2a-rpc-url",
     type=str,
     required=True,
@@ -91,6 +98,7 @@ def _sigint_handler(agent: Agent) -> None:
 def main(
     keystore_file: Path,
     password: str,
+    l1_rpc_url: URL,
     l2a_rpc_url: URL,
     l2b_rpc_url: URL,
     deployment_dir: Path,
@@ -107,6 +115,7 @@ def main(
     config = Config(
         account=account,
         deployment_info=deployment_info,
+        l1_rpc_url=l1_rpc_url,
         l2a_rpc_url=l2a_rpc_url,
         l2b_rpc_url=l2b_rpc_url,
         token_match_file=token_match_file,

--- a/beamer/config.py
+++ b/beamer/config.py
@@ -12,6 +12,7 @@ from beamer.typing import URL
 class Config:
     account: LocalAccount
     deployment_info: DeploymentInfo
+    l1_rpc_url: URL
     l2a_rpc_url: URL
     l2b_rpc_url: URL
     token_match_file: Path

--- a/beamer/events.py
+++ b/beamer/events.py
@@ -33,6 +33,11 @@ class LatestBlockUpdatedEvent(Event):
 
 
 @dataclass(frozen=True)
+class InitiateL1ResolutionEvent(Event):
+    request_id: RequestId
+
+
+@dataclass(frozen=True)
 class TxEvent(Event):
     tx_hash: HexBytes
 

--- a/beamer/events.py
+++ b/beamer/events.py
@@ -35,6 +35,7 @@ class LatestBlockUpdatedEvent(Event):
 @dataclass(frozen=True)
 class InitiateL1ResolutionEvent(Event):
     request_id: RequestId
+    claim_id: ClaimId
 
 
 @dataclass(frozen=True)

--- a/beamer/l1_resolution.py
+++ b/beamer/l1_resolution.py
@@ -1,10 +1,27 @@
+import shutil
 import subprocess
 
+import structlog
 from hexbytes import HexBytes
 
 from beamer.typing import URL
 
-RELAYER_EXECUTABLE = "beamer-relayer"
+
+log = structlog.get_logger(__name__)
+
+_RELAYER_EXECUTABLE = "beamer-relayer"
+
+
+def relayer_executable_exists() -> bool:
+    """Checks if the relayer executable is in PATH, return `False` if not"""
+
+    maybe_relayer = shutil.which(_RELAYER_EXECUTABLE)
+    if maybe_relayer is not None:
+        log.debug("Relayer found in PATH", relayer=maybe_relayer)
+        return True
+
+    log.warning("Relayer executable not found in PATH")
+    return False
 
 
 def run_relayer(l1_rpc: URL, l2_rpc: URL, privkey: str, tx_hash: HexBytes) -> None:

--- a/beamer/l1_resolution.py
+++ b/beamer/l1_resolution.py
@@ -1,0 +1,26 @@
+import subprocess
+
+from hexbytes import HexBytes
+
+from beamer.typing import URL
+
+RELAYER_EXECUTABLE = "beamer-relayer"
+
+
+def run_relayer(l1_rpc: URL, l2_rpc: URL, privkey: str, tx_hash: HexBytes) -> None:
+    subprocess.run(
+        [
+            _RELAYER_EXECUTABLE,
+            "--l1rpcprovider",
+            l1_rpc,
+            "--l2rpcprovider",
+            l2_rpc,
+            "--l1wallet",
+            privkey,
+            "--froml2transactionhash",
+            tx_hash,
+        ],
+        capture_output=True,
+        encoding="utf-8",
+        check=True,  # check throws an error right away
+    )

--- a/beamer/models/claim.py
+++ b/beamer/models/claim.py
@@ -61,6 +61,10 @@ class Claim(StateMachine):
     def termination(self) -> Termination:
         return self._latest_claim_made.termination
 
+    @property
+    def latest_claim_made(self) -> ClaimMade:
+        return self._latest_claim_made
+
     def valid_claim_for_request(self, request: Request) -> bool:
         claim_event = self._latest_claim_made
         if claim_event.request_id != request.id:

--- a/beamer/models/request.py
+++ b/beamer/models/request.py
@@ -1,3 +1,4 @@
+from concurrent.futures import Future
 from typing import Optional
 
 from eth_typing import ChecksumAddress
@@ -31,7 +32,8 @@ class Request(StateMachine):
         self.filler: Optional[ChecksumAddress] = None
         self.fill_tx: Optional[HexBytes] = None
         self.fill_id: Optional[int] = None
-        self.l1_resolution_filler = Optional[ChecksumAddress]
+        self.l1_resolution_filler: Optional[ChecksumAddress] = None
+        self.l1_resolution_tx_handle: Optional[Future] = None
 
     pending = State("Pending", initial=True)
     filled = State("Filled")

--- a/beamer/models/request.py
+++ b/beamer/models/request.py
@@ -31,6 +31,7 @@ class Request(StateMachine):
         self.filler: Optional[ChecksumAddress] = None
         self.fill_tx: Optional[HexBytes] = None
         self.fill_id: Optional[int] = None
+        self.l1_resolution_filler = Optional[ChecksumAddress]
 
     pending = State("Pending", initial=True)
     filled = State("Filled")

--- a/beamer/models/request.py
+++ b/beamer/models/request.py
@@ -1,4 +1,3 @@
-from concurrent.futures import Future
 from typing import Optional
 
 from eth_typing import ChecksumAddress
@@ -33,7 +32,7 @@ class Request(StateMachine):
         self.fill_tx: Optional[HexBytes] = None
         self.fill_id: Optional[int] = None
         self.l1_resolution_filler: Optional[ChecksumAddress] = None
-        self.l1_resolution_tx_handle: Optional[Future] = None
+        self.l1_resolution_started = False
 
     pending = State("Pending", initial=True)
     filled = State("Filled")

--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -256,10 +256,10 @@ def _l1_resolution_criteria_fulfilled(claim: Claim, context: Context) -> Handler
     limit = int(l1_resolution_gas_cost * l1_gas_price * l1_safety_factor)
 
     if claim.claimer == context.address:
-        if claim._latest_claim_made.challenger_stake > limit:
+        if claim.latest_claim_made.challenger_stake > limit:
             return True, None
     elif claim.challenger == context.address:
-        if claim._latest_claim_made.claimer_stake > limit:
+        if claim.latest_claim_made.claimer_stake > limit:
             return True, None
 
     return False, None

--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -238,4 +238,19 @@ def _handle_claim_withdrawn(event: ClaimWithdrawn, context: Context) -> HandlerR
         return False, None
 
     claim.withdraw()
-    return True
+    return True, None
+
+
+def _handle_request_resolved(event: RequestResolved, context: Context) -> HandlerResult:
+    request = context.requests.get(event.request_id)
+    if request is None:
+        return False
+
+    request.l1_resolution_filler = event.filler
+
+    return False
+
+
+def _handle_fill_hash_invalidated(event: FillHashInvalidated, context: Context) -> bool:
+    pass
+    # FIXME

--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -242,8 +242,7 @@ def _handle_request_resolved(event: RequestResolved, context: Context) -> Handle
         return False, None
 
     request.l1_resolution_filler = event.filler
-
-    return False
+    return True, None
 
 
 def _handle_fill_hash_invalidated(_event: FillHashInvalidated, _context: Context) -> HandlerResult:

--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -7,6 +7,7 @@ import structlog
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
 from statemachine.exceptions import TransitionNotAllowed
+from web3 import Web3
 from web3.constants import ADDRESS_ZERO
 from web3.contract import Contract
 from web3.types import BlockData
@@ -44,6 +45,7 @@ class Context:
     address: ChecksumAddress
     latest_blocks: dict[ChainId, BlockData]
     config: Config
+    web3_l1: Web3
 
 
 HandlerResult = tuple[bool, Optional[list[Event]]]
@@ -169,7 +171,7 @@ def _handle_deposit_withdrawn(event: DepositWithdrawn, context: Context) -> Hand
 
 def _l1_resolution_criteria_fulfilled(claim: Claim, context: Context) -> bool:
     l1_resolution_gas_cost = 1_000_000  # FIXME
-    l1_gas_price = 1e9  # FIXME
+    l1_gas_price = context.web3_l1.eth.gas_price
     l1_safety_factor = 1.25
     limit = int(l1_resolution_gas_cost * l1_gas_price * l1_safety_factor)
 

--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -211,7 +211,7 @@ def _handle_claim_made(event: ClaimMade, context: Context) -> HandlerResult:
     except TransitionNotAllowed:
         return False, events
 
-    if not request.l1_resolution_started and request.fill_tx is not None:
+    if not request.is_l1_resolved and request.fill_tx is not None:
         events = [
             InitiateL1ResolutionEvent(
                 chain_id=request.target_chain_id,  # Resolution happens on the target chain
@@ -241,7 +241,7 @@ def _handle_request_resolved(event: RequestResolved, context: Context) -> Handle
     if request is None:
         return False, None
 
-    request.l1_resolution_filler = event.filler
+    request.l1_resolve(event.filler)
     return True, None
 
 
@@ -287,7 +287,7 @@ def _handle_initiate_l1_resolution(
             request.fill_tx,
         )
         context.l1_resolutions[request.id] = future
-        request.l1_resolution_started = True
+        request.l1_resolve()
 
         log.info("Initiated L1 resolution", request=request, claim_id=event.claim_id)
 

--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -286,6 +286,16 @@ def _handle_initiate_l1_resolution(
             context.config.account.key,
             request.fill_tx,
         )
+
+        def on_future_done(f: Future) -> None:
+            try:
+                f.result()
+                assert request is not None, "Request object missing"
+                del context.l1_resolutions[request.id]
+            except Exception as ex:
+                log.error("L1 Resolution failed", ex=ex)
+
+        future.add_done_callback(on_future_done)
         context.l1_resolutions[request.id] = future
         request.l1_resolve()
 

--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -179,15 +179,14 @@ def _handle_deposit_withdrawn(event: DepositWithdrawn, context: Context) -> Hand
 
 
 def _handle_claim_made(event: ClaimMade, context: Context) -> HandlerResult:
-    claim = context.claims.get(event.claim_id)
-    request = context.requests.get(event.request_id)
-
-    events: Optional[List[Event]] = None
-
     # RequestCreated event must arrive before ClaimMade
     # Additionally, a request should never be dropped before all claims are finalized
+    request = context.requests.get(event.request_id)
     assert request is not None, "Request object missing upon ClaimMade event"
 
+    events: Optional[list[Event]] = None
+
+    claim = context.claims.get(event.claim_id)
     if claim is None:
         challenge_back_off_timestamp = int(time.time())
         # if fill event is not fetched yet, wait `_fill_wait_time`

--- a/beamer/tests/agent/test_cli.py
+++ b/beamer/tests/agent/test_cli.py
@@ -60,6 +60,8 @@ def test_cli(config, tmp_path, contracts):
             str(keyfile),
             "--password",
             "",
+            "--l1-rpc-url",
+            "",
             "--l2a-rpc-url",
             config.l2a_rpc_url,
             "--l2b-rpc-url",

--- a/beamer/tests/agent/test_handlers.py
+++ b/beamer/tests/agent/test_handlers.py
@@ -47,14 +47,14 @@ def make_address() -> ChecksumAddress:
     return to_checksum_address(make_bytes(20))
 
 
-def make_request(token) -> Request:
+def make_request() -> Request:
     return Request(
         request_id=REQUEST_ID,
         source_chain_id=SOURCE_CHAIN_ID,
         target_chain_id=TARGET_CHAIN_ID,
-        source_token_address=token.address,
-        target_token_address=token.address,
-        target_address=token.address,
+        source_token_address=make_address(),
+        target_token_address=make_address(),
+        target_address=make_address(),
         amount=TokenAmount(123),
         valid_until=456,
     )
@@ -105,8 +105,8 @@ def make_context(config: Config, request_manager: Contract = None):
     )
 
 
-def test_skip_not_self_filled(token, config: Config):
-    request = make_request(token)
+def test_skip_not_self_filled(config: Config):
+    request = make_request()
     context = make_context(config)
 
     context.requests.add(request.id, request)
@@ -116,8 +116,8 @@ def test_skip_not_self_filled(token, config: Config):
     assert request.is_pending  # pylint:disable=no-member
 
 
-def test_ignore_expired(token, config: Config):
-    request = make_request(token)
+def test_ignore_expired(config: Config):
+    request = make_request()
     request.filler = config.account.address
 
     context = make_context(config)
@@ -128,8 +128,8 @@ def test_ignore_expired(token, config: Config):
     assert request.is_ignored  # pylint:disable=no-member
 
 
-def test_request_garbage_collection_without_claim(token, config: Config):
-    request = make_request(token)
+def test_request_garbage_collection_without_claim(config: Config):
+    request = make_request()
     request.fill(config.account.address, b"", b"")
     request.withdraw()
 
@@ -140,7 +140,7 @@ def test_request_garbage_collection_without_claim(token, config: Config):
     process_requests(context)
     assert len(context.requests) == 0
 
-    request = make_request(token)
+    request = make_request()
     request.ignore()
     context.requests.add(request.id, request)
 
@@ -149,8 +149,8 @@ def test_request_garbage_collection_without_claim(token, config: Config):
     assert len(context.requests) == 0
 
 
-def test_request_garbage_collection_with_claim(token, config: Config):
-    request = make_request(token)
+def test_request_garbage_collection_with_claim(config: Config):
+    request = make_request()
     request.fill(config.account.address, b"", b"")
     request.withdraw()
 
@@ -178,8 +178,8 @@ def test_request_garbage_collection_with_claim(token, config: Config):
     assert len(context.claims) == 0
 
 
-def test_handle_initiate_l1_resolution(token: Contract, config: Config):
-    request = make_request(token)
+def test_handle_initiate_l1_resolution(config: Config):
+    request = make_request()
 
     context = make_context(config)
     context.requests.add(request.id, request)
@@ -207,7 +207,7 @@ def test_handle_initiate_l1_resolution(token: Contract, config: Config):
     assert context.resolution_pool.submit.called  # pylint:disable=no-member
 
 
-def test_handle_request_resolved(token: Contract, config: Config):
+def test_handle_request_resolved(config: Config):
     context = make_context(config)
     filler = make_address()
 
@@ -223,7 +223,7 @@ def test_handle_request_resolved(token: Contract, config: Config):
     assert process_event(event, context) == (False, None)
 
     # Must store the result in the request
-    request = make_request(token)
+    request = make_request()
     context.requests.add(request.id, request)
 
     assert request.l1_resolution_filler is None
@@ -231,10 +231,10 @@ def test_handle_request_resolved(token: Contract, config: Config):
     assert request.l1_resolution_filler == filler
 
 
-def test_handle_claim_made(token: Contract, config: Config):
+def test_handle_claim_made(config: Config):
     context = make_context(config)
 
-    request = make_request(token)
+    request = make_request()
     request.fill(config.account.address, b"", b"")
     context.requests.add(request.id, request)
 

--- a/beamer/tests/agent/test_handlers.py
+++ b/beamer/tests/agent/test_handlers.py
@@ -260,7 +260,7 @@ def test_handle_claim_made():
     claim = make_claim(request, claimer=config.account.address)
     context.claims.add(claim.id, claim)
 
-    event = deepcopy(claim._latest_claim_made)
+    event = deepcopy(claim.latest_claim_made)
     flag, events = process_event(event, context)
 
     assert flag

--- a/beamer/tests/agent/test_handlers.py
+++ b/beamer/tests/agent/test_handlers.py
@@ -117,6 +117,7 @@ def make_context() -> Tuple[Context, Config]:
         config=config,
         web3_l1=MagicMock(),
         resolution_pool=MagicMock(),
+        l1_resolutions={},
     )
 
     return context, config

--- a/beamer/tests/agent/test_handlers.py
+++ b/beamer/tests/agent/test_handlers.py
@@ -93,6 +93,7 @@ def make_context(config: Config, request_manager: Contract = None):
             )
         },
         config=config,
+        web3_l1=MagicMock(),
     )
 
 

--- a/beamer/tests/agent/test_handlers.py
+++ b/beamer/tests/agent/test_handlers.py
@@ -223,12 +223,13 @@ def test_handle_initiate_l1_resolution():
     # Check that task is added to resolution pool
     context.web3_l1.eth.gas_price = Wei(1)  # type: ignore
     request.fill(config.account.address, b"", b"")
+    request.try_to_claim()
     assert process_event(event, context) == (True, None)
     assert context.resolution_pool.submit.called  # type: ignore  # pylint:disable=no-member
 
 
 def test_handle_request_resolved():
-    context, _ = make_context()
+    context, config = make_context()
     filler = make_address()
 
     event = RequestResolved(
@@ -244,6 +245,8 @@ def test_handle_request_resolved():
 
     # Must store the result in the request
     request = make_request()
+    request.fill(config.account.address, b"", b"")
+    request.try_to_claim()
     context.requests.add(request.id, request)
 
     assert request.l1_resolution_filler is None

--- a/beamer/tests/agent/test_handlers.py
+++ b/beamer/tests/agent/test_handlers.py
@@ -94,6 +94,7 @@ def make_context(config: Config, request_manager: Contract = None):
         },
         config=config,
         web3_l1=MagicMock(),
+        resolution_pool=MagicMock(),
     )
 
 

--- a/beamer/tests/agent/utils.py
+++ b/beamer/tests/agent/utils.py
@@ -1,0 +1,13 @@
+import random
+import string
+
+from eth_typing import ChecksumAddress
+from eth_utils import to_checksum_address
+
+
+def make_bytes(length: int) -> bytes:
+    return bytes("".join(random.choice(string.printable) for _ in range(length)), encoding="utf-8")
+
+
+def make_address() -> ChecksumAddress:
+    return to_checksum_address(make_bytes(20))

--- a/beamer/tests/conftest.py
+++ b/beamer/tests/conftest.py
@@ -160,6 +160,7 @@ def config(request_manager, fill_manager, resolution_registry, token):
     token.mint(account.address, 300)
     url = brownie.web3.provider.endpoint_uri
     config = Config(
+        l1_rpc_url=url,
         l2a_rpc_url=url,
         l2b_rpc_url=url,
         deployment_info=deployment_info,

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -60,6 +60,7 @@ Start ``beamer-agent``::
 
     beamer-agent --keystore-file 0x1CEE82EEd89Bd5Be5bf2507a92a755dcF1D8e8dc.json \
                  --password '' \
+                 --l1-rpc-url http://localhost:8545 \
                  --l2a-rpc-url http://localhost:8545 \
                  --l2b-rpc-url http://localhost:8545 \
                  --deployment-dir deployments/ganache-local \
@@ -143,4 +144,3 @@ and `Graphviz <http://graphviz.org>`_ installed. Documentation can be built by r
    make docs
 
 and the resulting HTML will be available at ``docs/build/index.html``.
-

--- a/docs/source/request_state_machine.dot
+++ b/docs/source/request_state_machine.dot
@@ -1,11 +1,13 @@
 digraph request_state_machine {
-    node [] pending, filled, claimed, withdrawn, ignored;
+    node [] pending, filled, claimed, l1_resolved, withdrawn, ignored;
 
     pending -> filled [label = fill];
     pending -> filled [label = try_to_fill];
     pending -> ignored [label = ignore];
     filled -> claimed [label = try_to_claim];
     claimed -> withdrawn [label = withdraw];
+    claimed -> l1_resolved [label = resolve];
+    l1_resolved -> withdrawn [label = withdraw];
     filled -> withdrawn [label = withdraw];
     filled -> ignored [label = ignore];
     ignored -> withdrawn [label = withdraw];

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -11,6 +11,10 @@ an agent requires the following:
 
    .. :note: The same address is being used for both chains.
 
+ * URL of the L1 chain's RPC server.
+
+   Related options: ``--l1-rpc-url``
+
  * URL of the source L2 chain's RPC server.
 
    Related options: ``--l2a-rpc-url``
@@ -103,6 +107,7 @@ To run an agent container simply do::
 
     docker run ghcr.io/beamer-bridge/beamer-agent --keystore-file <keyfile> \
                                                   --password <keyfile-password> \
+                                                  --l1-rpc-url <l1-rpc-url> \
                                                   --l2a-rpc-url <source-l2-rpc-url> \
                                                   --l2b-rpc-url <target-l2-rpc-url> \
                                                   --deployment-dir <contract-deployment-dir> \
@@ -133,6 +138,7 @@ While still inside the virtual environment, run::
 
     beamer-agent --keystore-file <keyfile> \
                  --password <keyfile-password> \
+                 --l1-rpc-url <l1-rpc-url> \
                  --l2a-rpc-url <source-l2-rpc-url> \
                  --l2b-rpc-url <target-l2-rpc-url> \
                  --deployment-dir <contract-deployment-dir> \


### PR DESCRIPTION
Resolves #271 

The main work for initiating and handling L1 resolution. Some follow-ups will be needed one we have the new challenge and non-fill proofs integrated.

This is hopefully readable on a per-commit basis. Some important things that are added:
- Add the L1 RPC URL to the CLI and config
- Add the `InitiateL1ResolutionEvent`. It triggers a check if the L1 resolution is viable (financially) and triggers it in this case.
  - Important caveat: This currently only takes one claim into account. Do we want to fix this?
- Resolution is triggered by adding a new task to the `resolution_pool`. This is a `ThreadPoolExecutor` with one worker, which takes care of serializing multiple parallel resolutions.
- The `RequestResolved` event is handled in the state machine and writes the correct filler into the `Request` object.
