### PR TITLE
dependencies: Bump typescript to 4.5.5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,7 +49,7 @@
     "prettier": "^2.6.0",
     "sass": "^1.49.9",
     "ts-node": "^10.7.0",
-    "typescript": "~4.1.5",
+    "typescript": "~4.5.5",
     "vite": "^2.9.0",
     "vitest": "^0.9.3"
   },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3270,10 +3270,10 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
-typescript@~4.1.5:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
-  integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
+typescript@~4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
The dependabot PR for updating typescript got closed, because I think it is necessary to manually check typescript updates. I did so now and the version proposed by dependabot was indeed not compatible with our linting. So I updated to the newest version for which I could verify its compatibility. 