### PR TITLE
brownie-config.yaml: remove the explicit chain ID setting

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -14,8 +14,3 @@ compiler:
     version: 0.8.13
 
 dev_deployment_artifacts: true
-
-networks:
-  development:
-    cmd_settings:
-      chain_id: 1337


### PR DESCRIPTION
This should not be needed anymore with new ganache.
See 07bb2c6f1c5b42c7c1fe6b62b39280eb7a883d4e more details.