### PR TITLE
frontend: Improve types of the properties of Transfer

### DIFF
--- a/frontend/src/components/RequestDialog.vue
+++ b/frontend/src/components/RequestDialog.vue
@@ -53,7 +53,6 @@ import { useTransfer } from '@/composables/useTransfer';
 import { useConfiguration } from '@/stores/configuration';
 import { useEthereumProvider } from '@/stores/ethereum-provider';
 import type { RequestFormResult } from '@/types/form';
-import { UInt256 } from '@/types/uint-256';
 
 const configuration = useConfiguration();
 const ethereumProvider = useEthereumProvider();
@@ -65,7 +64,7 @@ const requestManagerAddress = computed(
   () => configuration.chains[chainId.value]?.requestManagerAddress,
 );
 
-const { amount: requestFeeAmount } = useRequestFee(provider, requestManagerAddress);
+const { amount: fees } = useRequestFee(provider, requestManagerAddress);
 
 const submitForm = () => {
   requestForm.value?.node.submit();
@@ -77,11 +76,13 @@ const submitRequestTransaction = async (formResult: RequestFormResult) => {
   if (!provider.value || !signer.value) {
     throw new Error('No signer available!');
   }
-
-  // TODO: Resolve by make useRequestFee using an UInt256.
-  const fees = new UInt256(requestFeeAmount.value.toString());
-
-  await runTransfer(formResult, signer.value, signerAddress.value, fees, configuration.chains);
+  await runTransfer(
+    formResult,
+    signer.value,
+    signerAddress.value,
+    fees.value,
+    configuration.chains,
+  );
 };
 
 watch(chainId, (_, oldChainId) => {

--- a/frontend/src/components/TransferStatus.vue
+++ b/frontend/src/components/TransferStatus.vue
@@ -29,8 +29,8 @@ const summary = computed(() => {
   const { transfer } = props;
 
   return {
-    amount: transfer.amount.decimalAmount,
-    tokenSymbol: transfer.sourceToken.symbol,
+    amount: transfer.sourceAmount.decimalAmount,
+    tokenSymbol: transfer.sourceAmount.token.symbol,
     sourceChainName: transfer.sourceChain.name,
     targetChainName: transfer.targetChain.name,
     targetAccount: transfer.targetAccount,

--- a/frontend/src/composables/useRequestFee.ts
+++ b/frontend/src/composables/useRequestFee.ts
@@ -1,25 +1,25 @@
-import { ethers } from 'ethers';
 import type { Ref } from 'vue';
 import { computed, ref, watch } from 'vue';
 
 import { getRequestFee } from '@/services/transactions/request-manager';
 import type { EthereumProvider } from '@/services/web3-provider';
+import { EthereumAmount } from '@/types/token-amount';
 
 export function useRequestFee(
   provider: Ref<EthereumProvider | undefined>,
   requestManagerAddress: Ref<string | undefined>,
 ) {
   const error = ref<string | undefined>(undefined);
-  const amount = ref<number>(0);
+  const amount = ref<EthereumAmount>(new EthereumAmount('0'));
 
   const show = computed(() => !!provider.value && !!requestManagerAddress);
-  const formattedAmount = computed(() => ethers.utils.formatEther(amount.value));
+  const formattedAmount = computed(() => amount.value.formattedAmount);
 
   const updateRequestFeeAmount = async () => {
     error.value = '';
 
     if (!provider.value || !requestManagerAddress.value) {
-      amount.value = 0;
+      amount.value = new EthereumAmount('0');
       return;
     }
 

--- a/frontend/src/composables/useTransfer.ts
+++ b/frontend/src/composables/useTransfer.ts
@@ -5,7 +5,7 @@ import { Transfer } from '@/actions/transfers';
 import type { ChainConfigMapping, ChainWithTokens } from '@/types/config';
 import type { Chain, Token } from '@/types/data';
 import type { RequestFormResult } from '@/types/form';
-import { TokenAmount } from '@/types/token-amount';
+import { EthereumAmount, TokenAmount } from '@/types/token-amount';
 import { UInt256 } from '@/types/uint-256';
 
 export function useTransfer() {
@@ -23,7 +23,7 @@ export function useTransfer() {
     formResult: RequestFormResult,
     signer: JsonRpcSigner,
     signerAddress: string,
-    fees: UInt256,
+    fees: EthereumAmount,
     chains: ChainConfigMapping,
   ) => {
     const sourceConfiguration = chains[formResult.sourceChainId.value];
@@ -33,6 +33,7 @@ export function useTransfer() {
       sourceConfiguration,
       formResult.tokenAddress.label,
     )!;
+    const sourceAmount = TokenAmount.parse(formResult.amount, sourceToken);
 
     const targetConfiguration = chains[formResult.targetChainId.value];
     const targetChain = parseChainFromConfiguration(targetConfiguration);
@@ -41,16 +42,15 @@ export function useTransfer() {
       targetConfiguration,
       formResult.tokenAddress.label,
     )!;
+    const targetAmount = TokenAmount.parse(formResult.amount, targetToken);
 
-    const amount = TokenAmount.parse(formResult.amount, sourceToken);
     const validityPeriod = new UInt256('600');
 
     transfer.value = Transfer.new(
-      amount,
       sourceChain,
-      sourceToken,
+      sourceAmount,
       targetChain,
-      targetToken,
+      targetAmount,
       formResult.toAddress,
       validityPeriod,
       fees,

--- a/frontend/src/services/transactions/request-manager.ts
+++ b/frontend/src/services/transactions/request-manager.ts
@@ -3,20 +3,22 @@ import type {
   JsonRpcSigner,
   TransactionResponse,
 } from '@ethersproject/providers';
-import { BigNumber, Contract } from 'ethers';
+import { BigNumber, BigNumberish, Contract } from 'ethers';
 
 import RequestManager from '@/assets/RequestManager.json';
 import type { EthereumProvider } from '@/services/web3-provider';
 import type { EthereumAddress } from '@/types/data';
+import { EthereumAmount } from '@/types/token-amount';
 import { UInt256 } from '@/types/uint-256';
 
 export async function getRequestFee(
   provider: EthereumProvider,
   requestManagerAddress: string,
-): Promise<number> {
+): Promise<EthereumAmount> {
   const requestManagerContract = new Contract(requestManagerAddress, RequestManager.abi);
   const connectedContract = provider.connectContract(requestManagerContract);
-  return await connectedContract.totalFee();
+  const fetchedAmount: BigNumberish = await connectedContract.totalFee();
+  return new EthereumAmount(fetchedAmount.toString());
 }
 
 export async function sendRequestTransaction(

--- a/frontend/src/types/data.ts
+++ b/frontend/src/types/data.ts
@@ -16,3 +16,9 @@ export type Token = {
   symbol: string;
   decimals: number;
 };
+
+export const ETH: Token = {
+  address: '',
+  symbol: 'ETH',
+  decimals: 18,
+};

--- a/frontend/src/types/token-amount.ts
+++ b/frontend/src/types/token-amount.ts
@@ -1,10 +1,10 @@
-import type { Token } from '@/types/data';
+import { ETH, Token } from '@/types/data';
 import type { Encodable } from '@/types/encoding';
 import type { UInt256Data } from '@/types/uint-256';
 import { UInt256 } from '@/types/uint-256';
 
 export class TokenAmount implements Encodable<TokenAmountData> {
-  private token: Token;
+  readonly token: Token;
   private amount: UInt256;
 
   constructor(data: TokenAmountData) {
@@ -41,3 +41,13 @@ export type TokenAmountData = {
   token: Token;
   amount: UInt256Data;
 };
+
+export class EthereumAmount extends TokenAmount {
+  constructor(amount: UInt256Data) {
+    super({ token: ETH, amount });
+  }
+
+  static parse(value: string) {
+    return TokenAmount.parse(value, ETH);
+  }
+}

--- a/frontend/tests/unit/actions/transfers/transfer.spec.ts
+++ b/frontend/tests/unit/actions/transfers/transfer.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
 
-import { Transfer } from '@/actions/transfers/transfer';
+import { Transfer, TransferData } from '@/actions/transfers/transfer';
 import * as fillManager from '@/services/transactions/fill-manager';
 import * as requestManager from '@/services/transactions/request-manager';
 import type { EthereumAddress } from '@/types/data';
@@ -76,14 +76,19 @@ describe('transfer', () => {
   describe('sendRequestTransaction()', () => {
     it('calls the transfer function on the request manager contract', async () => {
       const data = generateTransferData({
-        amount: generateTokenAmountData({ amount: '1' }),
         sourceChain: generateChain({ requestManagerAddress: '0xRequestManager' }),
-        sourceToken: generateToken({ address: '0xSourceToken' }),
+        sourceAmount: generateTokenAmountData({
+          token: generateToken({ address: '0xSourceToken' }),
+          amount: '1',
+        }),
         targetChain: generateChain({ identifier: 2 }),
-        targetToken: generateToken({ address: '0xTargetToken' }),
+        targetAmount: generateTokenAmountData({
+          token: generateToken({ address: '0xTargetToken' }),
+          amount: '1',
+        }),
         targetAccount: '0xTargetAccount',
         validityPeriod: generateUInt256Data('3'),
-        fees: generateUInt256Data('4'),
+        fees: generateTokenAmountData({ amount: '4' }),
       });
       const transfer = new TestTransfer(data);
       const signer = new JsonRpcSigner(undefined, new JsonRpcProvider());
@@ -214,23 +219,21 @@ describe('transfer', () => {
 
   describe('encode()', () => {
     it('serializes all data to persist the whole transfer', () => {
-      const amount = generateTokenAmountData();
       const sourceChain = generateChain();
-      const sourceToken = generateToken();
+      const sourceAmount = generateTokenAmountData();
       const targetChain = generateChain();
-      const targetToken = generateToken();
+      const targetAmount = generateTokenAmountData();
       const targetAccount = getRandomEthereumAddress();
       const validityPeriod = generateUInt256Data();
-      const fees = generateUInt256Data();
+      const fees = generateTokenAmountData();
       const requestInformation = generateRequestInformationData();
       const fulfillmentInformation = generateFulfillmentInformation();
       const steps = [generateStepData()];
-      const data = {
-        amount,
+      const data: TransferData = {
         sourceChain,
-        sourceToken,
+        sourceAmount,
         targetChain,
-        targetToken,
+        targetAmount,
         targetAccount,
         validityPeriod,
         fees,
@@ -242,11 +245,10 @@ describe('transfer', () => {
 
       const encodedData = transfer.encode();
 
-      expect(encodedData.amount).toMatchObject(amount);
       expect(encodedData.sourceChain).toMatchObject(sourceChain);
-      expect(encodedData.sourceToken).toMatchObject(sourceToken);
+      expect(encodedData.sourceAmount).toMatchObject(sourceAmount);
       expect(encodedData.targetChain).toMatchObject(targetChain);
-      expect(encodedData.targetToken).toMatchObject(targetToken);
+      expect(encodedData.targetAmount).toMatchObject(targetAmount);
       expect(encodedData.targetAccount).toMatchObject(targetAccount);
       expect(encodedData.validityPeriod).toMatchObject(validityPeriod);
       expect(encodedData.fees).toMatchObject(fees);

--- a/frontend/tests/unit/components/TransferStatus.spec.ts
+++ b/frontend/tests/unit/components/TransferStatus.spec.ts
@@ -30,11 +30,10 @@ function createWrapper(options?: { transfer?: Transfer }) {
 describe('TransferStatus.vue', () => {
   it('shows transfer summary with correct data', () => {
     const data = generateTransferData({
-      amount: generateTokenAmountData({
+      sourceAmount: generateTokenAmountData({
         amount: '1',
-        token: generateToken({ decimals: 0 }),
+        token: generateToken({ symbol: 'TTT', decimals: 0 }),
       }),
-      sourceToken: generateToken({ symbol: 'TTT' }),
       sourceChain: generateChain({ name: 'Source Chain' }),
       targetChain: generateChain({ name: 'Target Chain' }),
       targetAccount: '0xTargetAccount',

--- a/frontend/tests/unit/types/token-amount.spec.ts
+++ b/frontend/tests/unit/types/token-amount.spec.ts
@@ -1,4 +1,4 @@
-import { TokenAmount } from '@/types/token-amount';
+import { EthereumAmount, TokenAmount } from '@/types/token-amount';
 import {
   generateToken,
   generateTokenAmountData,
@@ -70,6 +70,17 @@ describe('TokenAmount', () => {
       const newEncodedData = newTokenAmount.encode();
 
       expect(encodedData).toMatchObject(newEncodedData);
+    });
+  });
+});
+
+describe('EthereumAmount', () => {
+  describe('parse()', () => {
+    it('can parse integer based on 18 decimals', () => {
+      const amount = EthereumAmount.parse('0.123456789123456789');
+
+      expect(amount.decimalAmount).toBe('0.123456789123456789');
+      expect(amount.uint256.asString).toBe('123456789123456789');
     });
   });
 });

--- a/frontend/tests/utils/data_generators.ts
+++ b/frontend/tests/utils/data_generators.ts
@@ -128,16 +128,14 @@ export function generateFulfillmentInformation(
 }
 
 export function generateTransferData(partialTransferData?: Partial<TransferData>): TransferData {
-  const sourceToken = generateToken();
   return {
-    amount: generateTokenAmountData({ token: sourceToken }),
     sourceChain: generateChain(),
-    sourceToken,
+    sourceAmount: generateTokenAmountData(),
     targetChain: generateChain(),
-    targetToken: generateToken(),
+    targetAmount: generateTokenAmountData(),
     targetAccount: getRandomEthereumAddress(),
     validityPeriod: generateUInt256Data(),
-    fees: generateUInt256Data(),
+    fees: generateTokenAmountData(),
     ...partialTransferData,
   };
 }


### PR DESCRIPTION
This adds a sourceAmount and targetAmount (type: TokenAmount) to Transfer and removes the sourceToken, the targetToken and the amount.

The tokens can now be accessed from the amounts. This also enables later having a different target amount from the source one.
Also it makes the fees a TokenAmount because the fee model changes and we do not want to break backwards compatibility with encoding in the local storage.

For convenience an EthereumAmount class is created which inherits from the TokenAmount and sets the right symbol when created.  This type is also now used in the useRequestFee composable. Later, the composable will need to be adapted to the new fee model and use a TokenAmount.