### PR TITLE
frontend: enforce type imports

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
     'simple-import-sort/imports': 'warn',
     'simple-import-sort/exports': 'warn',
     'vue/multi-word-component-names': 'off',
+    '@typescript-eslint/consistent-type-imports': 'warn',
   },
   globals: {
     defineProps: 'readonly',

--- a/frontend/src/actions/transfers/transfer.ts
+++ b/frontend/src/actions/transfers/transfer.ts
@@ -1,7 +1,8 @@
 import type { JsonRpcSigner } from '@ethersproject/providers';
 import { JsonRpcProvider } from '@ethersproject/providers';
 
-import { MultiStepAction, Step, StepData } from '@/actions/steps';
+import type { StepData } from '@/actions/steps';
+import { MultiStepAction, Step } from '@/actions/steps';
 import { waitForFulfillment } from '@/services/transactions/fill-manager';
 import {
   getRequestIdentifier,

--- a/frontend/src/components/RequestDialog.vue
+++ b/frontend/src/components/RequestDialog.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script setup lang="ts">
-import { FormKitFrameworkContext } from '@formkit/core';
+import type { FormKitFrameworkContext } from '@formkit/core';
 import { FormKit } from '@formkit/vue';
 import { storeToRefs } from 'pinia';
 import { computed, reactive, ref, watch } from 'vue';

--- a/frontend/src/components/inputs/Selector.vue
+++ b/frontend/src/components/inputs/Selector.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-import { FormKitFrameworkContext } from '@formkit/core';
+import type { FormKitFrameworkContext } from '@formkit/core';
 import vSelect from 'vue-select';
 
 import type { SelectorOption } from '@/types/form';

--- a/frontend/src/composables/useChainSelection.ts
+++ b/frontend/src/composables/useChainSelection.ts
@@ -1,8 +1,9 @@
-import { computed, Ref, ref } from 'vue';
+import type { Ref } from 'vue';
+import { computed, ref } from 'vue';
 
 import type { EthereumProvider } from '@/services/web3-provider';
-import { ChainConfigMapping } from '@/types/config';
-import { SelectorOption } from '@/types/form';
+import type { ChainConfigMapping } from '@/types/config';
+import type { SelectorOption } from '@/types/form';
 
 export function useChainSelection(
   provider: Ref<EthereumProvider | undefined>,

--- a/frontend/src/composables/useFaucet.ts
+++ b/frontend/src/composables/useFaucet.ts
@@ -1,5 +1,6 @@
-import { JsonRpcSigner } from '@ethersproject/providers';
-import { computed, reactive, Ref } from 'vue';
+import type { JsonRpcSigner } from '@ethersproject/providers';
+import type { Ref } from 'vue';
+import { computed, reactive } from 'vue';
 
 import { requestFaucet } from '@/services/transactions/faucet';
 import createAsyncProcess from '@/utils/create-async-process';

--- a/frontend/src/composables/useLoadConfiguration.ts
+++ b/frontend/src/composables/useLoadConfiguration.ts
@@ -1,6 +1,6 @@
 import { onMounted, ref } from 'vue';
 
-import { BeamerConfig, ChainConfig } from '@/types/config';
+import type { BeamerConfig, ChainConfig } from '@/types/config';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default function useLoadConfiguration(

--- a/frontend/src/composables/useTokenSelection.ts
+++ b/frontend/src/composables/useTokenSelection.ts
@@ -1,9 +1,10 @@
-import { computed, Ref, ref } from 'vue';
+import type { Ref } from 'vue';
+import { computed, ref } from 'vue';
 
 import { getTokenDecimals } from '@/services/transactions/token';
 import type { EthereumProvider } from '@/services/web3-provider';
-import { ChainConfigMapping, Token } from '@/types/config';
-import { SelectorOption } from '@/types/form';
+import type { ChainConfigMapping, Token } from '@/types/config';
+import type { SelectorOption } from '@/types/form';
 
 export function useTokenSelection(
   provider: Ref<EthereumProvider | undefined>,

--- a/frontend/src/composables/useWallet.ts
+++ b/frontend/src/composables/useWallet.ts
@@ -1,4 +1,4 @@
-import { Ref } from 'vue';
+import type { Ref } from 'vue';
 
 import type { EthereumProvider } from '@/services/web3-provider';
 import { createMetaMaskProvider, createWalletConnectProvider } from '@/services/web3-provider';

--- a/frontend/src/formkitTheme.ts
+++ b/frontend/src/formkitTheme.ts
@@ -1,4 +1,4 @@
-import { FormKitNode } from '@formkit/core';
+import type { FormKitNode } from '@formkit/core';
 
 function rootClasses(sectionKey: string, node: FormKitNode): Record<string, boolean> {
   const type = node.props.type;

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,4 +1,5 @@
-import { createRouter, createWebHashHistory, RouteRecordRaw } from 'vue-router';
+import type { RouteRecordRaw } from 'vue-router';
+import { createRouter, createWebHashHistory } from 'vue-router';
 
 import Home from '../views/Home.vue';
 

--- a/frontend/src/services/transactions/fill-manager.ts
+++ b/frontend/src/services/transactions/fill-manager.ts
@@ -1,4 +1,4 @@
-import { JsonRpcProvider } from '@ethersproject/providers';
+import type { JsonRpcProvider } from '@ethersproject/providers';
 import { BigNumber, Contract } from 'ethers';
 
 import FillManager from '@/assets/FillManager.json';

--- a/frontend/src/services/transactions/request-manager.ts
+++ b/frontend/src/services/transactions/request-manager.ts
@@ -3,7 +3,8 @@ import type {
   JsonRpcSigner,
   TransactionResponse,
 } from '@ethersproject/providers';
-import { BigNumber, BigNumberish, Contract } from 'ethers';
+import type { BigNumberish } from 'ethers';
+import { BigNumber, Contract } from 'ethers';
 
 import RequestManager from '@/assets/RequestManager.json';
 import type { EthereumProvider } from '@/services/web3-provider';

--- a/frontend/src/services/transactions/token.ts
+++ b/frontend/src/services/transactions/token.ts
@@ -1,5 +1,6 @@
 import type { JsonRpcSigner } from '@ethersproject/providers';
-import { BigNumber, Contract } from 'ethers';
+import type { BigNumber } from 'ethers';
+import { Contract } from 'ethers';
 
 import StandardToken from '@/assets/StandardToken.json';
 import type { EthereumProvider } from '@/services/web3-provider';

--- a/frontend/src/services/web3-provider/ethereum-provider.ts
+++ b/frontend/src/services/web3-provider/ethereum-provider.ts
@@ -1,9 +1,12 @@
-import { Block, getNetwork, JsonRpcSigner, Web3Provider } from '@ethersproject/providers';
-import { BigNumber, Contract } from 'ethers';
+import type { Block, JsonRpcSigner } from '@ethersproject/providers';
+import { getNetwork, Web3Provider } from '@ethersproject/providers';
+import type { Contract } from 'ethers';
+import { BigNumber } from 'ethers';
 import { hexValue } from 'ethers/lib/utils';
-import { Ref, ref, ShallowRef, shallowRef } from 'vue';
+import type { Ref, ShallowRef } from 'vue';
+import { ref, shallowRef } from 'vue';
 
-import { ChainData, Eip1193Provider, IEthereumProvider, TokenData } from './types';
+import type { ChainData, Eip1193Provider, IEthereumProvider, TokenData } from './types';
 
 export abstract class EthereumProvider implements IEthereumProvider {
   signer: ShallowRef<JsonRpcSigner | undefined> = shallowRef(undefined);

--- a/frontend/src/services/web3-provider/metamask-provider.ts
+++ b/frontend/src/services/web3-provider/metamask-provider.ts
@@ -1,8 +1,9 @@
-import { ExternalProvider } from '@ethersproject/providers';
+import type { ExternalProvider } from '@ethersproject/providers';
 import detectEthereumProvider from '@metamask/detect-provider';
 import { hexValue } from 'ethers/lib/utils';
 
-import { Eip1193Provider, EthereumProvider, ISigner } from '@/services/web3-provider';
+import type { Eip1193Provider, ISigner } from '@/services/web3-provider';
+import { EthereumProvider } from '@/services/web3-provider';
 
 export async function createMetaMaskProvider(): Promise<MetaMaskProvider | undefined> {
   const detectedProvider = (await detectEthereumProvider()) as ExternalProvider | undefined;

--- a/frontend/src/services/web3-provider/types.ts
+++ b/frontend/src/services/web3-provider/types.ts
@@ -1,6 +1,6 @@
-import { Block, ExternalProvider, JsonRpcSigner } from '@ethersproject/providers';
-import { Contract } from 'ethers';
-import { Ref, ShallowRef } from 'vue';
+import type { Block, ExternalProvider, JsonRpcSigner } from '@ethersproject/providers';
+import type { Contract } from 'ethers';
+import type { Ref, ShallowRef } from 'vue';
 
 export interface IEthereumProvider {
   signer: ShallowRef<JsonRpcSigner | undefined>;

--- a/frontend/src/services/web3-provider/walletconnect-provider.ts
+++ b/frontend/src/services/web3-provider/walletconnect-provider.ts
@@ -1,7 +1,8 @@
 import WalletConnect from '@walletconnect/web3-provider/dist/umd/index.min.js';
 import { hexValue } from 'ethers/lib/utils';
 
-import { Eip1193Provider, EthereumProvider } from '@/services/web3-provider';
+import type { Eip1193Provider } from '@/services/web3-provider';
+import { EthereumProvider } from '@/services/web3-provider';
 
 export async function createWalletConnectProvider(rpcList: {
   [chainId: string]: string;

--- a/frontend/src/stores/configuration.ts
+++ b/frontend/src/stores/configuration.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 
-import { BeamerConfig, ChainWithTokens } from '@/types/config';
+import type { BeamerConfig, ChainWithTokens } from '@/types/config';
 
 export const useConfiguration = defineStore('configuration', {
   state: (): BeamerConfig => ({

--- a/frontend/src/stores/ethereum-provider.ts
+++ b/frontend/src/stores/ethereum-provider.ts
@@ -1,8 +1,8 @@
-import { JsonRpcSigner } from '@ethersproject/providers';
+import type { JsonRpcSigner } from '@ethersproject/providers';
 import { defineStore } from 'pinia';
 import { shallowRef } from 'vue';
 
-import { EthereumProvider } from '@/services/web3-provider';
+import type { EthereumProvider } from '@/services/web3-provider';
 
 export const useEthereumProvider = defineStore('ethereumProvider', {
   state: () => ({

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 
-import { WalletType } from '@/types/settings';
+import type { WalletType } from '@/types/settings';
 
 export const useSettings = defineStore('settings', {
   state: () => ({

--- a/frontend/src/stores/transfer-history/store.ts
+++ b/frontend/src/stores/transfer-history/store.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 
-import { Transfer } from '@/actions/transfers';
+import type { Transfer } from '@/actions/transfers';
 
 import { transferHistorySerializer } from './serializer';
 import type { TransferHistoryState } from './types';

--- a/frontend/src/types/token-amount.ts
+++ b/frontend/src/types/token-amount.ts
@@ -1,4 +1,5 @@
-import { ETH, Token } from '@/types/data';
+import type { Token } from '@/types/data';
+import { ETH } from '@/types/data';
 import type { Encodable } from '@/types/encoding';
 import type { UInt256Data } from '@/types/uint-256';
 import { UInt256 } from '@/types/uint-256';

--- a/frontend/src/utils/create-async-process.ts
+++ b/frontend/src/utils/create-async-process.ts
@@ -1,4 +1,5 @@
-import { Ref, ref } from 'vue';
+import type { Ref } from 'vue';
+import { ref } from 'vue';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 interface CreateAsyncProcessReturn<T extends (...args: any[]) => any> {

--- a/frontend/tests/unit/actions/transfers/transfer.spec.ts
+++ b/frontend/tests/unit/actions/transfers/transfer.spec.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
 
-import { Transfer, TransferData } from '@/actions/transfers/transfer';
+import type { TransferData } from '@/actions/transfers/transfer';
+import { Transfer } from '@/actions/transfers/transfer';
 import * as fillManager from '@/services/transactions/fill-manager';
 import * as requestManager from '@/services/transactions/request-manager';
 import type { EthereumAddress } from '@/types/data';

--- a/frontend/tests/utils/mocks/ethereum-provider.ts
+++ b/frontend/tests/utils/mocks/ethereum-provider.ts
@@ -1,8 +1,8 @@
-import { JsonRpcSigner } from '@ethersproject/providers';
+import type { JsonRpcSigner } from '@ethersproject/providers';
 import type { Ref, ShallowRef } from 'vue';
 import { ref, shallowRef } from 'vue';
 
-import { IEthereumProvider, ISigner } from '@/services/web3-provider';
+import type { IEthereumProvider, ISigner } from '@/services/web3-provider';
 
 export abstract class MockedEthereumProvider implements IEthereumProvider {
   readonly signer: ShallowRef<JsonRpcSigner | undefined>;

--- a/relayer/.eslintrc.js
+++ b/relayer/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     semi: [
       "error",
       "always"
-    ]
+    ],
+    "@typescript-eslint/consistent-type-imports": "warn",
   }
 };

--- a/relayer/src/service.ts
+++ b/relayer/src/service.ts
@@ -1,7 +1,7 @@
-import { Signer } from "ethers";
+import type { Signer } from "ethers";
 import { BaseServiceV2, validators } from "@eth-optimism/common-ts";
 import { CrossChainMessenger, MessageStatus } from "@eth-optimism/sdk";
-import { Provider } from "@ethersproject/abstract-provider";
+import type { Provider } from "@ethersproject/abstract-provider";
 
 type MessageRelayerOptions = {
   l1RpcProvider: Provider


### PR DESCRIPTION
Since TypeScript 3.8 it is a good practice to use type imports (`import type ...`) where possible. Type imports allow for certain compiler and tooling optimizations.

This rule is auto-fixable. So it doesn't add extra work to the developers. Except the ESLint rule adaption, all changes in this commit are caused by automated fixes.

Note that this got applied to the `relayer` too.