### PR TITLE
Remove request ID in L1 contract events

### DIFF
--- a/beamer/events.py
+++ b/beamer/events.py
@@ -98,14 +98,12 @@ class ClaimWithdrawn(ClaimEvent):
 
 @dataclass(frozen=True)
 class RequestResolved(TxEvent):
-    request_id: RequestId
     fill_hash: FillHash
     filler: ChecksumAddress
 
 
 @dataclass(frozen=True)
 class FillHashInvalidated(TxEvent):
-    request_id: RequestId
     fill_hash: FillHash
 
 

--- a/beamer/models/claim.py
+++ b/beamer/models/claim.py
@@ -6,7 +6,7 @@ from web3.types import Wei
 
 from beamer.events import ClaimMade
 from beamer.models.request import Request
-from beamer.typing import ClaimId, RequestId, Termination
+from beamer.typing import ClaimId, FillId, RequestId, Termination
 
 
 class Claim(StateMachine):
@@ -68,6 +68,10 @@ class Claim(StateMachine):
     @property
     def termination(self) -> Termination:
         return self._latest_claim_made.termination
+
+    @property
+    def fill_id(self) -> FillId:
+        return self._latest_claim_made.fill_id
 
     @property
     def latest_claim_made(self) -> ClaimMade:

--- a/beamer/tests/agent/unit/test_handlers.py
+++ b/beamer/tests/agent/unit/test_handlers.py
@@ -135,7 +135,6 @@ def test_handle_request_resolved():
     event = RequestResolved(
         chain_id=TARGET_CHAIN_ID,
         tx_hash=HexBytes(""),
-        request_id=REQUEST_ID,
         fill_hash=FillHash(b""),
         filler=filler,
     )

--- a/beamer/tests/agent/unit/test_invalidate.py
+++ b/beamer/tests/agent/unit/test_invalidate.py
@@ -35,7 +35,6 @@ def test_handle_fill_hash_invalidated():
     event = FillHashInvalidated(
         chain_id=request.target_chain_id,
         tx_hash=HexBytes(""),
-        request_id=request.id,
         fill_hash=fill_hash,
     )
     assert process_event(event, context) == (True, None)

--- a/beamer/tests/contracts/test_fill_manager.py
+++ b/beamer/tests/contracts/test_fill_manager.py
@@ -78,16 +78,15 @@ def test_invalidate_valid_fill_hash(fill_manager, token, deployer):
         amount,
     )
     with brownie.reverts("Fill hash valid"):
-        fill_manager.invalidateFillHash(request_id, request_hash, fill_id, chain_id)
+        fill_manager.invalidateFillHash(request_hash, fill_id, chain_id)
 
 
 def test_invalidated_fill_hash_event(fill_manager):
-    request_id = 123
     request_hash = "1234" + "00" * 30
     fill_id = "5678" + "00" * 30
     chain_id = brownie.web3.eth.chain_id
 
-    tx = fill_manager.invalidateFillHash(request_id, request_hash, fill_id, chain_id)
+    tx = fill_manager.invalidateFillHash(request_hash, fill_id, chain_id)
 
     fill_hash = keccak(
         encode_abi_packed(

--- a/beamer/tests/contracts/test_l1_resolution.py
+++ b/beamer/tests/contracts/test_l1_resolution.py
@@ -51,12 +51,11 @@ def test_l1_resolution_correct_hash(
 
 @pytest.mark.parametrize("forward_state", [True])
 def test_l1_non_fill_proof(fill_manager, resolution_registry):
-    request_id = 123
     request_hash = "1234" + "00" * 30
     fill_id = "5678" + "00" * 30
     chain_id = brownie.web3.eth.chain_id
 
-    fill_manager.invalidateFillHash(request_id, request_hash, fill_id, chain_id)
+    fill_manager.invalidateFillHash(request_hash, fill_id, chain_id)
 
     fill_hash = keccak(
         encode_abi_packed(
@@ -74,27 +73,22 @@ def test_l1_non_fill_proof(fill_manager, resolution_registry):
 def test_restricted_calls(contracts, resolver):
     """Test that important contract calls cannot be invoked by a random caller."""
     (caller,) = alloc_accounts(1)
-    req_id = 123
 
     # fill_manager -> proof_submitter -> messenger1 -> L1 resolver ->
     # messenger2 -> resolution registry
     with brownie.reverts("RestrictedCalls: unknown caller"):
         contracts.proof_submitter.submitProof(
-            resolver, brownie.chain.id, req_id, 0, caller, {"from": caller}
+            resolver, brownie.chain.id, 0, caller, {"from": caller}
         )
 
     with brownie.reverts("XRestrictedCalls: unknown caller"):
-        contracts.resolver.resolve(
-            req_id, 0, brownie.chain.id, brownie.chain.id, caller, {"from": caller}
-        )
+        contracts.resolver.resolve(0, brownie.chain.id, brownie.chain.id, caller, {"from": caller})
 
     with brownie.reverts("XRestrictedCalls: unknown caller"):
-        contracts.resolver.resolveNonFill(
-            req_id, 0, brownie.chain.id, brownie.chain.id, {"from": caller}
-        )
+        contracts.resolver.resolveNonFill(0, brownie.chain.id, brownie.chain.id, {"from": caller})
 
     with brownie.reverts("XRestrictedCalls: unknown caller"):
-        contracts.resolution_registry.resolveRequest(req_id, 0, 0, caller, {"from": caller})
+        contracts.resolution_registry.resolveRequest(0, 0, caller, {"from": caller})
 
     with brownie.reverts("XRestrictedCalls: unknown caller"):
-        contracts.resolution_registry.invalidateFillHash(req_id, 0, 0, {"from": caller})
+        contracts.resolution_registry.invalidateFillHash(0, 0, {"from": caller})

--- a/beamer/tests/contracts/test_request_manager.py
+++ b/beamer/tests/contracts/test_request_manager.py
@@ -744,15 +744,13 @@ def test_withdraw_without_challenge_with_resolution(
     contracts.messenger2.setLastSender(contracts.resolver.address)
 
     if invalidate:
-        resolution_registry.invalidateFillHash(
-            request_id, fill_hash, chain.id, {"from": contracts.messenger2}
-        )
+        resolution_registry.invalidateFillHash(fill_hash, chain.id, {"from": contracts.messenger2})
     # Assert that invalidation works
     assert resolution_registry.invalidFillHashes(fill_hash) == invalidate
 
     # Register a L1 resolution
     resolution_registry.resolveRequest(
-        request_id, fill_hash, web3.eth.chain_id, l1_filler, {"from": contracts.messenger2}
+        fill_hash, web3.eth.chain_id, l1_filler, {"from": contracts.messenger2}
     )
 
     # Assert that correct filler is resolved, it reverts the false invalidation

--- a/beamer/tests/contracts/test_resolution_registry.py
+++ b/beamer/tests/contracts/test_resolution_registry.py
@@ -26,16 +26,14 @@ def test_invalidation_before_and_after_resolution(contracts, token, resolution_r
     )
 
     assert not resolution_registry.invalidFillHashes(fill_hash)
-    resolution_registry.invalidateFillHash(
-        request_id, fill_hash, chain_id, {"from": contracts.messenger2}
-    )
+    resolution_registry.invalidateFillHash(fill_hash, chain_id, {"from": contracts.messenger2})
     # Fill hash must be invalidated
     assert resolution_registry.invalidFillHashes(fill_hash)
 
     assert resolution_registry.fillers(fill_hash) == ADDRESS_ZERO
 
     resolution_registry.resolveRequest(
-        1, fill_hash, chain_id, address, {"from": contracts.messenger2}
+        fill_hash, chain_id, address, {"from": contracts.messenger2}
     )
 
     # Resolution validates fill hash again
@@ -44,6 +42,4 @@ def test_invalidation_before_and_after_resolution(contracts, token, resolution_r
 
     # Invalidation of a resolved request should fail
     with brownie.reverts("Cannot invalidate resolved fillHashes"):
-        resolution_registry.invalidateFillHash(
-            request_id, fill_hash, chain_id, {"from": contracts.messenger2}
-        )
+        resolution_registry.invalidateFillHash(fill_hash, chain_id, {"from": contracts.messenger2})

--- a/contracts/contracts/FillManager.sol
+++ b/contracts/contracts/FillManager.sol
@@ -64,13 +64,7 @@ contract FillManager is Ownable {
         token.safeTransferFrom(msg.sender, targetReceiverAddress, amount);
 
         IProofSubmitter.ProofReceipt memory proofReceipt = proofSubmitter
-            .submitProof(
-                l1Resolver,
-                sourceChainId,
-                requestId,
-                requestHash,
-                msg.sender
-            );
+            .submitProof(l1Resolver, sourceChainId, requestHash, msg.sender);
         require(proofReceipt.fillId != 0, "Submitting proof data failed");
 
         fills[requestHash] = proofReceipt.fillHash;
@@ -88,19 +82,13 @@ contract FillManager is Ownable {
     }
 
     function invalidateFillHash(
-        uint256 requestId,
         bytes32 requestHash,
         bytes32 fillId,
         uint256 sourceChainId
     ) external {
         bytes32 fillHash = BeamerUtils.createFillHash(requestHash, fillId);
         require(fills[requestHash] != fillHash, "Fill hash valid");
-        proofSubmitter.submitNonFillProof(
-            l1Resolver,
-            sourceChainId,
-            requestId,
-            fillHash
-        );
+        proofSubmitter.submitNonFillProof(l1Resolver, sourceChainId, fillHash);
         emit HashInvalidated(requestHash, fillId, fillHash);
     }
 

--- a/contracts/contracts/OptimismProofSubmitter.sol
+++ b/contracts/contracts/OptimismProofSubmitter.sol
@@ -20,7 +20,6 @@ contract OptimismProofSubmitter is IProofSubmitter, RestrictedCalls {
     function submitProof(
         address l1Resolver,
         uint256 sourceChainId,
-        uint256 requestId,
         bytes32 requestHash,
         address filler
     )
@@ -35,7 +34,7 @@ contract OptimismProofSubmitter is IProofSubmitter, RestrictedCalls {
             l1Resolver,
             abi.encodeCall(
                 Resolver.resolve,
-                (requestId, fillHash, block.chainid, sourceChainId, filler)
+                (fillHash, block.chainid, sourceChainId, filler)
             ),
             MESSAGE_GAS_LIMIT
         );
@@ -46,14 +45,13 @@ contract OptimismProofSubmitter is IProofSubmitter, RestrictedCalls {
     function submitNonFillProof(
         address l1Resolver,
         uint256 sourceChainId,
-        uint256 requestId,
         bytes32 fillHash
     ) external {
         messenger.sendMessage(
             l1Resolver,
             abi.encodeCall(
                 Resolver.resolveNonFill,
-                (requestId, fillHash, block.chainid, sourceChainId)
+                (fillHash, block.chainid, sourceChainId)
             ),
             MESSAGE_GAS_LIMIT
         );

--- a/contracts/contracts/ResolutionRegistry.sol
+++ b/contracts/contracts/ResolutionRegistry.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.12;
 import "./CrossDomainRestrictedCalls.sol";
 
 contract ResolutionRegistry is CrossDomainRestrictedCalls {
-    event RequestResolved(uint256 requestId, bytes32 fillHash, address filler);
+    event RequestResolved(bytes32 fillHash, address filler);
 
-    event FillHashInvalidated(uint256 requestId, bytes32 fillHash);
+    event FillHashInvalidated(bytes32 fillHash);
 
     // mapping from fillHash to filler
     mapping(bytes32 => address) public fillers;
@@ -14,7 +14,6 @@ contract ResolutionRegistry is CrossDomainRestrictedCalls {
     mapping(bytes32 => bool) public invalidFillHashes;
 
     function resolveRequest(
-        uint256 requestId,
         bytes32 fillHash,
         uint256 resolutionChainId,
         address filler
@@ -24,14 +23,13 @@ contract ResolutionRegistry is CrossDomainRestrictedCalls {
         // Revert fill hash invalidation, fill proofs outweigh an invalidation
         invalidFillHashes[fillHash] = false;
 
-        emit RequestResolved(requestId, fillHash, filler);
+        emit RequestResolved(fillHash, filler);
     }
 
-    function invalidateFillHash(
-        uint256 requestId,
-        bytes32 fillHash,
-        uint256 resolutionChainId
-    ) external restricted(resolutionChainId, msg.sender) {
+    function invalidateFillHash(bytes32 fillHash, uint256 resolutionChainId)
+        external
+        restricted(resolutionChainId, msg.sender)
+    {
         require(
             fillers[fillHash] == address(0),
             "Cannot invalidate resolved fillHashes"
@@ -43,6 +41,6 @@ contract ResolutionRegistry is CrossDomainRestrictedCalls {
 
         invalidFillHashes[fillHash] = true;
 
-        emit FillHashInvalidated(requestId, fillHash);
+        emit FillHashInvalidated(fillHash);
     }
 }

--- a/contracts/contracts/Resolver.sol
+++ b/contracts/contracts/Resolver.sol
@@ -22,7 +22,6 @@ contract Resolver is Ownable, CrossDomainRestrictedCalls {
     mapping(uint256 => ResolutionInfos) public resolutionInfos;
 
     function resolve(
-        uint256 requestId,
         bytes32 fillHash,
         uint256 fillChainId,
         uint256 sourceChainId,
@@ -43,7 +42,7 @@ contract Resolver is Ownable, CrossDomainRestrictedCalls {
             info.resolutionRegistry,
             abi.encodeCall(
                 ResolutionRegistry.resolveRequest,
-                (requestId, fillHash, block.chainid, filler)
+                (fillHash, block.chainid, filler)
             ),
             1_000_000
         );
@@ -52,7 +51,6 @@ contract Resolver is Ownable, CrossDomainRestrictedCalls {
     }
 
     function resolveNonFill(
-        uint256 requestId,
         bytes32 fillHash,
         uint256 fillChainId,
         uint256 sourceChainId
@@ -72,7 +70,7 @@ contract Resolver is Ownable, CrossDomainRestrictedCalls {
             info.resolutionRegistry,
             abi.encodeCall(
                 ResolutionRegistry.invalidateFillHash,
-                (requestId, fillHash, block.chainid)
+                (fillHash, block.chainid)
             ),
             1_000_000
         );

--- a/contracts/interfaces/IProofSubmitter.sol
+++ b/contracts/interfaces/IProofSubmitter.sol
@@ -10,7 +10,6 @@ interface IProofSubmitter {
     function submitProof(
         address l1Resolver,
         uint256 sourceChainId,
-        uint256 requestId,
         bytes32 requestHash,
         address eligibleClaimer
     ) external returns (ProofReceipt memory);
@@ -18,7 +17,6 @@ interface IProofSubmitter {
     function submitNonFillProof(
         address l1Resolver,
         uint256 sourceChainId,
-        uint256 requestId,
         bytes32 fillHash
     ) external;
 }


### PR DESCRIPTION
The agent must find the corresponding request by the fill hash.

For simplicity I chose iterating over claims and reconstructing the fill hash to find the corresponding requests / claims.

This is only a temporary change and will be changed soon by #645 changes in the resolution registry. In that PR we can optionally introduce optimizations on the agent to find the corresponding objects more efficiently.