### PR TITLE
frontend: display error messages in steps

### DIFF
--- a/frontend/src/components/TransferStatus.vue
+++ b/frontend/src/components/TransferStatus.vue
@@ -67,6 +67,7 @@ const progressSteps = computed(() =>
     label: step.label,
     completed: step.completed,
     failed: step.failed,
+    errorMessage: step.errorMessage,
   })),
 );
 

--- a/frontend/src/components/layout/Progress.vue
+++ b/frontend/src/components/layout/Progress.vue
@@ -1,12 +1,6 @@
 <template>
-  <ul class="steps steps-vertical text-left">
-    <ProgressStep
-      v-for="(step, index) in steps"
-      :key="index"
-      :label="step.label"
-      :completed="step.completed"
-      :failed="step.failed"
-    />
+  <ul class="steps steps-vertical text-left w-full p-5">
+    <ProgressStep v-for="(step, index) in steps" :key="index" v-bind="step" />
   </ul>
 </template>
 
@@ -18,14 +12,9 @@ interface Props {
     label: string;
     completed?: boolean;
     failed?: boolean;
+    errorMessage?: string;
   }>;
 }
 
 defineProps<Props>();
 </script>
-
-<style>
-.steps-vertical .step {
-  min-height: 3rem !important;
-}
-</style>

--- a/frontend/src/components/layout/ProgressStep.vue
+++ b/frontend/src/components/layout/ProgressStep.vue
@@ -1,7 +1,10 @@
 <template>
-  <li data-content="" class="step" :class="classObject">
-    {{ label }}
-  </li>
+  <div data-content="" class="step relative !min-h-[4rem]" :class="stepClasses">
+    <div class="absolute left-20 text-left" :class="contentClasses">
+      {{ label }}
+      <span v-if="errorMessage" class="text-orange-dark"> <br />{{ errorMessage }} </span>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -11,45 +14,55 @@ interface Props {
   readonly label: string;
   readonly completed?: boolean;
   readonly failed?: boolean;
+  readonly errorMessage?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   completed: false,
   failed: false,
+  errorMessage: undefined,
 });
 
-const classObject = computed(() => {
-  return {
-    'step--completed': props.completed && !props.failed,
-    'step--failed': props.failed,
-  };
-});
+const stepClasses = computed(() => ({
+  'step--completed': props.completed && !props.failed,
+  'step--failed': props.failed,
+}));
+
+const contentClasses = computed(() => ({
+  'top-4': props.errorMessage,
+}));
 </script>
 
 <style lang="css">
 .steps .step:before {
   @apply bg-light;
 }
+
 .steps .step:after {
   @apply border-light bg-teal;
   height: 1.5rem;
   width: 1.5rem;
   border-width: 2px;
 }
+
 .steps .step--completed:after {
   @apply border-teal bg-green;
   border-width: 2px;
 }
+
 .steps .step--completed + .step--completed:before {
   @apply bg-light;
 }
+
 .steps .step--failed:after {
   @apply border-teal bg-orange-dark;
   border-width: 2px;
 }
+
 .steps-vertical .step:before {
   width: 0.2rem;
 }
+
 .steps-vertical .step {
   gap: 1.5rem;
   min-height: 5rem;


### PR DESCRIPTION
Currently we still use `daisyUI` for the progress steps. Having this, it wasn't easy to have multiline content in the step label with different colors. The workaround with an absolute `<div>`, conditional padding etc. is not optimal. As it is only a visual component, this is okay. In the long term we should replace this with a custom implementation that can be tailed 100% to our needs.