### PR TITLE
frontend: recover token allowance usage

### DIFF
--- a/frontend/src/services/transactions/token.ts
+++ b/frontend/src/services/transactions/token.ts
@@ -1,21 +1,21 @@
 import type { JsonRpcSigner } from '@ethersproject/providers';
-import type { BigNumber } from 'ethers';
-import { Contract } from 'ethers';
+import { BigNumber, Contract } from 'ethers';
 
 import StandardToken from '@/assets/StandardToken.json';
 import type { EthereumProvider } from '@/services/web3-provider';
+import type { UInt256 } from '@/types/uint-256';
 
 export async function ensureTokenAllowance(
   signer: JsonRpcSigner,
   tokenAddress: string,
   allowedSpender: string,
-  amount: BigNumber,
+  minimumRequiredAmount: UInt256,
 ): Promise<void> {
   const tokenContract = new Contract(tokenAddress, StandardToken.abi, signer);
   const signerAddress = await signer.getAddress();
   const signerTokenBalance = await tokenContract.balanceOf(signerAddress);
   const allowance: BigNumber = await tokenContract.allowance(signerAddress, allowedSpender);
-  if (allowance.lt(amount)) {
+  if (allowance.lt(BigNumber.from(minimumRequiredAmount.asString))) {
     const transaction = await tokenContract.approve(allowedSpender, signerTokenBalance);
     await transaction.wait();
   }


### PR DESCRIPTION
Somehow I managed to loose the call of the token allowance. As soon as the last allowance is no more enough (always for new users), no transfer is possible anymore.
This simply adds it back, using the still existing utility function, but integrating it as a new first step of a transfer. First time that our new architecture really plays it strength, as we can simply add a news step, at first place, fully backwards compatible and neatly  working.