### PR TITLE
frontend: Add typescript compiler check to linting

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,8 +6,11 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint --ext .js,.ts,.vue --ignore-path .gitignore --max-warnings 0 .",
-    "lint:fix": "eslint --ext .js,.ts,.vue --ignore-path .gitignore --fix .",
+    "check-types": "tsc --noEmit",
+    "eslint": "eslint --ext .js,.ts,.vue --ignore-path .gitignore --max-warnings 0 .",
+    "eslint:fix": "eslint --ext .js,.ts,.vue --ignore-path .gitignore --fix .",
+    "lint": "yarn check-types && yarn eslint",
+    "lint:fix": "yarn check-types; yarn eslint:fix",
     "test:unit": "vitest run --dir=./tests/unit",
     "test:coverage": "vitest run --dir=./tests --coverage"
   },

--- a/frontend/src/actions/steps/multi-step-action.ts
+++ b/frontend/src/actions/steps/multi-step-action.ts
@@ -75,7 +75,7 @@ export class MultiStepAction {
         await method();
         step.complete();
       } catch (error) {
-        step.setErrorMessage(error.message ?? error);
+        step.setErrorMessage((error as { message?: string }).message ?? 'Unknown failure!');
         throw error;
       } finally {
         step.deactivate();

--- a/frontend/src/composables/useLoadConfiguration.ts
+++ b/frontend/src/composables/useLoadConfiguration.ts
@@ -1,10 +1,10 @@
 import { onMounted, ref } from 'vue';
 
-import type { BeamerConfig, ChainConfig } from '@/types/config';
+import type { BeamerConfig, ChainWithTokens } from '@/types/config';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default function useLoadConfiguration(
-  setChainConfiguration: (id: string, configuration: ChainConfig) => void,
+  setChainConfiguration: (id: string, configuration: ChainWithTokens) => void,
 ) {
   const configurationLoaded = ref(false);
 

--- a/frontend/src/composables/useTokenSelection.ts
+++ b/frontend/src/composables/useTokenSelection.ts
@@ -3,7 +3,8 @@ import { computed, ref } from 'vue';
 
 import { getTokenDecimals } from '@/services/transactions/token';
 import type { EthereumProvider } from '@/services/web3-provider';
-import type { ChainConfigMapping, Token } from '@/types/config';
+import type { ChainConfigMapping } from '@/types/config';
+import type { Token } from '@/types/data';
 import type { SelectorOption } from '@/types/form';
 
 export function useTokenSelection(

--- a/frontend/src/services/web3-provider/walletconnect-provider.ts
+++ b/frontend/src/services/web3-provider/walletconnect-provider.ts
@@ -1,4 +1,4 @@
-import WalletConnect from '@walletconnect/web3-provider/dist/umd/index.min.js';
+import WalletConnect from '@walletconnect/web3-provider';
 import { hexValue } from 'ethers/lib/utils';
 
 import type { Eip1193Provider } from '@/services/web3-provider';
@@ -9,7 +9,7 @@ export async function createWalletConnectProvider(rpcList: {
 }): Promise<WalletConnectProvider | undefined> {
   const provider = new WalletConnect({
     rpc: rpcList,
-  });
+  }) as Eip1193Provider & WalletConnect;
 
   await provider.enable();
 

--- a/frontend/src/stores/ethereum-provider.ts
+++ b/frontend/src/stores/ethereum-provider.ts
@@ -2,13 +2,13 @@ import type { JsonRpcSigner } from '@ethersproject/providers';
 import { defineStore } from 'pinia';
 import { shallowRef } from 'vue';
 
-import type { EthereumProvider } from '@/services/web3-provider';
+import type { IEthereumProvider } from '@/services/web3-provider';
 
 export const useEthereumProvider = defineStore('ethereumProvider', {
   state: () => ({
     // We need a shallow reference here to prevent issues with ethers.js on
     // contract function calls.
-    provider: shallowRef<EthereumProvider | undefined>(undefined),
+    provider: shallowRef<IEthereumProvider | undefined>(undefined),
   }),
   getters: {
     signer: (state): JsonRpcSigner | undefined => state.provider?.signer.value,

--- a/frontend/src/types/encoding.ts
+++ b/frontend/src/types/encoding.ts
@@ -1,9 +1,9 @@
 type EncodableBaseTypes = boolean | string | number | undefined;
 
-type EncodableArray = Array<EncodableBaseTypes>;
+type EncodableArray = Array<EncodableData>;
 
 interface EncodableObject {
-  [key: string]: EncodableBaseTypes | EncodableArray | EncodableObject;
+  [key: string]: EncodableData;
 }
 
 export type EncodableData = EncodableBaseTypes | EncodableArray | EncodableObject;

--- a/frontend/tests/unit/stores/ethereum-provider.spec.ts
+++ b/frontend/tests/unit/stores/ethereum-provider.spec.ts
@@ -2,7 +2,7 @@ import type { JsonRpcSigner } from '@ethersproject/providers';
 import { createPinia, setActivePinia } from 'pinia';
 
 import { useEthereumProvider } from '@/stores/ethereum-provider';
-import { MockedEthereumProvider } from '~/utils/mocks/ethereum-provider';
+import { MockedMetaMaskProvider } from '~/utils/mocks/ethereum-provider';
 
 describe('configuration store', () => {
   beforeEach(() => {
@@ -23,7 +23,7 @@ describe('configuration store', () => {
       // TODO: Creating a mocked signer is not trivial. It will help to remove
       // 3rd party types from our own types. Therefore use this ugly hack here.
       const signer = { fake: 'signer' } as unknown as JsonRpcSigner;
-      ethereumProvider.$state.provider = new MockedEthereumProvider({ signer });
+      ethereumProvider.$state.provider = new MockedMetaMaskProvider({ signer });
 
       expect(ethereumProvider.signer).toBe(signer);
     });
@@ -39,7 +39,7 @@ describe('configuration store', () => {
 
     it('mirrors the value of the providers property if state is defined', () => {
       const ethereumProvider = useEthereumProvider();
-      ethereumProvider.$state.provider = new MockedEthereumProvider({
+      ethereumProvider.$state.provider = new MockedMetaMaskProvider({
         signerAddress: '0xSignerAddress',
       });
 
@@ -57,7 +57,7 @@ describe('configuration store', () => {
 
     it('mirrors the value of the providers property if state is defined', () => {
       const ethereumProvider = useEthereumProvider();
-      ethereumProvider.$state.provider = new MockedEthereumProvider({ chainId: 5 });
+      ethereumProvider.$state.provider = new MockedMetaMaskProvider({ chainId: 5 });
 
       expect(ethereumProvider.chainId).toBe(5);
     });


### PR DESCRIPTION
I was a bit annoyed that my IDE showed typescript errors which were not caught by our linting and the CI, so I added tsc to the linting script.