### PR TITLE
Trigger L1 invalidation

### DIFF
--- a/beamer/agent.py
+++ b/beamer/agent.py
@@ -38,7 +38,7 @@ class Agent:
         # Just add one worker, as this effectively serializes the work
         # This is necessary as we use the account for all resolutions and
         # would otherwise run into nonce problems
-        self._resolution_pool = ThreadPoolExecutor(max_workers=1)
+        self._task_pool = ThreadPoolExecutor(max_workers=1)
 
         w3_l1 = _make_web3(config.l1_rpc_url, config.account)
         w3_l2a = _make_web3(config.l2a_rpc_url, config.account)
@@ -70,7 +70,7 @@ class Agent:
             latest_blocks={},
             config=config,
             web3_l1=w3_l1,
-            resolution_pool=self._resolution_pool,
+            task_pool=self._task_pool,
             l1_resolutions={},
         )
         self._event_processor = EventProcessor(self.context)
@@ -107,7 +107,7 @@ class Agent:
         self._event_processor.stop()
         self._event_monitor_l2a.stop()
         self._event_monitor_l2b.stop()
-        self._resolution_pool.shutdown(wait=True, cancel_futures=False)
+        self._task_pool.shutdown(wait=True, cancel_futures=False)
         self._stopped.set()
 
     @property

--- a/beamer/chain.py
+++ b/beamer/chain.py
@@ -286,9 +286,6 @@ def process_claims(context: Context) -> None:
             # TODO: See https://github.com/beamer-bridge/beamer/issues/674
             continue
 
-        # TODO: Maybe trigger L1 forwarding
-        #  See https://github.com/beamer-bridge/beamer/issues/669
-
         # Check if claim is an honest claim. Honest claims can be ignored.
         # This only counts for claims, where the agent is not the filler
         if claim.valid_claim_for_request(request) and request.filler != context.address:

--- a/beamer/events.py
+++ b/beamer/events.py
@@ -41,6 +41,11 @@ class InitiateL1ResolutionEvent(Event):
 
 
 @dataclass(frozen=True)
+class InitiateL1InvalidationEvent(Event):
+    claim_id: ClaimId
+
+
+@dataclass(frozen=True)
 class TxEvent(Event):
     tx_hash: HexBytes
 

--- a/beamer/l1_resolution.py
+++ b/beamer/l1_resolution.py
@@ -24,7 +24,7 @@ def relayer_executable_exists() -> bool:
     return False
 
 
-def run_relayer(l1_rpc: URL, l2_rpc: URL, privkey: str, tx_hash: HexBytes) -> None:
+def run_relayer_for_tx(l1_rpc: URL, l2_rpc: URL, privkey: str, tx_hash: HexBytes) -> None:
     subprocess.run(
         [
             _RELAYER_EXECUTABLE,

--- a/beamer/models/claim.py
+++ b/beamer/models/claim.py
@@ -46,8 +46,10 @@ class Claim(StateMachine):
         | challenger_winning.to(claimer_winning)
         | ignored.to(ignored)
     )
-    l1_invalidate = claimer_winning.to(invalidated_l1_resolved) | challenger_winning.to(
-        invalidated_l1_resolved
+    l1_invalidate = (
+        claimer_winning.to(invalidated_l1_resolved)
+        | challenger_winning.to(invalidated_l1_resolved)
+        | invalidated_l1_resolved.to(invalidated_l1_resolved)
     )
     withdraw = (
         claimer_winning.to(withdrawn)

--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -279,16 +279,18 @@ def _handle_fill_hash_invalidated(event: FillHashInvalidated, context: Context) 
     return True, None
 
 
-def _l1_resolution_criteria_fulfilled(claim: Claim, context: Context) -> HandlerResult:
-    l1_resolution_gas_cost = 1_000_000  # TODO: Adapt to real price
+def _l1_resolution_criteria_fulfilled(claim: Claim, context: Context) -> bool:
+    l1_gas_cost = 1_000_000  # TODO: Adapt to real price
     l1_gas_price = context.web3_l1.eth.gas_price
     l1_safety_factor = 1.25
-    limit = int(l1_resolution_gas_cost * l1_gas_price * l1_safety_factor)
+    limit = int(l1_gas_cost * l1_gas_price * l1_safety_factor)
 
+    # Agent is claimer
     if claim.claimer == context.address:
         if claim.latest_claim_made.challenger_stake_total > limit:
-            return True, None
+            return True
     else:
+        # Agent is challenger
         reward = claim.get_challenger_stake(context.address)
         last_challenger = claim.latest_claim_made.last_challenger
         if last_challenger == context.address:
@@ -298,8 +300,8 @@ def _l1_resolution_criteria_fulfilled(claim: Claim, context: Context) -> Handler
             )
 
         if reward > limit:
-            return True, None
-    return False, None
+            return True
+    return False
 
 
 def _handle_initiate_l1_resolution(

--- a/beamer/tests/agent/unit/test_l1.py
+++ b/beamer/tests/agent/unit/test_l1.py
@@ -1,0 +1,72 @@
+import pytest
+from web3.types import Wei
+
+from beamer.events import InitiateL1InvalidationEvent, InitiateL1ResolutionEvent
+from beamer.state_machine import process_event
+from beamer.tests.agent.unit.utils import (
+    CLAIM_ID,
+    REQUEST_ID,
+    TARGET_CHAIN_ID,
+    make_claim_challenged,
+    make_context,
+    make_request,
+)
+from beamer.tests.agent.utils import make_tx_hash
+
+
+def test_handle_initiate_l1_resolution():
+    context, config = make_context()
+
+    request = make_request()
+    context.requests.add(request.id, request)
+
+    event = InitiateL1ResolutionEvent(
+        chain_id=TARGET_CHAIN_ID,
+        request_id=REQUEST_ID,
+        claim_id=CLAIM_ID,
+    )
+
+    # Without a claim, this must fail
+    assert process_event(event, context) == (False, None)
+
+    claim = make_claim_challenged(request, claimer=config.account.address)
+    context.claims.add(claim.id, claim)
+
+    # Must only be called if request is filled
+    with pytest.raises(AssertionError, match="Request not yet filled"):
+        process_event(event, context)
+
+    # Check that task is added to resolution pool
+    context.web3_l1.eth.gas_price = Wei(1)  # type: ignore
+    request.fill(config.account.address, b"", b"")
+    request.try_to_claim()
+    assert process_event(event, context) == (True, None)
+    assert context.task_pool.submit.called  # type: ignore  # pylint:disable=no-member
+
+
+def test_handle_initiate_l1_invalidation():
+    context, config = make_context()
+
+    request = make_request()
+    context.requests.add(request.id, request)
+
+    event = InitiateL1InvalidationEvent(
+        chain_id=TARGET_CHAIN_ID,
+        claim_id=CLAIM_ID,
+    )
+
+    # Without a claim, this must fail
+    assert process_event(event, context) == (False, None)
+
+    claim = make_claim_challenged(request, claimer=config.account.address)
+    context.claims.add(claim.id, claim)
+
+    # Must only be called if claim is invalidated
+    with pytest.raises(AssertionError, match="Claim not invalidated"):
+        process_event(event, context)
+
+    # Check that task is added to resolution pool
+    context.web3_l1.eth.gas_price = Wei(1)  # type: ignore
+    claim.start_challenge(make_tx_hash())
+    assert process_event(event, context) == (True, None)
+    assert context.task_pool.submit.called  # type: ignore  # pylint:disable=no-member

--- a/beamer/tests/agent/unit/utils.py
+++ b/beamer/tests/agent/unit/utils.py
@@ -158,7 +158,7 @@ def make_context() -> Tuple[Context, Config]:
         },
         config=config,
         web3_l1=MagicMock(),
-        resolution_pool=MagicMock(),
+        task_pool=MagicMock(),
         l1_resolutions={},
     )
     context.request_manager.functions.claimStake().call.return_value = 1  # type: ignore


### PR DESCRIPTION
Resolves #669 

- First commit fixes an oversight on the return type of the `_l1_resolution_criteria_fulfilled` function
- Second commit add the `InitiateL1InvalidationEvent`, which is triggered when a claim that has been invalidated can be L1 resolved.