### PR TITLE
Also store fill id in request when withdrawn to correctly resolve other active claims

### DIFF
--- a/beamer/tests/agent/test_challenge.py
+++ b/beamer/tests/agent/test_challenge.py
@@ -6,6 +6,7 @@ import pytest
 from eth_utils import to_checksum_address
 
 import beamer.agent
+from beamer.tests.agent.unit.utils import FILL_ID
 from beamer.tests.util import EventCollector, HTTPProxy, alloc_accounts, earnings, make_request
 
 
@@ -133,7 +134,7 @@ def test_challenge_3(request_manager, fill_manager, token, config):
         )
 
         stake = request_manager.claimStake()
-        request_manager.claimRequest(request_id, 0, {"from": charlie, "value": stake})
+        request_manager.claimRequest(request_id, FILL_ID, {"from": charlie, "value": stake})
 
         collector = EventCollector(request_manager, "ClaimMade")
         collector.next_event()
@@ -187,7 +188,7 @@ def test_challenge_4(request_manager, fill_manager, token, config):
         )
 
         stake = request_manager.claimStake()
-        request_manager.claimRequest(request_id, 0, {"from": charlie, "value": stake})
+        request_manager.claimRequest(request_id, FILL_ID, {"from": charlie, "value": stake})
 
         collector = EventCollector(request_manager, "ClaimMade")
         claim = collector.next_event()
@@ -263,7 +264,7 @@ def test_challenge_5(request_manager, fill_manager, token, config, honest_claim)
     request_id = make_request(
         request_manager, token, requester, target, amount, fee_data="standard"
     )
-    fill_id = 0
+    fill_id = FILL_ID
 
     if honest_claim:
         # Fill by Charlie
@@ -331,7 +332,7 @@ def test_withdraw_not_participant(request_manager, token, config):
     )
 
     stake = request_manager.claimStake()
-    request_manager.claimRequest(request_id, 0, {"from": charlie, "value": stake})
+    request_manager.claimRequest(request_id, FILL_ID, {"from": charlie, "value": stake})
 
     collector = EventCollector(request_manager, "ClaimMade")
     claim = collector.next_event()
@@ -373,7 +374,7 @@ def test_challenge_7(request_manager, fill_manager, token, config):
         request_id = make_request(request_manager, token, requester, target, amount)
 
         stake = request_manager.claimStake()
-        request_manager.claimRequest(request_id, 0, {"from": charlie, "value": stake})
+        request_manager.claimRequest(request_id, FILL_ID, {"from": charlie, "value": stake})
 
         collector = EventCollector(request_manager, "ClaimMade")
         claim = collector.next_event()

--- a/beamer/tests/contracts/test_request_manager_fees.py
+++ b/beamer/tests/contracts/test_request_manager_fees.py
@@ -1,6 +1,7 @@
 import brownie
 from brownie import chain
 
+from beamer.tests.agent.unit.utils import FILL_ID
 from beamer.tests.constants import RM_R_FIELD_LP_FEE, RM_R_FIELD_PROTOCOL_FEE
 from beamer.tests.util import alloc_accounts, make_request, temp_fee_data
 
@@ -30,7 +31,9 @@ def test_fee_split_works(deployer, request_manager, token, claim_stake, claim_pe
     assert request_manager.requests(request_id)[RM_R_FIELD_LP_FEE] == lp_fee
     assert request_manager.requests(request_id)[RM_R_FIELD_PROTOCOL_FEE] == protocol_fee
 
-    claim_tx = request_manager.claimRequest(request_id, 0, {"from": claimer, "value": claim_stake})
+    claim_tx = request_manager.claimRequest(
+        request_id, FILL_ID, {"from": claimer, "value": claim_stake}
+    )
     claim_id = claim_tx.return_value
 
     # Update fees, which should not have any effect on the fee amounts that
@@ -71,7 +74,9 @@ def test_protocol_fee_withdrawable_by_owner(
     with brownie.reverts("Protocol fee is zero"):
         request_manager.withdrawProtocolFees(token, owner, {"from": owner})
 
-    claim_tx = request_manager.claimRequest(request_id, 0, {"from": claimer, "value": claim_stake})
+    claim_tx = request_manager.claimRequest(
+        request_id, FILL_ID, {"from": claimer, "value": claim_stake}
+    )
     claim_id = claim_tx.return_value
 
     chain.mine(timedelta=claim_period)
@@ -188,10 +193,10 @@ def test_different_fees(request_manager, token, claim_period, claim_stake):
         == amount * 2 + protocol_fee_1 + protocol_fee_2 + lp_fee_1 + lp_fee_2
     )
     claim_id_1 = request_manager.claimRequest(
-        request_id_1, 0, {"from": claimer, "value": claim_stake}
+        request_id_1, FILL_ID, {"from": claimer, "value": claim_stake}
     ).return_value
     claim_id_2 = request_manager.claimRequest(
-        request_id_2, 0, {"from": claimer, "value": claim_stake}
+        request_id_2, FILL_ID, {"from": claimer, "value": claim_stake}
     ).return_value
 
     chain.mine(timedelta=claim_period)

--- a/contracts/contracts/BeamerUtils.sol
+++ b/contracts/contracts/BeamerUtils.sol
@@ -2,6 +2,11 @@
 pragma solidity ^0.8.12;
 
 library BeamerUtils {
+    struct FillInfo {
+        address filler;
+        bytes32 fillId;
+    }
+
     function createRequestHash(
         uint256 requestId,
         uint256 sourceChainId,


### PR DESCRIPTION
There was a bug in the contracts code when a claimer had multiple claims on the same request.

If one of them was successfully withdrawn, all other claims would be resolved in favor of the claimer which could be wrong if the fill id was different.

The rule is: 

All identical claims should be resolved equally. A correct claim is only correct if the claimer is the filler and the fill id matches. If the correct filler creates a claim with a wrong fill id, the claim becomes invalid.

This must be reflected in the withdraw function: In order to achieve that we need to store all relevant information with the request upon deposit withdraw, so that future claims can be resolved correctly. 
That means if the future claim is from the same address who withdrew the deposit AND the fill id is the same as from the claim which was used when withdrawing the deposit, then the claimer is entitled to receive the claim stake. In all other cases the challenger wins.

was found and is partially needed for #645 

Please note that the `FillerInfo` object will be used in an upcoming PR in the resolution registry as well