### PR TITLE
frontend: fix issues on wallet connect import

### DIFF
--- a/frontend/src/services/web3-provider/walletconnect-provider.ts
+++ b/frontend/src/services/web3-provider/walletconnect-provider.ts
@@ -1,4 +1,6 @@
-import WalletConnect from '@walletconnect/web3-provider';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore TODO: we need to check what is going on here.
+import WalletConnect from '@walletconnect/web3-provider/dist/umd/index.min.js';
 import { hexValue } from 'ethers/lib/utils';
 
 import type { Eip1193Provider } from '@/services/web3-provider';


### PR DESCRIPTION
When we worked on the WalletConnect integration, we had some weird issues with importing the dependency. While TypeScript is fine, the application does no more work at all in the browser. Therefore we uses a more specific import of a specific file of the package. That import causes issues with TypeScript due to a missing declaration file.
This issue was solved in the past and working, because we had no TypeScript linting enabled. Recently we enabled the latter and this import got simply fixed, without checking the functionality of the application.
This commit is now recovering the ugly fix of the past and makes the linting pass.