### PR TITLE
frontend: add waiting dots for active steps

### DIFF
--- a/frontend/src/components/Transfer.vue
+++ b/frontend/src/components/Transfer.vue
@@ -64,6 +64,7 @@ const status = computed(() => {
 const progressSteps = computed(() =>
   props.transfer.steps.map((step) => ({
     label: step.label,
+    active: step.active,
     completed: step.completed,
     failed: step.failed,
     errorMessage: step.errorMessage,

--- a/frontend/src/components/layout/Progress.vue
+++ b/frontend/src/components/layout/Progress.vue
@@ -10,6 +10,7 @@ import ProgressStep from '@/components/layout/ProgressStep.vue';
 interface Props {
   readonly steps: Array<{
     label: string;
+    active?: boolean;
     completed?: boolean;
     failed?: boolean;
     errorMessage?: string;

--- a/frontend/src/components/layout/ProgressStep.vue
+++ b/frontend/src/components/layout/ProgressStep.vue
@@ -2,6 +2,7 @@
   <div data-content="" class="step relative !min-h-[4rem]" :class="stepClasses">
     <div class="absolute left-20 text-left" :class="contentClasses">
       {{ label }}
+      <WaitingDots v-if="active" />
       <span v-if="errorMessage" class="text-red"> <br />{{ errorMessage }} </span>
     </div>
   </div>
@@ -10,14 +11,18 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
+import WaitingDots from '@/components/layout/WaitingDots.vue';
+
 interface Props {
   readonly label: string;
+  readonly active?: boolean;
   readonly completed?: boolean;
   readonly failed?: boolean;
   readonly errorMessage?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
+  active: false,
   completed: false,
   failed: false,
   errorMessage: undefined,

--- a/frontend/src/components/layout/WaitingDots.vue
+++ b/frontend/src/components/layout/WaitingDots.vue
@@ -1,0 +1,29 @@
+<template>
+  <span>{{ currentFrame }}</span>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+
+const frameSequence = ['\xa0\xa0\xa0', '.\xa0\xa0', '..\xa0', '...'];
+const currentFrameIndex = ref(0);
+const timer = ref<ReturnType<typeof setInterval> | undefined>(undefined);
+
+const currentFrame = computed(() => frameSequence[currentFrameIndex.value]);
+
+function nextFrame() {
+  let nextIndex = currentFrameIndex.value + 1;
+  nextIndex = nextIndex >= frameSequence.length ? 0 : nextIndex;
+  currentFrameIndex.value = nextIndex;
+}
+
+onMounted(() => {
+  timer.value = setInterval(nextFrame, 500);
+});
+
+onUnmounted(() => {
+  if (timer.value) {
+    clearInterval(timer.value);
+  }
+});
+</script>

--- a/frontend/tests/unit/components/layout/Progress.spec.ts
+++ b/frontend/tests/unit/components/layout/Progress.spec.ts
@@ -6,8 +6,10 @@ import ProgressStep from '@/components/layout/ProgressStep.vue';
 function createWrapper(options?: {
   steps?: Array<{
     label: string;
+    active?: boolean;
     completed?: boolean;
     failed?: boolean;
+    errorMessage?: string;
   }>;
 }) {
   return mount(Progress, {
@@ -27,7 +29,21 @@ describe('RequestProcessing.vue', () => {
     expect(progressSteps[1].props()).toContain({ label: 'two' });
   });
 
-  it('sets correct the completion state for each state', () => {
+  it('sets correctly the activity state for each state', () => {
+    const wrapper = createWrapper({
+      steps: [
+        { label: 'one', active: true },
+        { label: 'two', active: false },
+      ],
+    });
+    const progressSteps = wrapper.findAllComponents(ProgressStep);
+
+    expect(progressSteps.length).toBe(2);
+    expect(progressSteps[0].props()).toContain({ active: true });
+    expect(progressSteps[1].props()).toContain({ active: false });
+  });
+
+  it('sets correctly the completion state for each state', () => {
     const wrapper = createWrapper({
       steps: [
         { label: 'one', completed: true },
@@ -41,7 +57,7 @@ describe('RequestProcessing.vue', () => {
     expect(progressSteps[1].props()).toContain({ completed: false });
   });
 
-  it('sets correct the failed state for each state', () => {
+  it('sets correctly the failed state for each state', () => {
     const wrapper = createWrapper({
       steps: [
         { label: 'one', failed: true },
@@ -53,5 +69,19 @@ describe('RequestProcessing.vue', () => {
     expect(progressSteps.length).toBe(2);
     expect(progressSteps[0].props()).toContain({ failed: true });
     expect(progressSteps[1].props()).toContain({ failed: false });
+  });
+
+  it('sets correctly the error message for each state', () => {
+    const wrapper = createWrapper({
+      steps: [
+        { label: 'one', errorMessage: 'error one' },
+        { label: 'two', errorMessage: '' },
+      ],
+    });
+    const progressSteps = wrapper.findAllComponents(ProgressStep);
+
+    expect(progressSteps.length).toBe(2);
+    expect(progressSteps[0].props()).toContain({ errorMessage: 'error one' });
+    expect(progressSteps[1].props()).toContain({ errorMessage: '' });
   });
 });

--- a/frontend/tests/unit/components/layout/ProgressStep.spec.ts
+++ b/frontend/tests/unit/components/layout/ProgressStep.spec.ts
@@ -1,12 +1,19 @@
 import { mount } from '@vue/test-utils';
 
 import ProgressStep from '@/components/layout/ProgressStep.vue';
+import WaitingDots from '@/components/layout/WaitingDots.vue';
 
-function createWrapper(options?: { completed?: boolean; failed?: boolean; label?: string }) {
+function createWrapper(options?: {
+  active?: boolean;
+  completed?: boolean;
+  failed?: boolean;
+  label?: string;
+}) {
   return mount(ProgressStep, {
     shallow: true,
     props: {
       label: options?.label ?? 'label',
+      active: options?.active,
       completed: options?.completed,
       failed: options?.failed,
     },
@@ -18,6 +25,14 @@ describe('ProgressStep.vue', () => {
     const wrapper = createWrapper({ label: 'test label' });
 
     expect(wrapper.text()).toContain('test label');
+  });
+
+  it('shows waiting dots to indicate active step', async () => {
+    const wrapper = createWrapper({ active: true });
+    const dots = wrapper.findComponent(WaitingDots);
+
+    expect(dots.exists()).toBeTruthy();
+    expect(dots.isVisible()).toBeTruthy();
   });
 
   it('indicates that a step got completed', () => {

--- a/frontend/tests/unit/components/layout/WaitingDots.spec.ts
+++ b/frontend/tests/unit/components/layout/WaitingDots.spec.ts
@@ -1,0 +1,42 @@
+import { mount } from '@vue/test-utils';
+
+import WaitingDots from '@/components/layout/WaitingDots.vue';
+
+function createWrapper() {
+  return mount(WaitingDots, { shallow: true });
+}
+
+describe('WaitingDots.vue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('updates the dots based on an interval in a cycle', async () => {
+    const wrapper = createWrapper();
+
+    const runNextInterval = async () => {
+      vi.runOnlyPendingTimers();
+      await wrapper.vm.$nextTick();
+    };
+
+    expect(wrapper.text()).toBe('');
+    await runNextInterval();
+    expect(wrapper.text()).toBe('.');
+    await runNextInterval();
+    expect(wrapper.text()).toBe('..');
+    await runNextInterval();
+    expect(wrapper.text()).toBe('...');
+    await runNextInterval();
+    expect(wrapper.text()).toBe('');
+    await runNextInterval();
+    expect(wrapper.text()).toBe('.');
+    await runNextInterval();
+    expect(wrapper.text()).toBe('..');
+    await runNextInterval();
+    expect(wrapper.text()).toBe('...');
+  });
+});


### PR DESCRIPTION
Little weekend PR to implement a little UI feature for our designer. 😉 

A new component called `WaitingDots` got added. This component does an animation of three dots that appear after each other ('' -> '.' -> '..' -> '...' -> '' -> '.' -> ...).
It gets used as an indicator that a `ProgressStep` is currently active (and waiting or doing something).

This includes a missing test case for error messages in progress steps.