### PR TITLE
frontend: allow token selection without wallet

### DIFF
--- a/frontend/src/components/RequestFormInputs.vue
+++ b/frontend/src/components/RequestFormInputs.vue
@@ -152,8 +152,10 @@ const { selectedSourceChain, sourceChains, targetChains, switchChain } = useChai
   chains,
 );
 
+const selectedSourceChainIdentifier = computed(() => selectedSourceChain.value?.value ?? -1);
+
 const { selectedToken, selectedTokenAddress, tokens, addTokenToProvider, addTokenAvailable } =
-  useTokenSelection(provider, chains);
+  useTokenSelection(chains, selectedSourceChainIdentifier, provider);
 
 const { available: showRequestFee, formattedAmount: formattedRequestFeeAmount } = useRequestFee(
   provider,

--- a/frontend/src/components/TransferSummary.vue
+++ b/frontend/src/components/TransferSummary.vue
@@ -4,12 +4,14 @@
       {{ date.toLocaleString() }}<br />
       You sent {{ amount }}&nbsp;{{ tokenSymbol }}<br />
       from {{ sourceChainName }} to {{ targetChainName }}<br />
-      Target address:&nbsp;<EthereumAddress :address="targetAccount" />
+      Target address:&nbsp;
+      <EthereumAddress :address="targetAccount" />
     </div>
 
     <a
       v-if="requestTransactionUrl"
       class="underline"
+      target="_blank"
       :href="requestTransactionUrl"
       data-test="explorer-link"
     >

--- a/frontend/src/composables/useTokenSelection.ts
+++ b/frontend/src/composables/useTokenSelection.ts
@@ -8,11 +8,12 @@ import type { Token } from '@/types/data';
 import type { SelectorOption } from '@/types/form';
 
 export function useTokenSelection(
-  provider: Ref<EthereumProvider | undefined>,
   chains: Ref<ChainConfigMapping>,
+  connectedChainIdentifier: Ref<number>,
+  provider: Ref<EthereumProvider | undefined>,
 ) {
   const tokens = computed(() =>
-    chains.value[String(provider.value?.chainId.value)]?.tokens.map((token) =>
+    chains.value[connectedChainIdentifier.value]?.tokens.map((token) =>
       getTokenSelectorOption(token),
     ),
   );


### PR DESCRIPTION
When the user has not connected with his wallet yet, the list of selectable tokens is empty even if he has chosen a source chain. The reason was that the tokens get filtered by the connected chain of the wallet, not the selected chain. But the user tends to first put in some values before connecting. Seeing that no token is available is a bad experience.

This is includes a tiny fix to open the block explorer link in a new tab. This somehow got lost during merge conflict resolution.