### PR TITLE
Withdraw correctly after l1 resolution

### DIFF
--- a/beamer/models/request.py
+++ b/beamer/models/request.py
@@ -34,6 +34,7 @@ class Request(StateMachine):
         self.fill_tx: Optional[HexBytes] = None
         self.fill_id: Optional[FillId] = None
         self.l1_resolution_filler: Optional[ChecksumAddress] = None
+        self.l1_resolution_fill_id: Optional[FillId] = None
 
     pending = State("Pending", initial=True)
     filled = State("Filled")
@@ -59,8 +60,11 @@ class Request(StateMachine):
         self.fill_tx = fill_tx
         self.fill_id = fill_id
 
-    def on_l1_resolve(self, l1_filler: Optional[ChecksumAddress] = None) -> None:
+    def on_l1_resolve(
+        self, l1_filler: Optional[ChecksumAddress] = None, l1_fill_id: Optional[FillId] = None
+    ) -> None:
         self.l1_resolution_filler = l1_filler
+        self.l1_resolution_fill_id = l1_fill_id
 
     @property
     def request_hash(self) -> RequestHash:

--- a/beamer/models/request.py
+++ b/beamer/models/request.py
@@ -46,7 +46,7 @@ class Request(StateMachine):
     fill = pending.to(filled) | filled.to(filled) | ignored.to(filled)
     try_to_fill = pending.to(filled)
     try_to_claim = filled.to(claimed)
-    l1_resolve = claimed.to(l1_resolved) | l1_resolved.to(l1_resolved)
+    l1_resolve = filled.to(l1_resolved) | claimed.to(l1_resolved) | l1_resolved.to(l1_resolved)
     withdraw = (
         claimed.to(withdrawn)
         | filled.to(withdrawn)

--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -278,7 +278,7 @@ def _handle_claim_withdrawn(event: ClaimWithdrawn, context: Context) -> HandlerR
 def _handle_request_resolved(event: RequestResolved, context: Context) -> HandlerResult:
     request = _find_request_by_request_hash(context, event.request_hash)
     if request is not None:
-        request.l1_resolve(event.filler)
+        request.l1_resolve(event.filler, event.fill_id)
         return True, None
 
     return False, None


### PR DESCRIPTION
This changes the withdraw scheme of the agent to withdraw a claim correctly after a request is l1 resolved

The agent needs to take the l1_filler as well as the fill_if into account

partially related to #645