### PR TITLE
Fix call_contracts.py 

### DIFF
--- a/beamer/cli.py
+++ b/beamer/cli.py
@@ -1,12 +1,9 @@
-import json
 import signal
 from pathlib import Path
 from typing import Optional
 
 import click
 import structlog
-from eth_account import Account
-from eth_account.signers.local import LocalAccount
 
 import beamer.contracts
 import beamer.util
@@ -14,14 +11,9 @@ from beamer.agent import Agent
 from beamer.config import Config
 from beamer.l1_resolution import relayer_executable_exists
 from beamer.typing import URL
+from beamer.util import account_from_keyfile
 
 log = structlog.get_logger(__name__)
-
-
-def _account_from_keyfile(keyfile: Path, password: str) -> LocalAccount:
-    with open(keyfile, "rt") as fp:
-        privkey = Account.decrypt(json.load(fp), password)
-    return Account.from_key(privkey)
 
 
 def _sigint_handler(agent: Agent) -> None:
@@ -113,7 +105,7 @@ def main(
     # TODO: use return value and exit if relayer is not available
     relayer_executable_exists()
 
-    account = _account_from_keyfile(keystore_file, password)
+    account = account_from_keyfile(keystore_file, password)
     log.info(f"Using account {account.address}")
     deployment_info = beamer.contracts.load_deployment_info(deployment_dir)
     config = Config(

--- a/beamer/util.py
+++ b/beamer/util.py
@@ -1,10 +1,13 @@
 import json
 import logging
 import sys
+from pathlib import Path
 from typing import Any, List, Optional, TextIO, Union, cast
 
 import requests
 import structlog
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
 from eth_utils import is_checksum_address, to_checksum_address
 from web3.contract import ContractConstructor, ContractFunction
 from web3.exceptions import ContractLogicError
@@ -63,6 +66,12 @@ def setup_logging(log_level: str, log_json: bool) -> None:
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=True,
     )
+
+
+def account_from_keyfile(keyfile: Path, password: str) -> LocalAccount:
+    with open(keyfile, "rt") as fp:
+        privkey = Account.decrypt(json.load(fp), password)
+    return cast(LocalAccount, Account.from_key(privkey))
 
 
 _Token = tuple[ChainId, ChecksumAddress]

--- a/docker/optimism/optimism.sh
+++ b/docker/optimism/optimism.sh
@@ -50,7 +50,8 @@ create_deployment_config_file() {
 
 e2e_test() {
     l2_rpc=http://localhost:8545
-    poetry run python "${ROOT}/scripts/e2e-test.py" ${DEPLOYMENT_DIR} ${KEYFILE} ${l2_rpc}
+    password=""
+    poetry run python "${ROOT}/scripts/e2e-test.py" ${DEPLOYMENT_DIR} ${KEYFILE} "${password}" ${l2_rpc}
 }
 
 usage() {

--- a/scripts/_util.py
+++ b/scripts/_util.py
@@ -1,9 +1,13 @@
+from pathlib import Path
 from typing import Optional
 
 import click
 from eth_utils import decode_hex, is_checksum_address, is_hexstr, to_canonical_address
+from web3 import Web3
+from web3.contract import Contract
 
-from beamer.typing import Address
+import beamer.contracts
+from beamer.typing import Address, ChainId
 
 
 def validate_address(
@@ -27,3 +31,9 @@ def validate_bytes(
         raise click.BadParameter("not a hex string")
 
     return decode_hex(value)
+
+
+def contracts_for_web3(web3: Web3, deployment_dir: Path) -> dict[str, Contract]:
+    deployment_info = beamer.contracts.load_deployment_info(deployment_dir)
+    chain_id = ChainId(web3.eth.chain_id)
+    return beamer.contracts.make_contracts(web3, deployment_info[chain_id])

--- a/scripts/e2e-test.py
+++ b/scripts/e2e-test.py
@@ -10,13 +10,15 @@ from scripts._util import contracts_for_web3
 
 
 def main() -> None:
-    assert len(sys.argv) == 4
+    assert len(sys.argv) == 5
     deployment_dir = Path(sys.argv[1])
     keystore_file = Path(sys.argv[2])
-    l2_rpc = URL(sys.argv[3])
+    password = sys.argv[3]
+    l2_rpc = URL(sys.argv[4])
 
-    deployer = account_from_keyfile(keystore_file, "")
+    deployer = account_from_keyfile(keystore_file, password)
     web3 = make_web3(l2_rpc, deployer)
+
     l2_contracts = contracts_for_web3(web3, deployment_dir)
     chain_id = ChainId(web3.eth.chain_id)
 


### PR DESCRIPTION
`call_contracts.py` did not work because of a misconfigured web3 object. The code from e2e-test and the deployment script was reused to setup web3. 

Since all the 3 scripts share the same code to setup web3, load contract information and create an account, I moved the code to `scripts/_util.py` to remove the redundant code.

fixes: #711 