### PR TITLE
agent: Wait to trigger L1 resolution until finalization

### DIFF
--- a/beamer/events.py
+++ b/beamer/events.py
@@ -47,6 +47,7 @@ class InitiateL1InvalidationEvent(Event):
 
 @dataclass(frozen=True)
 class TxEvent(Event):
+    block_number: BlockNumber
     tx_hash: HexBytes
 
 
@@ -161,6 +162,7 @@ def _decode_event(
     if data.event in _EVENT_TYPES:
         kwargs = {_camel_to_snake(name): value for name, value in data.args.items()}
         kwargs["chain_id"] = chain_id
+        kwargs["block_number"] = log_entry["blockNumber"]
         kwargs["tx_hash"] = log_entry["transactionHash"]
         return _EVENT_TYPES[data.event](**kwargs)
     return None

--- a/beamer/models/claim.py
+++ b/beamer/models/claim.py
@@ -3,7 +3,7 @@ from typing import Optional
 from eth_typing import ChecksumAddress as Address
 from hexbytes import HexBytes
 from statemachine import State, StateMachine
-from web3.types import Wei
+from web3.types import Timestamp, Wei
 
 from beamer.events import ClaimMade
 from beamer.models.request import Request
@@ -26,6 +26,7 @@ class Claim(StateMachine):
         # sending another transaction
         self.transaction_pending = False
         self.invalidation_tx: Optional[HexBytes] = None
+        self.invalidation_timestamp: Optional[Timestamp] = None
 
     started = State("Started", initial=True)
     # Claimer is winning
@@ -114,8 +115,11 @@ class Claim(StateMachine):
         else:
             return Wei(claimer_stake - challenger_stake + 1)
 
-    def on_start_challenge(self, invalidation_tx: HexBytes = None) -> None:
+    def on_start_challenge(
+        self, invalidation_tx: HexBytes = None, invalidation_timestamp: Timestamp = None
+    ) -> None:
         self.invalidation_tx = invalidation_tx
+        self.invalidation_timestamp = invalidation_timestamp
 
     def on_challenge(self, new_claim_made: ClaimMade) -> None:
         self._on_new_claim_made(new_claim_made)

--- a/beamer/models/request.py
+++ b/beamer/models/request.py
@@ -5,6 +5,7 @@ from eth_typing import ChecksumAddress
 from eth_utils import keccak, to_canonical_address
 from hexbytes import HexBytes
 from statemachine import State, StateMachine
+from web3.types import Timestamp
 
 from beamer.typing import ChainId, FillHash, FillId, RequestHash, RequestId, TokenAmount
 
@@ -32,6 +33,7 @@ class Request(StateMachine):
         self.valid_until = valid_until
         self.filler: Optional[ChecksumAddress] = None
         self.fill_tx: Optional[HexBytes] = None
+        self.fill_timestamp: Optional[Timestamp] = None
         self.fill_id: Optional[FillId] = None
         self.l1_resolution_filler: Optional[ChecksumAddress] = None
         self.l1_resolution_fill_id: Optional[FillId] = None
@@ -55,10 +57,17 @@ class Request(StateMachine):
     )
     ignore = pending.to(ignored) | filled.to(ignored)
 
-    def on_fill(self, filler: ChecksumAddress, fill_tx: HexBytes, fill_id: FillId) -> None:
+    def on_fill(
+        self,
+        filler: ChecksumAddress,
+        fill_tx: HexBytes,
+        fill_id: FillId,
+        fill_timestamp: Timestamp,
+    ) -> None:
         self.filler = filler
         self.fill_tx = fill_tx
         self.fill_id = fill_id
+        self.fill_timestamp = fill_timestamp
 
     def on_l1_resolve(
         self, l1_filler: Optional[ChecksumAddress] = None, l1_fill_id: Optional[FillId] = None

--- a/beamer/tests/agent/test_request.py
+++ b/beamer/tests/agent/test_request.py
@@ -13,6 +13,7 @@ from beamer.chain import maybe_challenge
 from beamer.events import ClaimMade, RequestFilled
 from beamer.models.claim import Claim
 from beamer.models.request import Request
+from beamer.tests.agent.unit.utils import BLOCK_NUMBER
 from beamer.tests.util import HTTPProxy, Sleeper, Timeout, alloc_accounts, make_request
 from beamer.typing import ChainId, ClaimId, FillId, RequestId, Termination, TokenAmount
 
@@ -108,6 +109,7 @@ def test_challenge_own_claim(config, request_manager, token):
             last_challenger=ZERO_ADDRESS,
             challenger_stake_total=Wei(0),
             termination=Termination(1700000000),
+            block_number=BLOCK_NUMBER,
         ),
         int(time.time()),
     )
@@ -235,6 +237,7 @@ def test_agent_ignores_invalid_fill(_, request_manager, token, agent: Agent):
                 target_token_address=token,
                 filler=filler,
                 amount=amount - 1,
+                block_number=brownie.web3.eth.block_number,
             ),
         ]
     )
@@ -253,6 +256,7 @@ def test_agent_ignores_invalid_fill(_, request_manager, token, agent: Agent):
                 target_token_address=token,
                 filler=filler,
                 amount=amount,
+                block_number=brownie.web3.eth.block_number,
             ),
         ]
     )
@@ -271,6 +275,7 @@ def test_agent_ignores_invalid_fill(_, request_manager, token, agent: Agent):
                 target_token_address=filler,
                 filler=filler,
                 amount=amount,
+                block_number=brownie.web3.eth.block_number,
             ),
         ]
     )
@@ -289,6 +294,7 @@ def test_agent_ignores_invalid_fill(_, request_manager, token, agent: Agent):
                 target_token_address=token,
                 filler=filler,
                 amount=amount,
+                block_number=brownie.web3.eth.block_number,
             ),
         ]
     )

--- a/beamer/tests/agent/unit/test_handlers.py
+++ b/beamer/tests/agent/unit/test_handlers.py
@@ -136,7 +136,6 @@ def test_handle_request_resolved():
 
 def test_handle_generate_l1_resolution_event():
     context, config = make_context()
-    context.request_manager.functions.finalizationTimes().call.return_value = 1_000  # type: ignore
 
     request = make_request()
     request.fill(config.account.address, b"", b"", TIMESTAMP)
@@ -154,17 +153,13 @@ def test_handle_generate_l1_resolution_event():
     flag, events = process_event(event, context)
 
     assert flag
-
-    if timestamp == TIMESTAMP:
-        assert events == [
-            InitiateL1ResolutionEvent(
-                chain_id=TARGET_CHAIN_ID,
-                request_id=REQUEST_ID,
-                claim_id=CLAIM_ID,
-            )
-        ]
-    else:
-        assert events == []
+    assert events == [
+        InitiateL1ResolutionEvent(
+            chain_id=TARGET_CHAIN_ID,
+            request_id=REQUEST_ID,
+            claim_id=CLAIM_ID,
+        )
+    ]
 
 
 def test_maybe_claim_no_l1():

--- a/beamer/tests/agent/unit/test_invalidate.py
+++ b/beamer/tests/agent/unit/test_invalidate.py
@@ -212,7 +212,6 @@ def test_maybe_withdraw_after_invalidation(mocked_withdraw, test_data):
 @pytest.mark.parametrize("timestamp", [TIMESTAMP, int(time.time())])
 def test_handle_generate_l1_invalidation_event(timestamp):
     context, config = make_context()
-    context.request_manager.functions.finalizationTimes().call.return_value = 1_000  # type: ignore
 
     request = make_request()
     context.requests.add(request.id, request)
@@ -229,12 +228,9 @@ def test_handle_generate_l1_invalidation_event(timestamp):
 
     assert flag
 
-    if timestamp == TIMESTAMP:
-        assert events == [
-            InitiateL1InvalidationEvent(
-                chain_id=TARGET_CHAIN_ID,
-                claim_id=CLAIM_ID,
-            )
-        ]
-    else:
-        assert events == []
+    assert events == [
+        InitiateL1InvalidationEvent(
+            chain_id=TARGET_CHAIN_ID,
+            claim_id=CLAIM_ID,
+        )
+    ]

--- a/beamer/tests/agent/unit/test_l1.py
+++ b/beamer/tests/agent/unit/test_l1.py
@@ -7,6 +7,7 @@ from beamer.tests.agent.unit.utils import (
     CLAIM_ID,
     REQUEST_ID,
     TARGET_CHAIN_ID,
+    TIMESTAMP,
     make_claim_challenged,
     make_context,
     make_request,
@@ -38,7 +39,7 @@ def test_handle_initiate_l1_resolution():
 
     # Check that task is added to resolution pool
     context.web3_l1.eth.gas_price = Wei(1)  # type: ignore
-    request.fill(config.account.address, b"", b"")
+    request.fill(config.account.address, b"", b"", TIMESTAMP)
     request.try_to_claim()
     assert process_event(event, context) == (True, None)
     assert context.task_pool.submit.called  # type: ignore  # pylint:disable=no-member
@@ -67,6 +68,6 @@ def test_handle_initiate_l1_invalidation():
 
     # Check that task is added to resolution pool
     context.web3_l1.eth.gas_price = Wei(1)  # type: ignore
-    claim.start_challenge(make_tx_hash())
+    claim.start_challenge(make_tx_hash(), TIMESTAMP)
     assert process_event(event, context) == (True, None)
     assert context.task_pool.submit.called  # type: ignore  # pylint:disable=no-member

--- a/beamer/tests/agent/unit/utils.py
+++ b/beamer/tests/agent/unit/utils.py
@@ -32,6 +32,7 @@ ZERO_STAKE = Wei(0)
 
 TERMINATION = Termination(1)
 TIMESTAMP = Timestamp(457)
+BLOCK_NUMBER = BlockNumber(12345)
 
 ACCOUNT = Account.from_key(0xB25C7DB31FEED9122727BF0939DC769A96564B2DE4C4726D035B36ECF1E5B364)
 ADDRESS1 = make_address()
@@ -110,6 +111,7 @@ def make_claim_challenged(
             last_challenger=challenger,
             challenger_stake_total=challenger_stake,
             termination=termination,
+            block_number=BLOCK_NUMBER,
         ),
         challenge_back_off_timestamp=123,
     )

--- a/beamer/util.py
+++ b/beamer/util.py
@@ -13,6 +13,9 @@ from web3.types import TxParams
 from beamer.typing import ChainId, ChecksumAddress
 
 
+SECONDS_PER_DAY = 24 * 60 * 60
+
+
 class TransactionFailed(Exception):
     def __repr__(self) -> str:
         return "TransactionFailed(%r)" % self.__cause__

--- a/beamer/util.py
+++ b/beamer/util.py
@@ -13,9 +13,6 @@ from web3.types import TxParams
 from beamer.typing import ChainId, ChecksumAddress
 
 
-SECONDS_PER_DAY = 24 * 60 * 60
-
-
 class TransactionFailed(Exception):
     def __repr__(self) -> str:
         return "TransactionFailed(%r)" % self.__cause__


### PR DESCRIPTION
Resolves #749

Delay calling the relayer until the finalization period is over.

I decided to store the timestamps in the request and claim objects instead of recalculating it from the transaction every time to save some rpc requests.
