### PR TITLE
relayer: Shutdown on ppid change

### DIFF
--- a/.github/workflows/relayer.yml
+++ b/.github/workflows/relayer.yml
@@ -38,3 +38,14 @@ jobs:
       - name: Lint
         working-directory: relayer/
         run: yarn lint
+
+      - name: Build bundle
+        working-directory: relayer/
+        run: |
+          yarn add pkg
+          yarn run pkg -t node16-linux-x64 -o relayer build/src/service.js
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: relayer
+          path: relayer/relayer


### PR DESCRIPTION
The relayer should shut down when the agent crashes for whatever reason.
In that case the relayer process will be reattached to a process higher
in the process tree. This is used to check for the ppid, and shutdown in
case it changes.

Resolves #748 

Also adds basic bundling to the relayer.
Resolves #609