### PR TITLE
Fix UI flashing

### DIFF
--- a/frontend/src/components/inputs/Selector.vue
+++ b/frontend/src/components/inputs/Selector.vue
@@ -72,6 +72,10 @@ const props = defineProps<Props>();
   @apply mt-0 pl-8 border-0 text-2xl text-teal;
 }
 
+.selector.vs--disabled .vs__search {
+  background-color: inherit;
+}
+
 .selector .vs__dropdown-option {
   @apply px-8;
 }
@@ -102,6 +106,10 @@ const props = defineProps<Props>();
 
 .selector .vs__open-indicator {
   @apply fill-teal;
+}
+
+.selector.vs--disabled .vs__open-indicator {
+  background-color: inherit;
 }
 
 .selector .vs__fade-enter-active,


### PR DESCRIPTION
When submitting a request the UI input was being set to disabled. Unfortunately this caused the UI to "glitch" since the input field and selector dropdown icon backgroudns were white.

By inheriting the background-color from the parent elements the UI stays the same when disabled and one no longer has the feeling that the app is broken.

Without the changes:

<img width="435" alt="image" src="https://user-images.githubusercontent.com/693770/175791007-d45ff628-681f-4b49-8605-22d88cf8f447.png">

With the changes:
<img width="466" alt="image" src="https://user-images.githubusercontent.com/693770/175791034-3af0fc5d-dd3c-4771-8908-084044d498a4.png">

the fields are still disabled and if the user goes with the mouse over them he would receive the normal feedback that he cannot do anything in the field.