### PR TITLE
beamer: don't expect there will be a request if we encounter a claim

### DIFF
--- a/beamer/tests/agent/unit/test_handlers.py
+++ b/beamer/tests/agent/unit/test_handlers.py
@@ -130,8 +130,8 @@ def test_handle_request_resolved():
         block_number=BLOCK_NUMBER,
     )
 
-    # Without a request, this must fail
-    assert process_event(event, context) == (False, None)
+    # Without a request, we simply drop the event
+    assert process_event(event, context) == (True, None)
 
     # Adding the request and claim to context
     context.requests.add(request.id, request)

--- a/beamer/tests/agent/unit/test_l1.py
+++ b/beamer/tests/agent/unit/test_l1.py
@@ -31,8 +31,8 @@ def test_handle_initiate_l1_resolution(timestamp):
         claim_id=CLAIM_ID,
     )
 
-    # Without a claim, this must fail
-    assert process_event(event, context) == (False, None)
+    # Without a claim, we simply drop the event
+    assert process_event(event, context) == (True, None)
 
     claim = make_claim_challenged(request, claimer=config.account.address)
     context.claims.add(claim.id, claim)
@@ -67,8 +67,8 @@ def test_handle_initiate_l1_invalidation(timestamp):
         claim_id=CLAIM_ID,
     )
 
-    # Without a claim, this must fail
-    assert process_event(event, context) == (False, None)
+    # Without a claim, we simply drop the event
+    assert process_event(event, context) == (True, None)
 
     claim = make_claim_challenged(request, claimer=config.account.address)
     context.claims.add(claim.id, claim)


### PR DESCRIPTION
We may have ignored a request (e.g. due to an unsupported token pair) so
we need to be able to handle cases where we see claims for requests we
do not have. Note that we already do this in _handle_claim_withdrawn.

Fixes: #810 