### PR TITLE
Agent packaging

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -1,0 +1,48 @@
+name: Agent Packaging
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'false'
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Bundle relayer
+        working-directory: relayer/
+        run: |
+          yarn install
+          yarn build
+          yarn add pkg
+          yarn run pkg -t node16-linux-x64 -o relayer-node16-linux-x64 build/src/service.js
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - uses: Gr1N/setup-poetry@v7
+
+      - name: Cache Python packages
+        id: cache-python-packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: poetry-${{ runner.os }}-${{ hashFiles('.github/workflows/agent-release.yml', 'poetry.lock') }}
+
+      - name: Build agent package
+        run: |
+          cp relayer/relayer-node16-linux-x64 beamer/data/relayers
+          poetry install
+          poetry build
+          poetry publish -u '__token__' -p ${{ secrets.PIP_PASSWORD }}

--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -26,6 +26,7 @@ jobs:
           yarn build
           yarn add pkg
           yarn run pkg -t node16-linux-x64 -o relayer-node16-linux-x64 build/src/service.js
+          yarn run pkg -t node16-macos-x64 -o relayer-node16-macos-x64 build/src/service.js
 
       - uses: actions/setup-python@v4
         with:
@@ -43,6 +44,7 @@ jobs:
       - name: Build agent package
         run: |
           cp relayer/relayer-node16-linux-x64 beamer/data/relayers
+          cp relayer/relayer-node16-macos-x64 beamer/data/relayers
           poetry install
           poetry build
           poetry publish -u '__token__' -p ${{ secrets.PIP_PASSWORD }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.local
-          key: dotlocal-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml', 'poetry.lock') }}
+          key: dotlocal-${{ runner.os }}-${{ hashFiles('.github/workflows/backend.yml', 'poetry.lock') }}
 
       - uses: Gr1N/setup-poetry@v7
 
@@ -47,7 +47,7 @@ jobs:
           path: |
             ~/.cache/pypoetry/virtualenvs
             ~/.solcx
-          key: poetry-1-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml', 'poetry.lock') }}
+          key: poetry-1-${{ runner.os }}-${{ hashFiles('.github/workflows/backend.yml', 'poetry.lock') }}
 
       - name: Install ganache
         run: npm install ganache --global

--- a/beamer/cli.py
+++ b/beamer/cli.py
@@ -103,7 +103,7 @@ def main(
 ) -> None:
     beamer.util.setup_logging(log_level=log_level.upper(), log_json=False)
 
-    if get_relayer_executable() is None:
+    if not get_relayer_executable().exists():
         log.error("No relayer found")
         sys.exit(1)
 

--- a/beamer/cli.py
+++ b/beamer/cli.py
@@ -1,4 +1,5 @@
 import signal
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -9,7 +10,7 @@ import beamer.contracts
 import beamer.util
 from beamer.agent import Agent
 from beamer.config import Config
-from beamer.l1_resolution import relayer_executable_exists
+from beamer.l1_resolution import get_relayer_executable
 from beamer.typing import URL
 from beamer.util import account_from_keyfile
 
@@ -102,8 +103,9 @@ def main(
 ) -> None:
     beamer.util.setup_logging(log_level=log_level.upper(), log_json=False)
 
-    # TODO: use return value and exit if relayer is not available
-    relayer_executable_exists()
+    if get_relayer_executable() is None:
+        log.error("No relayer found")
+        sys.exit(1)
 
     account = account_from_keyfile(keystore_file, password)
     log.info(f"Using account {account.address}")

--- a/beamer/l1_resolution.py
+++ b/beamer/l1_resolution.py
@@ -28,7 +28,7 @@ def get_relayer_executable() -> Optional[Path]:
         log.debug("Found relayer executable", relayer=maybe_relayer)
         return maybe_relayer.resolve()
 
-    log.warning("No relayer executable found")
+    log.warning("No relayer executable found", directory=bin_dir)
     return None
 
 

--- a/beamer/l1_resolution.py
+++ b/beamer/l1_resolution.py
@@ -2,7 +2,6 @@ import subprocess
 import sys
 
 from pathlib import Path
-from typing import Optional
 import structlog
 from hexbytes import HexBytes
 
@@ -14,28 +13,21 @@ log = structlog.get_logger(__name__)
 _RELAYER_NAMES = {"linux": "relayer-node16-linux-x64", "darwin": "relayer-node16-macos-x64"}
 
 
-def get_relayer_executable() -> Optional[Path]:
-    """Returns the path to the relayer executable if available, otherwise `None`"""
+def get_relayer_executable() -> Path:
+    """Returns the path to the relayer executable.
+    Callers must check that the executable exists before using it."""
+    name = _RELAYER_NAMES.get(sys.platform)
+    if name is None:
+        raise RuntimeError(f"Unsupported platform: {sys.platform}")
 
-    bin_dir = Path(__file__).parent.joinpath("data/relayers/")
-    try:
-        maybe_relayer = bin_dir.joinpath(_RELAYER_NAMES[sys.platform])
-    except KeyError:
-        log.warning("Unsupported platform", platform=sys.platform)
-        return None
-
-    if maybe_relayer.exists():
-        log.debug("Found relayer executable", relayer=maybe_relayer)
-        return maybe_relayer.resolve()
-
-    log.warning("No relayer executable found", directory=bin_dir)
-    return None
+    path = Path(__file__).parent.joinpath(f"data/relayers/{name}")
+    return path.resolve()
 
 
 def run_relayer_for_tx(l1_rpc: URL, l2_rpc: URL, privkey: str, tx_hash: HexBytes) -> None:
     relayer = get_relayer_executable()
 
-    if relayer is None:
+    if not relayer.exists():
         log.error("No relayer found")
         sys.exit(1)
 

--- a/beamer/tests/agent/test_cli.py
+++ b/beamer/tests/agent/test_cli.py
@@ -2,6 +2,7 @@ import json
 import pathlib
 import shutil
 import signal
+import sys
 
 import brownie
 import eth_account
@@ -9,6 +10,7 @@ import pytest
 from click.testing import CliRunner
 
 from beamer.cli import main
+from beamer.l1_resolution import _RELAYER_NAMES
 from beamer.util import TokenMatchChecker
 
 
@@ -38,6 +40,23 @@ def _generate_deployment_dir(output_dir, root, contracts):
     shutil.copy(src / "ResolutionRegistry.json", output_dir)
 
 
+@pytest.fixture
+def setup_relayer_executable():
+    target = pathlib.Path(__file__).parent.parent.parent.joinpath("data/relayers/")
+    target.mkdir(parents=True, exist_ok=True)
+
+    executable = target / _RELAYER_NAMES[sys.platform]
+    if executable.exists():
+        return
+
+    executable.write_text("text")
+
+    yield
+
+    executable.unlink()
+
+
+@pytest.mark.usefixtures("setup_relayer_executable")
 def test_cli(config, tmp_path, contracts):
     key = "0x3ff6c8dfd3ab60a14f2a2d4650387f71fe736b519d990073e650092faaa621fa"
     acc = eth_account.Account.from_key(key)

--- a/beamer/tests/agent/test_cli.py
+++ b/beamer/tests/agent/test_cli.py
@@ -2,7 +2,6 @@ import json
 import pathlib
 import shutil
 import signal
-import sys
 
 import brownie
 import eth_account
@@ -10,7 +9,7 @@ import pytest
 from click.testing import CliRunner
 
 from beamer.cli import main
-from beamer.l1_resolution import _RELAYER_NAMES
+from beamer.l1_resolution import get_relayer_executable
 from beamer.util import TokenMatchChecker
 
 
@@ -42,18 +41,15 @@ def _generate_deployment_dir(output_dir, root, contracts):
 
 @pytest.fixture
 def setup_relayer_executable():
-    target = pathlib.Path(__file__).parent.parent.parent.joinpath("data/relayers/")
-    target.mkdir(parents=True, exist_ok=True)
-
-    executable = target / _RELAYER_NAMES[sys.platform]
-    if executable.exists():
+    relayer = get_relayer_executable()
+    if relayer.exists():
+        yield
         return
 
-    executable.write_text("text")
-
+    relayer.parent.mkdir(parents=True, exist_ok=True)
+    relayer.write_text("")
     yield
-
-    executable.unlink()
+    relayer.unlink()
 
 
 @pytest.mark.usefixtures("setup_relayer_executable")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,16 @@
 [tool.poetry]
-name = "beamer"
+name = "beamer-bridge"
 version = "0.0.1"
 description = "Bridging rollups with L1 guaranteed security"
-authors = ["brainbot technologies"]
+authors = ["Beamer Bridge Team <contact@beamerbridge.com>"]
 license = "MIT"
+readme = "README.md"
+homepage = "https://www.beamerbridge.com/"
+repository = "https://github.com/beamer-bridge/beamer"
+documentation = "https://docs.beamerbridge.com/"
+packages = [
+    { include = "beamer" },
+]
 
 [tool.poetry.dependencies]
 python = ">=3.9, <3.10"


### PR DESCRIPTION
Ref #739 

This PR adds basic packaging to the agent.
This is done by creating a bundled version of the relayer and including that in the agent package. The code to get the relayer executable is changed, so that it can find the bundles version.

Tested in a local VM:
```
Python 3.9.13 (main, Jun 23 2022, 11:12:54)
Type 'copyright', 'credits' or 'license' for more information
IPython 8.4.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import beamer.l1_resolution

In [2]: beamer.l1_resolution.get_relayer_executable()
2022-06-29 11:53.45 [debug    ] Found packaged relayer         relayer=PosixPath('/abc/venv/lib/python3.9/site-packages/beamer/data/bin/relayer-node16-linux-x64')
Out[2]: PosixPath('/abc/venv/lib/python3.9/site-packages/beamer/data/bin/relayer-node16-linux-x64')
```