### PR TITLE
ci: Remove dependabot for relayer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-
-  - package-ecosystem: "npm"
-    directory: "/relayer/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
This takes to much time, it's better to do it once in  a while by hand.