### PR TITLE
frontend: fix issue of a too low token allowance

### DIFF
--- a/frontend/src/actions/transfers/transfer.ts
+++ b/frontend/src/actions/transfers/transfer.ts
@@ -226,11 +226,13 @@ export class Transfer extends MultiStepAction implements Encodable<TransferData>
       throw new Error('Missing wallet connection!');
     }
 
+    const totalAmount = this.sourceAmount.uint256.add(this.fees.uint256);
+
     await ensureTokenAllowance(
       signer,
       this.sourceAmount.token.address,
       this.sourceChain.requestManagerAddress,
-      this.sourceAmount.uint256,
+      totalAmount,
     );
   }
 

--- a/frontend/tests/unit/actions/transfers/transfer.spec.ts
+++ b/frontend/tests/unit/actions/transfers/transfer.spec.ts
@@ -148,8 +148,9 @@ describe('transfer', () => {
       return expect(transfer.ensureTokenAllowance()).rejects.toThrow('Missing wallet connection!');
     });
 
-    it('calls the token utility function for the source token', async () => {
+    it('makes a call to set the allowance for the source token with minimum value of source amount plus fees ', async () => {
       const data = generateTransferData({
+        fees: generateTokenAmountData({ amount: '2' }),
         sourceChain: generateChain({ requestManagerAddress: '0xRequestManager' }),
         sourceAmount: generateTokenAmountData({
           token: generateToken({ address: '0xSourceToken' }),
@@ -166,7 +167,7 @@ describe('transfer', () => {
         signer,
         '0xSourceToken',
         '0xRequestManager',
-        new UInt256('1'),
+        new UInt256('3'),
       );
     });
   });


### PR DESCRIPTION
Fixes #854

How to verify the bug got fixed:
- use first an old version of the frontend
- use an account not used yet for Beamer (in fact that has no token allowance for the request manager contract)
- transfer some ETH to this account
- connect the app to the account
- mint some test tokens for this account
- send all tokens to a different account accept 2
- try to make a transfer of 1 TST
  - this will set the allowance to 2, as currently it is 0, is needs 1 and sets it to the current token balance of the user
  - the allowance step should be green
  - the request transaction step should fail (error in UI is `insufficient balance`)
  - the error in the console should reveal the contract reverted message because the token allowance is too low
  - this could be repeated, the allowance step gets skipped, because the allowance of 2 is greater than 1

- use this fixed version now
- send back all the TST tokens to the active account
- try to make another transfer of 1 TST
- it should now increase the allowance it requires a minimum of 6 (1TST transfer plus 5 TST fees)
- request transaction should succeed