### PR TITLE
frontend: Fix transfer history lazy loading

### DIFF
--- a/frontend/src/components/TransferHistory.vue
+++ b/frontend/src/components/TransferHistory.vue
@@ -16,27 +16,22 @@
         <span>Nothing here yet.</span>
       </div>
 
-      <LazyWrapper
-        v-for="group of groupedAndSortedTransfers"
-        :key="group.label"
-        :root-element="listElement"
-        :threshold="0.0"
-        class="mb-12"
-        data-test="transfer-group"
-      >
-        <div v-if="group.transfers.length > 0" class="text-2xl text-center">
-          {{ group.label }}
-        </div>
-
-        <LazyWrapper :threshold="0.0">
-          <TransferComponent
-            v-for="(transfer, groupTransferIndex) of group.transfers"
-            :key="transfer.requestInformation?.identifier?.asString ?? groupTransferIndex"
-            :transfer="transfer"
-            class="my-3"
-          />
+      <template v-for="group of groupedAndSortedTransfers" :key="group.label">
+        <LazyWrapper :root-element="listElement" :threshold="0.0">
+          <div v-if="group.transfers.length > 0" class="text-2xl text-center">
+            {{ group.label }}
+          </div>
         </LazyWrapper>
-      </LazyWrapper>
+        <LazyWrapper
+          v-for="(transfer, groupTransferIndex) of group.transfers"
+          :key="transfer.requestInformation?.identifier?.asString ?? groupTransferIndex"
+          :threshold="0.0"
+          :root-element="listElement"
+        >
+          <TransferComponent :transfer="transfer" class="my-3" data-test="transfer" />
+        </LazyWrapper>
+        <div v-if="group.transfers.length > 0" class="h-12"></div>
+      </template>
     </div>
 
     <!-- Bottom gradient to create phase out effect for scrolling content. -->

--- a/frontend/tests/unit/components/TransferHistory.spec.ts
+++ b/frontend/tests/unit/components/TransferHistory.spec.ts
@@ -70,9 +70,9 @@ describe('TransferHistory.vue', () => {
       }),
     });
     const wrapper = await createWrapper();
-    const transferGroups = wrapper.findAll('[data-test="transfer-group"]');
+    const transfers = wrapper.findAll('[data-test="transfer"]');
 
-    expect(transferGroups).toHaveLength(2);
+    expect(transfers).toHaveLength(2);
     expect(wrapper.text()).toContain('window one');
     expect(wrapper.text()).toContain('window two');
   });


### PR DESCRIPTION
Closes #851 

Every transfer group label and every transfer element is now wrapped in a LazyWrapper itself. This fixes the problem that a user needed to scroll to the label to see the whole group. Also, this removes the overhead of every transfer being added to the DOM when the respective group is displayed. As all transfers go eventually into the "older" group, this could have been an performance issue in my opinion.

I would like to have the opinion of @weilbith next week when he is back on this PR. This bug is nothing critical, so this should be fine. I am just wondering how he intended the LazyWrapper to be uses, because my version will create an extra div for every element.