### PR TITLE
frontend: Add target address prefill function

### DIFF
--- a/frontend/src/components/RequestDialog.vue
+++ b/frontend/src/components/RequestDialog.vue
@@ -157,7 +157,10 @@ function parseTokenFromChainConfiguration(
 
 function resetForm() {
   requestSource.value = EMPTY_SOURCE_DATA;
-  requestTarget.value = EMPTY_TARGET_DATA;
+  requestTarget.value = {
+    ...EMPTY_TARGET_DATA,
+    toAddress: requestTarget.value.toAddress === signerAddress.value ? signerAddress.value : '',
+  };
 }
 
 watch(chainId, (_, oldChainId) => {
@@ -166,9 +169,16 @@ watch(chainId, (_, oldChainId) => {
   }
 });
 
-const checkboxClasses = `appearance-none h-7 w-7 bg-teal-light shadow-inner rounded-md 
-hover:opacity-90 
-checked:after:content-['\\2713'] checked:after:text-teal 
+watch(signerAddress, (currSignerAddress, prevSignerAddress) => {
+  const toAddress = requestTarget.value.toAddress;
+
+  if (!toAddress || toAddress === prevSignerAddress)
+    requestTarget.value = { ...requestTarget.value, toAddress: currSignerAddress ?? '' };
+});
+
+const checkboxClasses = `appearance-none h-7 w-7 bg-teal-light shadow-inner rounded-md
+hover:opacity-90
+checked:after:content-['\\2713'] checked:after:text-teal
 checked:after:text-4xl checked:after:leading-7`;
 </script>
 

--- a/frontend/src/components/RequestTargetInputs.vue
+++ b/frontend/src/components/RequestTargetInputs.vue
@@ -65,8 +65,8 @@ const configuration = useConfiguration();
 
 const { chains } = storeToRefs(configuration);
 
-const selectedTargetChain = ref<SelectorOption<Chain> | null>(null);
-const selectedTargetAddress = ref('');
+const selectedTargetChain = ref<SelectorOption<Chain> | null>(props.modelValue.targetChain);
+const selectedTargetAddress = ref(props.modelValue.toAddress);
 
 const ignoreChains = computed(() =>
   process.env.NODE_ENV === 'development' || !props.sourceChain ? [] : [props.sourceChain.value],


### PR DESCRIPTION
Fixes #878

The target address input inside the request form is now reacting
and prefilling the value for the user on wallet address change
(connect/disconnect).
When the user manually entered a different address than his currently
connected wallet address the input will not be touched until
input value was cleared.