### PR TITLE
docs: update outdated "contributing" docs

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -23,7 +23,7 @@ Then enter the virtual environment::
 
 Compile the contracts::
 
-    pushd contracts && brownie compile && popd
+    brownie compile
 
 Start ganache::
 
@@ -40,7 +40,8 @@ Deploy the contracts on the local ganache test chain::
     python scripts/deployment/main.py --keystore-file 0x1CEE82EEd89Bd5Be5bf2507a92a755dcF1D8e8dc.json \
                                       --password '' \
                                       --output-dir deployments/ganache-local \
-                                      --config-file scripts/deployment/ganache-local.json
+                                      --config-file scripts/deployment/ganache-local.json \
+                                      --deploy-mintable-token
 
 Generate the token match file::
 


### PR DESCRIPTION
Aligned contract compile command to the latest directory structure.
Added missing argument inside contract deploy command which will enable
deploying the mintable token by default.