### PR TITLE
beamer: events: convert received bytes to HexBytes

### DIFF
--- a/beamer/events.py
+++ b/beamer/events.py
@@ -166,6 +166,17 @@ def _make_topics_to_abi(contract: Contract) -> dict[bytes, ABIEvent]:
     return event_abis
 
 
+def _convert_bytes(kwargs: dict) -> None:
+    for name, type_ in (
+        ("fill_id", FillId),
+        ("fill_hash", FillHash),
+        ("request_hash", RequestHash),
+    ):
+        value = kwargs.get(name)
+        if value is not None:
+            kwargs[name] = type_(value)
+
+
 def _decode_event(
     codec: ABICodec, log_entry: LogReceipt, chain_id: ChainId, event_abis: dict[bytes, ABIEvent]
 ) -> Optional[Event]:
@@ -177,6 +188,7 @@ def _decode_event(
         kwargs["chain_id"] = chain_id
         kwargs["block_number"] = log_entry["blockNumber"]
         kwargs["tx_hash"] = log_entry["transactionHash"]
+        _convert_bytes(kwargs)
         return _EVENT_TYPES[data.event](**kwargs)
     return None
 

--- a/beamer/tests/constants.py
+++ b/beamer/tests/constants.py
@@ -1,8 +1,8 @@
 # TODO: Extend and make it smarter to get fields of structs in the contracts
 from beamer.typing import FillId
 
-FILL_ID = FillId(b"00000000000000000000000000000abc")
-FILL_ID_EMPTY = FillId(bytes(bytearray(32)))
+FILL_ID = FillId("abc".zfill(64))
+FILL_ID_EMPTY = FillId(bytes(32))
 
 # request fields
 RM_R_FIELD_LP_FEE = 9

--- a/beamer/typing.py
+++ b/beamer/typing.py
@@ -7,12 +7,29 @@ from eth_typing import (  # NOQA pylint:disable=unused-import
     HexAddress,
 )
 
+from hexbytes import HexBytes
+
+
+class _HexBytes(HexBytes):
+    def __repr__(self) -> str:
+        return "%s(%r)" % (type(self).__name__, self.hex())
+
+
+class FillId(_HexBytes):
+    pass
+
+
+class FillHash(_HexBytes):
+    pass
+
+
+class RequestHash(_HexBytes):
+    pass
+
+
 ChainId = NewType("ChainId", int)
 ClaimId = NewType("ClaimId", int)
 RequestId = NewType("RequestId", int)
-FillId = NewType("FillId", bytes)
-RequestHash = NewType("RequestHash", bytes)
-FillHash = NewType("FillHash", bytes)
 PrivateKey = NewType("PrivateKey", bytes)
 TokenAmount = NewType("TokenAmount", int)
 URL = NewType("URL", str)

--- a/beamer/typing.py
+++ b/beamer/typing.py
@@ -30,7 +30,6 @@ class RequestHash(_HexBytes):
 ChainId = NewType("ChainId", int)
 ClaimId = NewType("ClaimId", int)
 RequestId = NewType("RequestId", int)
-PrivateKey = NewType("PrivateKey", bytes)
 TokenAmount = NewType("TokenAmount", int)
 URL = NewType("URL", str)
 Termination = NewType("Termination", int)


### PR DESCRIPTION
This improves the log output of fill IDs.
~(`fill_id` is typed as `FillId`, which is a newtype of `Hexbytes`, but we get `bytes` instances from `web3`, which means we must convert them)~

We need to convert received `bytes` from `web3` to proper `FillId` which is derived from `HexBytes` to improve repr.