### PR TITLE
First part of circle ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,3 +83,18 @@ jobs:
       - initialize-environment
       - run: make lint
 
+workflows:
+  backend:
+    jobs:
+      - checkout
+      - install-npm-packages
+      - install-python:
+          requires:
+            - checkout
+      - create-relayers:
+          requires:
+            - checkout
+      - lint:
+          requires:
+            - install-python
+            - install-npm-packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,3 +43,14 @@ jobs:
           root: "~"
           paths:
             - ".cache/pypoetry/virtualenvs"
+
+  create-relayers:
+    executor: node
+    steps:
+      - attach_workspace:
+          at: "~"
+      - run: make relayers
+      - persist_to_workspace:
+          root: "."
+          paths:
+            - "relayer"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,3 +76,10 @@ jobs:
           root: "~"
           paths:
             - ".nvm"
+
+  lint:
+    executor: python
+    steps:
+      - initialize-environment
+      - run: make lint
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2.1
+
+executors:
+  python:
+    docker:
+      - image: cimg/python:3.9.13
+    working_directory: ~/beamer
+
+  node:
+    docker:
+      - image: cimg/node:16.16
+    working_directory: ~/beamer
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,3 +20,26 @@ jobs:
           root: "~"
           paths:
             - beamer
+
+  install-python:
+    executor: python
+    environment:
+      SHELL: "/bin/bash"
+    steps:
+      - attach_workspace:
+          at: "~"
+      - run: pip install -U poetry
+      - restore_cache:
+          keys:
+            - beamer-dependencies-v1-{{ checksum "poetry.lock" }}
+            - beamer-dependencies-v1
+      - run: poetry install
+      - save_cache:
+          key:
+            beamer-dependencies-v1-{{ checksum "poetry.lock" }}
+          paths:
+            - "~/.cache/pypoetry/virtualenvs"
+      - persist_to_workspace:
+          root: "~"
+          paths:
+            - ".cache/pypoetry/virtualenvs"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,3 +11,12 @@ executors:
       - image: cimg/node:16.16
     working_directory: ~/beamer
 
+jobs:
+  checkout:
+    executor: python
+    steps:
+      - checkout
+      - persist_to_workspace:
+          root: "~"
+          paths:
+            - beamer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,14 @@
 version: 2.1
 
+commands:
+  initialize-environment:
+    steps:
+      - attach_workspace:
+          at: "~"
+      - run:
+         name: Configuring virtual environment activation
+         command: echo 'export PATH=$(poetry env info -p)/bin:~/.nvm/versions/node/v16.16.0/bin:${PATH}' >> ${BASH_ENV}
+
 executors:
   python:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,3 +54,16 @@ jobs:
           root: "."
           paths:
             - "relayer"
+
+  install-npm-packages:
+    executor: node
+    steps:
+      - attach_workspace:
+          at: "~"
+      - run: npm install prettier prettier-plugin-solidity --location=global
+      - run: npm install solhint --location=global
+      - run: npm install ganache --location=global
+      - persist_to_workspace:
+          root: "~"
+          paths:
+            - ".nvm"


### PR DESCRIPTION
Since the webhook to circle ci was introduced it blocks PRs. Unfortunately the only way to test circle ci is via github pushing to a branch and then let the CI run. 

To not block other PRs this is the first part of circle CIs config. It runs until lint. 
Until the config is complete we simply let circle and github CI run. 