### PR TITLE
relayer: use Promise.race instead of Promise.any

### DIFF
--- a/relayer/src/service.ts
+++ b/relayer/src/service.ts
@@ -120,7 +120,7 @@ if (require.main === module) {
   const service = new MessageRelayerService();
 
   try {
-    Promise.any([
+    Promise.race([
       service.run(),
       returnOnPpidChange(startPpid),
     ]);


### PR DESCRIPTION
The latter will block until one of the promises is fulfilled, or all are
rejected. Since the returnOnPpidChange never rejects, this means the
relayer will be forever stuck in case the main promise rejects (i.e.
throws). Promise.race will instead return as soon as one promise is
rejected, which is what we want here.

Closes: #891.