### PR TITLE
Frontend: Add eslint rule to require curly braces for blocks

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
     'simple-import-sort/exports': 'warn',
     'vue/multi-word-component-names': 'off',
     '@typescript-eslint/consistent-type-imports': 'warn',
+    curly: 'error',
   },
   globals: {
     defineProps: 'readonly',

--- a/frontend/src/components/RequestDialog.vue
+++ b/frontend/src/components/RequestDialog.vue
@@ -191,8 +191,9 @@ watch(chainId, (_, oldChainId) => {
 watch(signerAddress, (currSignerAddress, prevSignerAddress) => {
   const toAddress = requestTarget.value.toAddress;
 
-  if (!toAddress || toAddress === prevSignerAddress)
+  if (!toAddress || toAddress === prevSignerAddress) {
     requestTarget.value = { ...requestTarget.value, toAddress: currSignerAddress ?? '' };
+  }
 });
 
 const checkboxClasses = `appearance-none h-7 w-7 bg-sea-green shadow-inner rounded-md 

--- a/frontend/src/services/transactions/request-manager.ts
+++ b/frontend/src/services/transactions/request-manager.ts
@@ -169,7 +169,9 @@ export function failWhenRequestExpires(
           requestManagerAddress,
           requestIdentifier,
         );
-        if (activeClaims.eq(0)) cleanUpAndReject();
+        if (activeClaims.eq(0)) {
+          cleanUpAndReject();
+        }
       });
     };
 
@@ -184,13 +186,18 @@ export function failWhenRequestExpires(
       // If not expired by sequencer clock
       if (!requestExpiryInfo.validityExpired) {
         // And expired by our clock
-        if (requestExpiryInfo.timeToExpiredMillis === 0)
+        if (requestExpiryInfo.timeToExpiredMillis === 0) {
           // wait on new blocks until expired by sequencer clock
           provider.once('block', configureListeners);
+        }
         // sleep until expired by our clock
-        else timeout = setTimeout(configureListeners, requestExpiryInfo.timeToExpiredMillis);
+        else {
+          timeout = setTimeout(configureListeners, requestExpiryInfo.timeToExpiredMillis);
+        }
       } else {
-        if (!requestExpiryInfo.notWithdrawnBySomeoneElse) return cleanUpAndReject();
+        if (!requestExpiryInfo.notWithdrawnBySomeoneElse) {
+          return cleanUpAndReject();
+        }
         if (!requestExpiryInfo.noActiveClaims) {
           return attachClaimWithdrawnListener();
         }

--- a/frontend/src/services/web3-provider/walletconnect-provider.ts
+++ b/frontend/src/services/web3-provider/walletconnect-provider.ts
@@ -35,7 +35,9 @@ export class WalletConnectProvider extends EthereumProvider {
       await this.web3Provider.send('wallet_switchEthereumChain', [{ chainId: newChainIdHex }]);
       return true;
     } catch (error: unknown) {
-      if ((error as Error).message.startsWith('Unrecognized chain ID')) return false;
+      if ((error as Error).message.startsWith('Unrecognized chain ID')) {
+        return false;
+      }
       throw error;
     }
   }


### PR DESCRIPTION
Adding this because I saw this quite often in the recent PRs.
I think it is in general good practice to have the curly braces around any block, because it provides better readability, maintainability and is less prone to errors. See https://stackoverflow.com/questions/4797286/are-braces-necessary-in-one-line-statements-in-javascript for some arguments.