### PR TITLE
frontend: Correctly abbreviate long token amounts

### DIFF
--- a/frontend/src/components/RequestSourceInputs.vue
+++ b/frontend/src/components/RequestSourceInputs.vue
@@ -52,7 +52,7 @@
           </InputValidationMessage>
           <div v-else class="self-end">
             <div v-if="showTokenBalance" class="text-base mr-5 mt-1">
-              {{ formattedTokenBalance }} {{ selectedToken?.label }} available
+              {{ formattedTokenBalance }} available
             </div>
           </div>
         </div>
@@ -202,8 +202,11 @@ const selectedSourceChainIdentifier = computed(
   () => selectedSourceChain.value?.value.identifier ?? -1,
 );
 
-const { selectedToken, selectedTokenAddress, tokens, addTokenToProvider, addTokenAvailable } =
-  useTokenSelection(chains, selectedSourceChainIdentifier, provider);
+const { selectedToken, tokens, addTokenToProvider, addTokenAvailable } = useTokenSelection(
+  chains,
+  selectedSourceChainIdentifier,
+  provider,
+);
 
 const selectedTokenAmount = computed(() => {
   if (
@@ -228,7 +231,11 @@ const {
   available: showTokenBalance,
   formattedBalance: formattedTokenBalance,
   balance,
-} = useTokenBalance(provider, signer, selectedTokenAddress);
+} = useTokenBalance(
+  provider,
+  signer,
+  computed(() => selectedToken?.value?.value ?? undefined),
+);
 
 const {
   enabled: faucetEnabled,

--- a/frontend/src/components/RequestSourceInputs.vue
+++ b/frontend/src/components/RequestSourceInputs.vue
@@ -51,8 +51,19 @@
             {{ v$.$validationGroups && v$.$validationGroups.amount.$errors[0].$message }}
           </InputValidationMessage>
           <div v-else class="self-end">
-            <div v-if="showTokenBalance" class="text-base mr-5 mt-1">
-              {{ formattedTokenBalance }} available
+            <div v-if="showTokenBalance && balance" class="text-base mr-5 mt-1">
+              <div v-if="balance.uint256.isZero()">{{ formattedTokenBalance }} available</div>
+              <Tooltip
+                v-else
+                :hint="`You have ${balance.formatFullValue()} in your wallet. Click to use all.`"
+                show-outside-of-closest-reference-element
+                @click="balance && setSelectedAmount(balance)"
+              >
+                <span :class="{ underline: formattedTokenBalance?.includes('<') }">
+                  {{ formattedTokenBalance }}
+                </span>
+                available
+              </Tooltip>
             </div>
           </div>
         </div>
@@ -291,7 +302,9 @@ defineExpose({ v$ });
 const isSelectedAmountValid = computed(() => {
   return !v$.value.$validationGroups?.amount || !v$.value.$validationGroups.amount.$error;
 });
-
+const setSelectedAmount = (amount: TokenAmount) => {
+  selectedAmount.value = amount.decimalAmount;
+};
 watch(selectedToken, () => {
   if (selectedAmount.value) {
     v$.value.$touch();

--- a/frontend/src/components/Transfer.vue
+++ b/frontend/src/components/Transfer.vue
@@ -47,7 +47,7 @@ interface Props {
 
 const props = defineProps<Props>();
 const isExpanded = ref(props.transfer.active);
-const formattedAmount = computed(() => props.transfer.sourceAmount.format({ decimalPlaces: 2 }));
+const formattedAmount = computed(() => props.transfer.sourceAmount.format());
 
 const requestTransactionUrl = computed(() => {
   const { explorerTransactionUrl } = props.transfer.sourceChain;

--- a/frontend/src/composables/useRequestSourceInputValidations.ts
+++ b/frontend/src/composables/useRequestSourceInputValidations.ts
@@ -1,7 +1,6 @@
 import type { ValidationArgs } from '@vuelidate/core';
 import { useVuelidate } from '@vuelidate/core';
 import { helpers, minValue, numeric, required, sameAs } from '@vuelidate/validators';
-import type { BigNumber } from 'ethers';
 import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
 import { computed } from 'vue';
 
@@ -33,7 +32,7 @@ type ValidationRules = ValidationArgs<{
 
 export const useRequestSourceInputValidations = (
   options: ValidationState & {
-    balance: Ref<BigNumber>;
+    balance: Ref<TokenAmount | undefined>;
   },
 ) => {
   const computedRules: ComputedRef<ValidationRules> = computed(() => {
@@ -79,15 +78,11 @@ export const useRequestSourceInputValidations = (
 
         const totalRequestTokenAmountRules = {
           maxValue: helpers.withMessage('Insufficient funds', (value: TokenAmount) => {
-            if (!value || !options.selectedToken.value) {
+            if (!value || !options.selectedToken.value || !options.balance.value) {
               return true;
             }
             // Due to reactivity issues `max` has to be initialized here
-            const max = new TokenAmount({
-              amount: options.balance.value.toString(),
-              token: options.selectedToken.value.value,
-            });
-            return makeMaxTokenAmountValidator(max)(value);
+            return makeMaxTokenAmountValidator(options.balance.value)(value);
           }),
         };
         Object.assign(rules, { totalRequestTokenAmount: totalRequestTokenAmountRules });

--- a/frontend/src/composables/useTokenBalance.ts
+++ b/frontend/src/composables/useTokenBalance.ts
@@ -1,43 +1,41 @@
 import type { JsonRpcSigner } from '@ethersproject/providers';
-import { BigNumber, Contract, ethers } from 'ethers';
+import { BigNumber, Contract } from 'ethers';
 import type { Ref } from 'vue';
 import { computed, ref, watch } from 'vue';
 
 import StandardToken from '@/assets/StandardToken.json';
 import { getTokenBalance, getTokenDecimals } from '@/services/transactions/token';
 import type { IEthereumProvider } from '@/services/web3-provider';
+import type { Token } from '@/types/data';
+import type { TokenAmount } from '@/types/token-amount';
 
 export function useTokenBalance(
   provider: Ref<IEthereumProvider | undefined>,
   signer: Ref<JsonRpcSigner | undefined>,
-  tokenAddress: Ref<string | undefined>,
+  token: Ref<Token | undefined>,
 ) {
   const error = ref<string | undefined>(undefined);
   const signerAddress = ref<string | undefined>(undefined);
-  const balance = ref(BigNumber.from(0));
+  const balance: Ref<TokenAmount | undefined> = ref(undefined);
   const decimals = ref(BigNumber.from(0));
 
-  const available = computed(() => !!signerAddress.value && !!tokenAddress.value);
-
-  const formattedBalance = computed(() => {
-    const cutoff = balance.value.mod(1e14);
-    return ethers.utils.formatUnits(balance.value.sub(cutoff), decimals.value);
-  });
+  const available = computed(() => !!signerAddress.value && !!token.value);
+  const formattedBalance = computed(() => balance.value?.format());
 
   let tokenContract: Contract;
 
   async function updateTokenBalance(
     provider: IEthereumProvider | undefined,
-    tokenAddress: string | undefined,
+    token: Token | undefined,
     signerAddress: string | undefined,
   ) {
-    if (!provider || !tokenAddress || !signerAddress) {
-      balance.value = BigNumber.from(0);
+    if (!provider || !token || !signerAddress) {
+      balance.value = undefined;
       return;
     }
 
     try {
-      balance.value = await getTokenBalance(provider, tokenAddress, signerAddress);
+      balance.value = await getTokenBalance(provider, token, signerAddress);
     } catch (exception: unknown) {
       handleException(exception);
     }
@@ -51,41 +49,41 @@ export function useTokenBalance(
   async function listenToTokenBalance() {
     error.value = undefined;
 
-    if (!provider.value || !tokenAddress.value || !signer.value) {
-      balance.value = BigNumber.from(0);
+    if (!provider.value || !token.value || !signer.value) {
+      balance.value = undefined;
       return;
     }
 
     try {
       signerAddress.value = await signer.value.getAddress();
-      decimals.value = await getTokenDecimals(provider.value, tokenAddress.value);
+      decimals.value = await getTokenDecimals(provider.value, token.value.address);
     } catch (exception: unknown) {
       handleException(exception);
     }
 
-    await updateTokenBalance(provider.value, tokenAddress.value, signerAddress.value);
+    await updateTokenBalance(provider.value, token.value, signerAddress.value);
 
     if (tokenContract) {
       tokenContract.removeAllListeners();
     }
 
     tokenContract = provider.value.connectContract(
-      new Contract(tokenAddress.value, StandardToken.abi),
+      new Contract(token.value.address, StandardToken.abi),
     );
 
     const sendFilter = tokenContract.filters.Transfer(signerAddress.value, undefined);
     const receiveFilter = tokenContract.filters.Transfer(undefined, signerAddress.value);
 
     tokenContract.on(sendFilter, async () => {
-      await updateTokenBalance(provider.value, tokenAddress.value, signerAddress.value);
+      await updateTokenBalance(provider.value, token.value, signerAddress.value);
     });
 
     tokenContract.on(receiveFilter, async () => {
-      await updateTokenBalance(provider.value, tokenAddress.value, signerAddress.value);
+      await updateTokenBalance(provider.value, token.value, signerAddress.value);
     });
   }
 
-  watch([tokenAddress, provider, signer], listenToTokenBalance, { immediate: true });
+  watch([token, provider, signer], listenToTokenBalance, { immediate: true });
 
   return { available, balance, formattedBalance, error };
 }

--- a/frontend/src/composables/useTokenSelection.ts
+++ b/frontend/src/composables/useTokenSelection.ts
@@ -27,7 +27,6 @@ export function useTokenSelection(
       _selectedToken.value = token;
     },
   });
-  const selectedTokenAddress = computed(() => selectedToken.value?.value.address);
 
   const addTokenToProvider = async () => {
     if (!provider.value || !selectedToken.value) {
@@ -44,7 +43,6 @@ export function useTokenSelection(
 
   return {
     selectedToken,
-    selectedTokenAddress,
     tokens,
     addTokenToProvider,
     addTokenAvailable,

--- a/frontend/src/services/transactions/token.ts
+++ b/frontend/src/services/transactions/token.ts
@@ -3,7 +3,9 @@ import { BigNumber, Contract } from 'ethers';
 
 import StandardToken from '@/assets/StandardToken.json';
 import type { IEthereumProvider } from '@/services/web3-provider';
-import type { UInt256 } from '@/types/uint-256';
+import type { Token } from '@/types/data';
+import { TokenAmount } from '@/types/token-amount';
+import { UInt256 } from '@/types/uint-256';
 
 export async function ensureTokenAllowance(
   signer: JsonRpcSigner,
@@ -32,10 +34,11 @@ export async function getTokenDecimals(
 
 export async function getTokenBalance(
   provider: IEthereumProvider,
-  tokenAddress: string,
+  token: Token,
   accountAddress: string,
-): Promise<BigNumber> {
-  const tokenContract = new Contract(tokenAddress, StandardToken.abi);
+): Promise<TokenAmount> {
+  const tokenContract = new Contract(token.address, StandardToken.abi);
   const connectedContract = provider.connectContract(tokenContract);
-  return await connectedContract.balanceOf(accountAddress);
+  const balance: BigNumber = await connectedContract.balanceOf(accountAddress);
+  return TokenAmount.new(new UInt256(balance.toString()), token);
 }

--- a/frontend/tests/unit/types/token-amount.spec.ts
+++ b/frontend/tests/unit/types/token-amount.spec.ts
@@ -52,14 +52,14 @@ describe('TokenAmount', () => {
   });
 
   describe('format()', () => {
-    it('per defaults formats all decimals and and token symbol', () => {
-      const token = generateToken({ decimals: 4, symbol: 'TTT' });
-      const amount = new TokenAmount({ amount: '12345', token });
+    it('per default formats 4 decimals and token symbol for values with 1 pre-decimal digit', () => {
+      const token = generateToken({ decimals: 6, symbol: 'TTT' });
+      const amount = new TokenAmount({ amount: '1234567', token });
 
       expect(amount.format()).toBe('1.2345 TTT');
     });
 
-    it('can shorten decimals decimal places', () => {
+    it('can shorten number of visible decimal places', () => {
       const token = generateToken({ decimals: 4, symbol: 'TTT' });
       const amount = new TokenAmount({ amount: '12345', token });
 
@@ -71,6 +71,50 @@ describe('TokenAmount', () => {
       const amount = new TokenAmount({ amount: '12345', token });
 
       expect(amount.format({ withSymbol: false })).toBe('1.2345');
+    });
+
+    it('per default shows 3 decimal places for values with 2 pre-decimal digits', () => {
+      const token = generateToken({ decimals: 4, symbol: 'TTT' });
+      const amount = new TokenAmount({ amount: '123456', token });
+
+      expect(amount.format()).toBe('12.345 TTT');
+    });
+
+    it('per default shows 2 decimal places for values with more than 2 pre-decimal digits', () => {
+      const token = generateToken({ decimals: 4, symbol: 'TTT' });
+      const amount = new TokenAmount({ amount: '1234567', token });
+
+      expect(amount.format()).toBe('123.45 TTT');
+    });
+
+    it('per default limits to 8 decimal places for values smaller 1', () => {
+      const token = generateToken({ decimals: 18, symbol: 'TTT' });
+      const amount = new TokenAmount({ amount: '123456789012345678', token });
+
+      expect(amount.format()).toBe('0.12345678 TTT');
+    });
+
+    it('can show all decimal places for values smaller 1', () => {
+      const token = generateToken({ decimals: 18, symbol: 'TTT' });
+      const amount = new TokenAmount({ amount: '123456789012345678', token });
+
+      expect(amount.format({ decimalPlaces: 18 })).toBe('0.123456789012345678 TTT');
+    });
+
+    it('shows a smaller sign if value is smaller than visible in defined decimals', () => {
+      const token = generateToken({ decimals: 18, symbol: 'TTT' });
+      const amount = new TokenAmount({ amount: '1', token });
+
+      expect(amount.format()).toBe('<0.00000001 TTT');
+    });
+  });
+
+  describe('formatFullValue()', () => {
+    it('shows complete amount with all digits', () => {
+      const token = generateToken({ decimals: 18, symbol: 'TTT' });
+      const amount = new TokenAmount({ amount: '123456123456789012345678', token });
+
+      expect(amount.formatFullValue()).toBe('123456.123456789012345678 TTT');
     });
   });
 


### PR DESCRIPTION
Closes #698, closes #964


default beahavior for the new format() function:
- for values >= 1 shows maximum 5 digits totally or at least 2 decimals
- for values < 1 show 8 decimal places max
- for values < 1 if decimal places would only be 0 show a less than sign (e.g. < 0.001)

Or displays the given decimals from the options.


@GabrielBuragev this does not include the tooltip for displaying the full amount yet. I simply didn't have enough time. Could you add it either here or in a new PR? It should be displayed for the token balance and in the headers in the transfer history