### PR TITLE
frontend: Add back button on selector view & hide action button when selector view is opened

### DIFF
--- a/frontend/src/components/RequestSourceInputs.vue
+++ b/frontend/src/components/RequestSourceInputs.vue
@@ -27,6 +27,8 @@
         :options="chainOptions"
         placeholder="Source Rollup"
         required
+        @opened="hideActionButton"
+        @closed="showActionButton"
       />
       <InputValidationMessage v-if="v$.selectedSourceChain.$error">
         {{ v$.selectedSourceChain.$errors[0].$message }}
@@ -76,6 +78,8 @@
             :options="tokens"
             placeholder="Token"
             required
+            @opened="hideActionButton"
+            @closed="showActionButton"
           />
           <Tooltip
             class="self-end -mr-3"
@@ -156,6 +160,7 @@ import { useTokenBalance } from '@/composables/useTokenBalance';
 import { useTokenSelection } from '@/composables/useTokenSelection';
 import { useConfiguration } from '@/stores/configuration';
 import { useEthereumProvider } from '@/stores/ethereum-provider';
+import { usePortals } from '@/stores/portals';
 import type { Chain } from '@/types/data';
 import type { RequestSource, SelectorOption } from '@/types/form';
 import { TokenAmount } from '@/types/token-amount';
@@ -174,6 +179,7 @@ const emits = defineEmits<Emits>();
 
 const configuration = useConfiguration();
 const ethereumProvider = useEthereumProvider();
+const { hideActionButton, showActionButton } = usePortals();
 
 const { provider, signer } = storeToRefs(ethereumProvider);
 const { chains } = storeToRefs(configuration);

--- a/frontend/src/components/RequestTargetInputs.vue
+++ b/frontend/src/components/RequestTargetInputs.vue
@@ -9,6 +9,8 @@
         :options="chainOptions"
         placeholder="Target Rollup"
         required
+        @opened="hideActionButton"
+        @closed="showActionButton"
       />
     </div>
     <div class="flex flex-row gap-5">
@@ -65,6 +67,7 @@ import InputValidationMessage from '@/components/layout/InputValidationMessage.v
 import { useChainSelection } from '@/composables/useChainSelection';
 import { useRequestTargetInputValidations } from '@/composables/useRequestTargetInputValidations';
 import { useConfiguration } from '@/stores/configuration';
+import { usePortals } from '@/stores/portals';
 import type { Chain, Token } from '@/types/data';
 import type { RequestTarget, SelectorOption } from '@/types/form';
 
@@ -83,6 +86,7 @@ const props = defineProps<Props>();
 const emits = defineEmits<Emits>();
 
 const configuration = useConfiguration();
+const { hideActionButton, showActionButton } = usePortals();
 
 const { chains } = storeToRefs(configuration);
 

--- a/frontend/src/components/inputs/Selector.vue
+++ b/frontend/src/components/inputs/Selector.vue
@@ -44,7 +44,13 @@
         </div>
       </div>
       <div class="items-end">
-        <div class="text-5xl cursor-pointer text-sea-green" @click="closeSelector">&lt;</div>
+        <div
+          class="text-5xl cursor-pointer text-sea-green"
+          data-test="close-trigger"
+          @click="closeSelector"
+        >
+          &lt;
+        </div>
       </div>
     </div>
   </Transition>

--- a/frontend/src/components/inputs/Selector.vue
+++ b/frontend/src/components/inputs/Selector.vue
@@ -66,6 +66,8 @@ interface Props {
 
 interface Emits {
   (e: 'update:modelValue', value: SelectorOption<unknown>): void;
+  (e: 'opened'): void;
+  (e: 'closed'): void;
 }
 
 const props = defineProps<Props>();
@@ -75,9 +77,13 @@ const opened = ref(false);
 const openSelector = () => {
   if (!props.disabled) {
     opened.value = true;
+    emits('opened');
   }
 };
-const closeSelector = () => (opened.value = false);
+const closeSelector = () => {
+  opened.value = false;
+  emits('closed');
+};
 
 const searchFilter = ref('');
 const filteredOptions = computed(() =>

--- a/frontend/src/components/inputs/Selector.vue
+++ b/frontend/src/components/inputs/Selector.vue
@@ -23,7 +23,7 @@
         name="searchFilter"
         placeholder="Search"
         :focus-on-mount="true"
-        class="flex-[0_0_4.5rem] !text-left"
+        class="flex-[0_0_4.5rem]"
         data-test="search-field"
       />
       <div
@@ -42,6 +42,9 @@
           <img v-if="option.imageUrl" class="h-12" :src="option.imageUrl" />
           <span>{{ option.label }}</span>
         </div>
+      </div>
+      <div class="items-end">
+        <div class="text-5xl cursor-pointer text-sea-green" @click="closeSelector">&lt;</div>
       </div>
     </div>
   </Transition>

--- a/frontend/src/stores/portals.ts
+++ b/frontend/src/stores/portals.ts
@@ -1,0 +1,15 @@
+import { defineStore } from 'pinia';
+
+export const usePortals = defineStore('portals', {
+  state: () => ({
+    actionButtonPortalVisible: true,
+  }),
+  actions: {
+    showActionButton() {
+      this.actionButtonPortalVisible = true;
+    },
+    hideActionButton() {
+      this.actionButtonPortalVisible = false;
+    },
+  },
+});

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -24,15 +24,16 @@
           @tab-changed="onTabChanged"
         />
       </div>
-
-      <div id="action-button-portal" class="flex flex-col justify-center gap-5 h-28">
-        <ActionButton
-          v-if="!signer"
-          class="bg-orange disabled:hidden"
-          :disabled="walletMenuIsOpen"
-          @click="openWalletMenu"
-          >Connect to Wallet
-        </ActionButton>
+      <div class="h-28">
+        <div
+          v-show="actionButtonPortalVisible"
+          id="action-button-portal"
+          class="flex flex-col justify-center gap-5"
+        >
+          <ActionButton v-if="!signer" class="bg-orange" @click="openWalletMenu"
+            >Connect to Wallet
+          </ActionButton>
+        </div>
       </div>
     </div>
   </div>
@@ -51,20 +52,24 @@ import WalletMenu from '@/components/WalletMenu.vue';
 import { useWallet } from '@/composables/useWallet';
 import { useConfiguration } from '@/stores/configuration';
 import { useEthereumProvider } from '@/stores/ethereum-provider';
+import { usePortals } from '@/stores/portals';
 import { useSettings } from '@/stores/settings';
 
 const configuration = useConfiguration();
 const ethereumProvider = useEthereumProvider();
 const { signer } = storeToRefs(ethereumProvider);
-
+const { actionButtonPortalVisible } = storeToRefs(usePortals());
+const { hideActionButton, showActionButton } = usePortals();
 const walletMenuIsOpen = ref(false);
 
 function openWalletMenu(): void {
   walletMenuIsOpen.value = true;
+  hideActionButton();
 }
 
 function closeWalletMenu(): void {
   walletMenuIsOpen.value = false;
+  showActionButton();
 }
 
 const tabs = [

--- a/frontend/tests/unit/components/inputs/Selector.spec.ts
+++ b/frontend/tests/unit/components/inputs/Selector.spec.ts
@@ -29,6 +29,27 @@ function createWrapper(options?: {
 }
 
 describe('Selector.vue', () => {
+  it('emits `opened` event when selection view is opened', async () => {
+    const wrapper = createWrapper();
+    const openTrigger = wrapper.find('[data-test="open-trigger"]');
+
+    await openTrigger.trigger('click');
+
+    const closeTrigger = wrapper.find('[data-test="close-trigger"');
+    await closeTrigger.trigger('click');
+
+    expect(Object.keys(wrapper.emitted())).toContain('opened');
+  });
+
+  it('emits `closed` event when selection view is closed', async () => {
+    const wrapper = createWrapper();
+    const openTrigger = wrapper.find('[data-test="open-trigger"]');
+
+    await openTrigger.trigger('click');
+
+    expect(Object.keys(wrapper.emitted())).toContain('opened');
+  });
+
   it('displays the options when opened', async () => {
     const wrapper = createWrapper();
     const trigger = wrapper.find('[data-test="open-trigger"]');
@@ -127,6 +148,20 @@ describe('Selector.vue', () => {
     await optionList.trigger('keyup.esc');
 
     optionList = wrapper.find('[data-test="option-list"');
+
+    expect(optionList.exists()).toBe(false);
+  });
+
+  it('should close the selector when close button is clicked', async () => {
+    const wrapper = createWrapper();
+    const openTrigger = wrapper.find('[data-test="open-trigger"]');
+
+    await openTrigger.trigger('click');
+
+    const closeTrigger = wrapper.find('[data-test="close-trigger"');
+    await closeTrigger.trigger('click');
+
+    const optionList = wrapper.find('[data-test="option-list"');
 
     expect(optionList.exists()).toBe(false);
   });

--- a/frontend/tests/unit/stores/portals.spec.ts
+++ b/frontend/tests/unit/stores/portals.spec.ts
@@ -1,0 +1,31 @@
+import { createPinia, setActivePinia } from 'pinia';
+
+import { usePortals } from '@/stores/portals';
+
+describe('portals store', () => {
+  beforeEach(() => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  describe('state', () => {
+    it('keeps track of action button portal visibility', () => {
+      const { actionButtonPortalVisible } = usePortals();
+      expect(actionButtonPortalVisible).toBe(true);
+    });
+  });
+
+  describe('actions', () => {
+    it('allows hiding action button portal', () => {
+      const portals = usePortals();
+      portals.hideActionButton();
+      expect(portals.actionButtonPortalVisible).toBe(false);
+    });
+
+    it('allows showing action button portal', () => {
+      const portals = usePortals();
+      portals.showActionButton();
+      expect(portals.actionButtonPortalVisible).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #898 

This brings a new approach to how the app handles multiple Teleports on same target. Until now, the first element inside the Teleport target was displayed.
This makes it harder to control and override the content of the Teleport target since Vue Teleport component works only in [append mode](https://vuejs.org/guide/built-ins/teleport.html#multiple-teleports-on-the-same-target). 

There was a need of hiding the current displayed content inside the form action button when the selector view was open. 
In order to avoid introducing another store for managing such minor misc things, or another complex solution which might require communication between 3+ levels of components i settled down on using an approach where the most recently added element to the Teleport target is displayed.

With this i enabled inserting empty DOM elements on the lowest "leafs" in the Component tree in order to hide the other content inside the Teleport target.