### PR TITLE
frontend: Fix failing transfers

### DIFF
--- a/frontend/src/services/transactions/request-manager.ts
+++ b/frontend/src/services/transactions/request-manager.ts
@@ -71,15 +71,15 @@ export async function getRequestIdentifier(
 ): Promise<UInt256> {
   const provider = new JsonRpcProvider(rpcUrl);
   const contract = getContract(rpcUrl, requestManagerAddress);
-  const transaction = await provider.getTransaction(transactionHash);
-  const receipt = await transaction.wait();
-  const event = contract.interface.parseLog(receipt.logs[0]);
-
-  if (event) {
-    return new UInt256(event.args.requestId);
-  } else {
-    throw new Error("Request Failed. Couldn't retrieve Request ID");
+  const receipt = await provider.waitForTransaction(transactionHash, 1);
+  if (receipt) {
+    const event = contract.interface.parseLog(receipt.logs[0]);
+    if (event) {
+      return new UInt256(event.args.requestId);
+    }
   }
+
+  throw new Error("Request Failed. Couldn't retrieve Request ID");
 }
 
 type RequestData = {


### PR DESCRIPTION
Fixes #968 

Seems like the code where the `provider.getTransaction` function was used was not properly checking if the transaction was actually mined in a block or indexed yet therefore making the app crash due to returned `null` values inside the corresponding functions.

From the [official ethers docs](https://docs.ethers.io/v5/api/providers/provider/#Provider-getTransaction) it is clear that the calls to `provider.getTransaction` method are not always returning the values we are expecting currently. When network is congested or for any other reason, mining the blocks might take longer and that needs to be properly accounted for when trying to fetch the transactions from the blockchain.
Knowing this, i switched to using a call to `provider.waitForTransaction` first which expects at least 1 confirmation, which will partially ensure us that the transaction was mined & indexed? . 
By removing the call to `transaction.wait()` we avoid the possible error exception for when the value of the `transaction` property is null which was mostly making the app crash unpredictably.

Tested locally on ganache and saw a difference in how the steps are being resolved. Most importantly, with this update, the app accounts for delayed blocks and the call to `provider.waitForTransaction` waits until the block has been mined & transaction has 1 confirmation after which returns the receipt.

Would love some input from someone else experienced in Web3.