### PR TITLE
Request manager whitelist

### DIFF
--- a/beamer/agent.py
+++ b/beamer/agent.py
@@ -49,8 +49,10 @@ class Agent:
         resolution_registry = l2a_contracts["ResolutionRegistry"]
         fill_manager = l2b_contracts["FillManager"]
 
-        if not fill_manager.functions.allowedLPs(config.account.address).call():
-            raise RuntimeError("Agent address is not whitelisted")
+        if not fill_manager.functions.allowedLps(config.account.address).call():
+            raise RuntimeError("Agent address is not whitelisted on FillManager")
+        if not request_manager.functions.allowedLps(config.account.address).call():
+            raise RuntimeError("Agent address is not whitelisted on RequestManager")
 
         self.context = Context(
             requests=Tracker(),

--- a/beamer/tests/agent/test_challenge.py
+++ b/beamer/tests/agent/test_challenge.py
@@ -258,6 +258,7 @@ def test_challenge_5(request_manager, fill_manager, token, config, honest_claim)
     agent.start()
 
     fill_manager.addAllowedLp(charlie.address)
+    request_manager.addAllowedLp(charlie.address)
 
     # Submit a request that Bob cannot fill.
     amount = token.balanceOf(agent.address) + 1

--- a/beamer/tests/agent/test_challenge.py
+++ b/beamer/tests/agent/test_challenge.py
@@ -257,7 +257,7 @@ def test_challenge_5(request_manager, fill_manager, token, config, honest_claim)
     agent = beamer.agent.Agent(config)
     agent.start()
 
-    fill_manager.addAllowedLP(charlie.address)
+    fill_manager.addAllowedLp(charlie.address)
 
     # Submit a request that Bob cannot fill.
     amount = token.balanceOf(agent.address) + 1

--- a/beamer/tests/conftest.py
+++ b/beamer/tests/conftest.py
@@ -98,7 +98,7 @@ def contracts(
     l2_messenger.setForwardState(forward_state)
     proof_submitter = deployer.deploy(TestProofSubmitter, l2_messenger.address)
     fill_manager = deployer.deploy(FillManager, resolver.address, proof_submitter.address)
-    fill_manager.addAllowedLP(_LOCAL_ACCOUNT)
+    fill_manager.addAllowedLp(_LOCAL_ACCOUNT)
 
     # L2a contracts
     resolution_registry = deployer.deploy(ResolutionRegistry)

--- a/beamer/tests/conftest.py
+++ b/beamer/tests/conftest.py
@@ -98,7 +98,6 @@ def contracts(
     l2_messenger.setForwardState(forward_state)
     proof_submitter = deployer.deploy(TestProofSubmitter, l2_messenger.address)
     fill_manager = deployer.deploy(FillManager, resolver.address, proof_submitter.address)
-    fill_manager.addAllowedLp(_LOCAL_ACCOUNT)
 
     # L2a contracts
     resolution_registry = deployer.deploy(ResolutionRegistry)
@@ -109,6 +108,10 @@ def contracts(
         challenge_period_extension,
         resolution_registry.address,
     )
+
+    # Add allowed LPs
+    fill_manager.addAllowedLp(_LOCAL_ACCOUNT)
+    request_manager.addAllowedLp(_LOCAL_ACCOUNT)
 
     # Explicitly allow calls between contracts. The chain of trust:
     #

--- a/beamer/tests/contracts/test_fill_manager.py
+++ b/beamer/tests/contracts/test_fill_manager.py
@@ -11,10 +11,10 @@ def test_fill_request(fill_manager, token, deployer):
     filler, receiver = alloc_accounts(2)
 
     with brownie.reverts("Ownable: caller is not the owner"):
-        fill_manager.addAllowedLP(deployer, {"from": filler})
+        fill_manager.addAllowedLp(deployer, {"from": filler})
 
-    whitelist_tx = fill_manager.addAllowedLP(deployer, {"from": deployer})
-    assert "LPAdded" in whitelist_tx.events
+    whitelist_tx = fill_manager.addAllowedLp(deployer, {"from": deployer})
+    assert "LpAdded" in whitelist_tx.events
 
     token.approve(fill_manager.address, amount, {"from": deployer})
     fill_manager.fillRequest(
@@ -36,7 +36,7 @@ def test_fill_request(fill_manager, token, deployer):
             {"from": deployer},
         )
 
-    fill_manager.removeAllowedLP(deployer, {"from": deployer})
+    fill_manager.removeAllowedLp(deployer, {"from": deployer})
     with brownie.reverts("Sender not whitelisted"):
         fill_manager.fillRequest(
             1,
@@ -47,8 +47,8 @@ def test_fill_request(fill_manager, token, deployer):
             {"from": deployer},
         )
 
-    blacklist_tx = fill_manager.removeAllowedLP(deployer, {"from": deployer})
-    assert "LPRemoved" in blacklist_tx.events
+    blacklist_tx = fill_manager.removeAllowedLp(deployer, {"from": deployer})
+    assert "LpRemoved" in blacklist_tx.events
 
 
 def test_invalidate_valid_fill_hash(fill_manager, token, deployer):
@@ -56,7 +56,7 @@ def test_invalidate_valid_fill_hash(fill_manager, token, deployer):
     amount = 100
     (receiver,) = alloc_accounts(1)
 
-    fill_manager.addAllowedLP(deployer, {"from": deployer})
+    fill_manager.addAllowedLp(deployer, {"from": deployer})
 
     token.approve(fill_manager.address, amount, {"from": deployer})
     request_id = 1

--- a/beamer/tests/contracts/test_fill_manager.py
+++ b/beamer/tests/contracts/test_fill_manager.py
@@ -36,7 +36,9 @@ def test_fill_request(fill_manager, token, deployer):
             {"from": deployer},
         )
 
-    fill_manager.removeAllowedLp(deployer, {"from": deployer})
+    blacklist_tx = fill_manager.removeAllowedLp(deployer, {"from": deployer})
+    assert "LpRemoved" in blacklist_tx.events
+
     with brownie.reverts("Sender not whitelisted"):
         fill_manager.fillRequest(
             1,
@@ -46,9 +48,6 @@ def test_fill_request(fill_manager, token, deployer):
             amount,
             {"from": deployer},
         )
-
-    blacklist_tx = fill_manager.removeAllowedLp(deployer, {"from": deployer})
-    assert "LpRemoved" in blacklist_tx.events
 
 
 def test_invalidate_valid_fill_hash(fill_manager, token, deployer):

--- a/beamer/tests/contracts/test_l1_resolution.py
+++ b/beamer/tests/contracts/test_l1_resolution.py
@@ -17,7 +17,7 @@ def test_l1_resolution_correct_hash(fill_manager, deployer, resolution_registry,
     filler, receiver = alloc_accounts(2)
     chain_id = brownie.web3.eth.chain_id
 
-    fill_manager.addAllowedLP(filler, {"from": deployer})
+    fill_manager.addAllowedLp(filler, {"from": deployer})
 
     token.mint(filler, amount, {"from": filler})
     token.approve(fill_manager.address, amount, {"from": filler})

--- a/beamer/tests/contracts/test_l1_resolution.py
+++ b/beamer/tests/contracts/test_l1_resolution.py
@@ -6,18 +6,17 @@ from eth_utils import keccak
 from web3.constants import ADDRESS_ZERO
 
 from beamer.tests.constants import FILL_ID_EMPTY
-from beamer.tests.util import alloc_accounts, create_request_hash
+from beamer.tests.util import alloc_accounts, alloc_whitelisted_accounts, create_request_hash
 
 
 @pytest.mark.parametrize("amount", [100, 99, 101])
 @pytest.mark.parametrize("forward_state", [True])
-def test_l1_resolution_correct_hash(fill_manager, deployer, resolution_registry, token, amount):
+def test_l1_resolution_correct_hash(fill_manager, resolution_registry, token, amount):
     requested_amount = 100
     request_id = 23
-    filler, receiver = alloc_accounts(2)
+    (receiver,) = alloc_accounts(1)
+    (filler,) = alloc_whitelisted_accounts(1, {fill_manager})
     chain_id = brownie.web3.eth.chain_id
-
-    fill_manager.addAllowedLp(filler, {"from": deployer})
 
     token.mint(filler, amount, {"from": filler})
     token.approve(fill_manager.address, amount, {"from": filler})

--- a/beamer/tests/util.py
+++ b/beamer/tests/util.py
@@ -9,6 +9,7 @@ from typing import Any, List, Optional
 import brownie
 import requests
 import web3
+
 from eth_abi.packed import encode_abi_packed
 from eth_utils import keccak, to_canonical_address
 
@@ -26,6 +27,14 @@ def _alloc_account():
 
 def alloc_accounts(n):
     return tuple(_alloc_account() for _ in range(n))
+
+
+def alloc_whitelisted_accounts(n, contracts):
+    accounts = tuple(_alloc_account() for _ in range(n))
+    for account in accounts:
+        for contract in contracts:
+            contract.addAllowedLp(account)
+    return accounts
 
 
 class Timeout(Exception):

--- a/contracts/contracts/LpWhitelist.sol
+++ b/contracts/contracts/LpWhitelist.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.12;
+
+import "OpenZeppelin/openzeppelin-contracts@4.5.0/contracts/access/Ownable.sol";
+
+/// Liquidity Provider Whitelist.
+///
+/// This contract describes the concept of a whitelist for allowed Lps. RequestManager and FillManager
+/// inherit from this contract.
+contract LpWhitelist is Ownable {
+    /// Emitted when a liquidity provider has been added to the set of allowed
+    /// liquidity providers.
+    ///
+    /// .. seealso:: :sol:func:`addAllowedLp`
+    event LpAdded(address lp);
+
+    /// Emitted when a liquidity provider has been removed from the set of allowed
+    /// liquidity providers.
+    ///
+    /// .. seealso:: :sol:func:`removeAllowedLp`
+    event LpRemoved(address lp);
+
+    /// The set of liquidity providers that are added to the whitelist.
+    mapping(address => bool) public allowedLps;
+
+    /// Modifier to check whether the sender is whitelisted
+    modifier onlyWhitelist() {
+        require(allowedLps[msg.sender], "Sender not whitelisted");
+        _;
+    }
+
+    /// Add a liquidity provider to the set of allowed liquidity providers.
+    ///
+    /// .. note:: This function can only be called by the contract owner.
+    ///
+    /// @param newLp The liquidity provider.
+    function addAllowedLp(address newLp) public onlyOwner {
+        allowedLps[newLp] = true;
+
+        emit LpAdded(newLp);
+    }
+
+    /// Remove a liquidity provider from the set of allowed liquidity providers.
+    ///
+    /// .. note:: This function can only be called by the contract owner.
+    ///
+    /// @param oldLp The liquidity provider.
+    function removeAllowedLp(address oldLp) public onlyOwner {
+        delete allowedLps[oldLp];
+
+        emit LpRemoved(oldLp);
+    }
+}

--- a/contracts/contracts/RequestManager.sol
+++ b/contracts/contracts/RequestManager.sol
@@ -5,7 +5,7 @@ import "OpenZeppelin/openzeppelin-contracts@4.5.0/contracts/token/ERC20/IERC20.s
 import "OpenZeppelin/openzeppelin-contracts@4.5.0/contracts/token/ERC20/utils/SafeERC20.sol";
 import "OpenZeppelin/openzeppelin-contracts@4.5.0/contracts/utils/math/Math.sol";
 import "OpenZeppelin/openzeppelin-contracts@4.5.0/contracts/access/Ownable.sol";
-
+import "./LpWhitelist.sol";
 import "./BeamerUtils.sol";
 import "./ResolutionRegistry.sol";
 
@@ -16,7 +16,7 @@ import "./ResolutionRegistry.sol";
 /// tokens until they are withdrawn.
 ///
 /// It is the only contract that agents need to interact with on the source chain.
-contract RequestManager is Ownable {
+contract RequestManager is Ownable, LpWhitelist {
     using Math for uint256;
     using SafeERC20 for IERC20;
 
@@ -342,6 +342,7 @@ contract RequestManager is Ownable {
         external
         payable
         validRequestId(requestId)
+        onlyWhitelist
         returns (uint256)
     {
         Request storage request = requests[requestId];

--- a/scripts/call_contracts.py
+++ b/scripts/call_contracts.py
@@ -303,7 +303,7 @@ def whitelist(
         print(f"Address '{to_checksum_address(address)}' is already whitelisted.")
         return
 
-    tx_hash = fill_manager.functions.addAllowedLP(address).transact()
+    tx_hash = fill_manager.functions.addAllowedLp(address).transact()
     web3.eth.wait_for_transaction_receipt(tx_hash, poll_latency=1.0)
 
     print(f"Transaction sent, tx_hash: {tx_hash.hex()}")

--- a/scripts/e2e-test.py
+++ b/scripts/e2e-test.py
@@ -34,7 +34,7 @@ def main() -> None:
     tx_hash = token.functions.approve(fill_manager.address, request_amount).transact()
     web3.eth.wait_for_transaction_receipt(tx_hash)
 
-    tx_hash = fill_manager.functions.addAllowedLP(deployer.address).transact()
+    tx_hash = fill_manager.functions.addAllowedLp(deployer.address).transact()
     web3.eth.wait_for_transaction_receipt(tx_hash)
 
     tx_hash = fill_manager.functions.fillRequest(


### PR DESCRIPTION
resolves: #893 

For the tests I created a function called `alloc_whitelist_accounts` which takes contracts as an argument and calls `addAllowedLp()` on it. Since it is a util function in must be passed in the arguments.
The positive side on this is that I had to go through all the tests and bring more context to the addresses and give them better names. I also removed some overlappings where the requester was also the claimer (not that it is harmful in particular but it removes the possibgility of failures due to address misusage).

Regarding `call_contracts.py whitelist` I did not come up with a proper solution because the script only consumes one RPC endpoint but it would require two here. Since it is not critical for the audit I suggest to create a follow up issue for that.  