### PR TITLE
dont drop InitiateL1ResolutionEvent

### DIFF
--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -423,7 +423,8 @@ def _handle_initiate_l1_resolution(
 
         log.info("Initiated L1 resolution", request=request, claim=claim)
 
-    return True, None
+        return True, None
+    return False, None
 
 
 def _handle_initiate_l1_invalidation(


### PR DESCRIPTION
this is a quick hotfix.

If the agent is in a challenge, the timestamp is finalized but not enough funds are reached it would drop the `initiateL1ResolutionEvent`. This should not be the case. It should only drop once the claim was removed by a withdraw or L1 resolution was triggered