### PR TITLE
Frontend: improve several wallet connect flows

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "pinia-plugin-persistedstate": "^1.5.2",
     "postcss": "^8.4",
     "tailwindcss": "^3",
+    "ua-parser-js": "^1.0.2",
     "vue": "^3.2.31",
     "vue-router": "^4.0.0-0",
     "vue-select": "^4.0.0-beta.2"
@@ -41,6 +42,7 @@
     "@rushstack/eslint-patch": "^1.1.1",
     "@types/lodash.debounce": "^4.0.7",
     "@types/node": "^17.0.25",
+    "@types/ua-parser-js": "^0.7.36",
     "@types/vue-select": "^3.16.0",
     "@types/vuelidate": "^0.7.15",
     "@vitejs/plugin-vue": "^2.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@ethersproject/providers": "^5.5.2",
     "@fontsource/sora": "^4.5.5",
     "@metamask/detect-provider": "^1.2.0",
+    "@metamask/onboarding": "^1.0.1",
     "@vuelidate/core": "^2.0.0-alpha.43",
     "@vuelidate/validators": "^2.0.0-alpha.31",
     "@walletconnect/web3-provider": "^1.7.8",

--- a/frontend/src/assets/images/close.svg
+++ b/frontend/src/assets/images/close.svg
@@ -1,4 +1,4 @@
-<svg width="30" height="29" viewBox="0 0 30 29" fill="none" stroke="black" xmlns="http://www.w3.org/2000/svg">
+<svg width="30" height="29" viewBox="0 0 30 29" fill="none" stroke="white" xmlns="http://www.w3.org/2000/svg">
 <line x1="0.353553" y1="0.646447" x2="28.1584" y2="28.4513" />
 <line x1="1.84176" y1="28.4511" x2="29.6466" y2="0.646256" />
 </svg>

--- a/frontend/src/components/WalletMenu.vue
+++ b/frontend/src/components/WalletMenu.vue
@@ -35,7 +35,7 @@ const walletOptions = [
     name: 'MetaMask',
     icon: new URL('../assets/images/metamask.svg', import.meta.url).href,
     description: 'Connect using browser wallet',
-    connect: connectMetaMask,
+    connect: () => connectMetaMask(true),
   },
   {
     name: 'WalletConnect',

--- a/frontend/src/components/WalletMenu.vue
+++ b/frontend/src/components/WalletMenu.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="w-full h-full flex flex-col justify-center items-center bg-teal/30 p-16 rounded-lg">
+  <div
+    class="w-full h-full flex flex-col justify-center items-center bg-teal/30 p-16 rounded-lg"
+    @click="close"
+  >
     <button class="absolute top-0 right-0 m-10" data-test="close-button" @click="close">
       <img class="h-6 w-6" src="@/assets/images/close.svg" alt="close" />
     </button>
@@ -8,7 +11,7 @@
       v-for="walletOption of walletOptions"
       :key="walletOption.name"
       class="w-[25rem] flex flex-col items-center my-5 py-5 bg-sea-green rounded-lg text-black gap-2"
-      @click="walletOption.connect"
+      @click.stop="walletOption.connect"
     >
       <img class="h-20 w-20" :src="walletOption.icon" :alt="walletOption.name + ' icon'" />
       <div class="text-2xl font-bold">{{ walletOption.name }}</div>

--- a/frontend/src/components/WalletMenu.vue
+++ b/frontend/src/components/WalletMenu.vue
@@ -13,7 +13,10 @@
       class="w-[25rem] flex flex-col items-center my-5 py-5 bg-sea-green rounded-lg text-black gap-2"
       @click.stop="walletOption.connect"
     >
-      <img class="h-20 w-20" :src="walletOption.icon" :alt="walletOption.name + ' icon'" />
+      <div v-if="walletOption.connecting" class="w-20 h-20 items-center justify-center flex">
+        <spinner class="border-t-teal border-4 h-1/2 w-1/2"></spinner>
+      </div>
+      <img v-else class="h-20 w-20" :src="walletOption.icon" :alt="walletOption.name + ' icon'" />
       <div class="text-2xl font-bold">{{ walletOption.name }}</div>
       <div class="text-lg">{{ walletOption.description }}</div>
     </button>
@@ -23,6 +26,7 @@
 import { storeToRefs } from 'pinia';
 import { onMounted, ref, watch } from 'vue';
 
+import Spinner from '@/components/Spinner.vue';
 import { useWallet } from '@/composables/useWallet';
 import { useConfiguration } from '@/stores/configuration';
 import { useEthereumProvider } from '@/stores/ethereum-provider';
@@ -32,7 +36,8 @@ import { isMobile } from '@/utils/userAgent';
 const { provider, signer } = storeToRefs(useEthereumProvider());
 const { rpcUrls } = storeToRefs(useConfiguration());
 const { connectedWallet } = storeToRefs(useSettings());
-const { connectMetaMask, connectWalletConnect } = useWallet(provider, connectedWallet, rpcUrls);
+const { connectMetaMask, connectWalletConnect, connectingMetaMask, connectingWalletConnect } =
+  useWallet(provider, connectedWallet, rpcUrls);
 
 const walletOptions = ref([
   {
@@ -40,12 +45,14 @@ const walletOptions = ref([
     icon: new URL('../assets/images/metamask.svg', import.meta.url).href,
     description: 'Connect using browser wallet',
     connect: () => connectMetaMask(true),
+    connecting: connectingMetaMask,
   },
   {
     name: 'WalletConnect',
     icon: new URL('../assets/images/walletconnect.svg', import.meta.url).href,
     description: 'Connect using mobile wallet',
     connect: connectWalletConnect,
+    connecting: connectingWalletConnect,
   },
 ]);
 

--- a/frontend/src/composables/useWallet.ts
+++ b/frontend/src/composables/useWallet.ts
@@ -1,5 +1,6 @@
 import type { Ref } from 'vue';
 
+import { useAsynchronousTask } from '@/composables/useAsynchronousTask';
 import type { EthereumProvider } from '@/services/web3-provider';
 import {
   createMetaMaskProvider,
@@ -44,5 +45,14 @@ export function useWallet(
     }
   }
 
-  return { connectMetaMask, connectWalletConnect, reconnectToWallet };
+  const metamaskTask = useAsynchronousTask(connectMetaMask);
+  const walletConnectTask = useAsynchronousTask(connectWalletConnect);
+
+  return {
+    connectMetaMask: metamaskTask.run,
+    connectingMetaMask: metamaskTask.active,
+    connectWalletConnect: walletConnectTask.run,
+    connectingWalletConnect: walletConnectTask.active,
+    reconnectToWallet,
+  };
 }

--- a/frontend/src/composables/useWallet.ts
+++ b/frontend/src/composables/useWallet.ts
@@ -1,7 +1,11 @@
 import type { Ref } from 'vue';
 
 import type { EthereumProvider } from '@/services/web3-provider';
-import { createMetaMaskProvider, createWalletConnectProvider } from '@/services/web3-provider';
+import {
+  createMetaMaskProvider,
+  createWalletConnectProvider,
+  onboardMetaMask,
+} from '@/services/web3-provider';
 import { WalletType } from '@/types/settings';
 
 export function useWallet(
@@ -9,13 +13,15 @@ export function useWallet(
   connectedWallet: Ref<WalletType | undefined>,
   rpcUrls: Ref<{ [chainId: number]: string }>,
 ) {
-  async function connectMetaMask() {
+  async function connectMetaMask(withOnboarding?: boolean) {
     const metaMaskProvider = await createMetaMaskProvider();
 
     if (metaMaskProvider) {
       metaMaskProvider.requestSigner();
       provider.value = metaMaskProvider;
       connectedWallet.value = WalletType.MetaMask;
+    } else if (withOnboarding) {
+      onboardMetaMask();
     }
   }
 

--- a/frontend/src/services/web3-provider/metamask-provider.ts
+++ b/frontend/src/services/web3-provider/metamask-provider.ts
@@ -1,5 +1,6 @@
 import type { ExternalProvider } from '@ethersproject/providers';
 import detectEthereumProvider from '@metamask/detect-provider';
+import MetaMaskOnboarding from '@metamask/onboarding';
 import { hexValue } from 'ethers/lib/utils';
 
 import type { Eip1193Provider, ISigner } from '@/services/web3-provider';
@@ -13,6 +14,12 @@ export async function createMetaMaskProvider(): Promise<MetaMaskProvider | undef
     return metaMaskProvider;
   }
   return undefined;
+}
+
+export async function onboardMetaMask() {
+  const onboarding = new MetaMaskOnboarding();
+  onboarding.startOnboarding();
+  return onboarding;
 }
 
 export class MetaMaskProvider extends EthereumProvider implements ISigner {

--- a/frontend/src/utils/userAgent.ts
+++ b/frontend/src/utils/userAgent.ts
@@ -1,0 +1,7 @@
+import { UAParser } from 'ua-parser-js';
+
+export const isMobile = (userAgent: string): boolean => {
+  const parser = new UAParser(userAgent);
+  const { type } = parser.getDevice();
+  return type === 'mobile';
+};

--- a/frontend/tests/unit/composables/useWallet.spec.ts
+++ b/frontend/tests/unit/composables/useWallet.spec.ts
@@ -62,6 +62,17 @@ describe('useWallets', () => {
 
       expect(connectedWallet.value).toBe('metamask');
     });
+    describe('when onboarding is enabled', () => {
+      it('starts onboarding process when metamask instance is not found', async () => {
+        Object.defineProperty(web3ProviderService, 'createMetaMaskProvider', {
+          value: vi.fn().mockResolvedValue(undefined),
+        });
+
+        const { connectMetaMask } = useWallet(ref(undefined), ref(undefined), ref({}));
+        await connectMetaMask(true);
+        expect(web3ProviderService.onboardMetaMask).toHaveBeenCalledOnce();
+      });
+    });
   });
 
   describe('connectWalletConnect()', () => {

--- a/frontend/tests/unit/utils/userAgent.spec.ts
+++ b/frontend/tests/unit/utils/userAgent.spec.ts
@@ -1,0 +1,18 @@
+import { isMobile } from '@/utils/userAgent';
+
+describe('userAgent', () => {
+  describe('isMobile()', () => {
+    it('returns true if provided user agent matches a mobile device', () => {
+      const userAgent =
+        'Mozilla/5.0 (Linux; Android 7.0; SM-G930V Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36';
+
+      expect(isMobile(userAgent)).toBe(true);
+    });
+    it("returns false if provided user agent doesn't match a mobile device", () => {
+      const userAgent =
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36 Edg/105.0.1343.33';
+
+      expect(isMobile(userAgent)).toBe(false);
+    });
+  });
+});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -653,6 +653,13 @@
   resolved "https://registry.yarnpkg.com/@metamask/detect-provider/-/detect-provider-1.2.0.tgz#3667a7531f2a682e3c3a43eaf3a1958bdb42a696"
   integrity sha512-ocA76vt+8D0thgXZ7LxFPyqw3H7988qblgzddTDA6B8a/yU0uKV42QR/DhA+Jh11rJjxW0jKvwb5htA6krNZDQ==
 
+"@metamask/onboarding@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@metamask/onboarding/-/onboarding-1.0.1.tgz#14a36e1e175e2f69f09598e2008ab6dc1b3297e6"
+  integrity sha512-FqHhAsCI+Vacx2qa5mAFcWNSrTcVGMNjzxVgaX8ECSny/BJ9/vgXP9V7WF/8vb9DltPeQkxr+Fnfmm6GHfmdTQ==
+  dependencies:
+    bowser "^2.9.0"
+
 "@metamask/safe-event-emitter@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz#af577b477c683fad17c619a78208cede06f9605c"
@@ -1554,6 +1561,11 @@ bn.js@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
+
+bowser@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -806,6 +806,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/ua-parser-js@^0.7.36":
+  version "0.7.36"
+  resolved "https://registry.yarnpkg.com/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz#9bd0b47f26b5a3151be21ba4ce9f5fa457c5f190"
+  integrity sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==
+
 "@types/vue-select@^3.16.0":
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/@types/vue-select/-/vue-select-3.16.0.tgz#377d26d5e768c19a4863e101f36824df7e8c1592"
@@ -5007,6 +5012,11 @@ typescript@~4.5.5:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+
+ua-parser-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.2.tgz#e2976c34dbfb30b15d2c300b2a53eac87c57a775"
+  integrity sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Fixes #937 
Fixes #1015 

This PR contains fixes for several wallet connection flows.


Desktop flows (#937)
---
- MetaMask wallet provider option was enabled even when the MetaMask extension was not installed on the user's browser. 
In this case, when the user makes a selection, the dApp silently fails to connect and shows no relevant information to the user.
With this PR, i included an onboarding process for these cases. 
Now, when the user clicks on the MetaMask button and he has no installed extension, he will be redirected to finish the onboarding process before he can start using the app. 
The dApp autoconfigures itself after onboarding process is finished

Mobile device flows (#1015)
---
After some research on this topic i found out that some of the UX flows (regarding wallet connection) on mobile devices could be improved/fixed:
- Previously, users that access the dApp via a mobile device browser are given all the wallet provider options (including MetaMask). While MetaMask exists on mobile as an app, it doesn't exist on mobile as a browser extension. 
The right approach here is to only show the user the wallet provider options which actually work inside a mobile device browser. Therefore, MetaMask option should be removed and leave WalletConnect as the only visible option for these cases.
- Previously, users that access the dApp directly via MetaMask mobile app were given the option to connect via WalletConnect. In these cases, we should only show MetaMask as an accepted connection option since every other connection will fail inside the MetaMask app.

Read commit messages and issue descriptions for more info on the problems & implementation.

Testing tip: In order to test the behavior on MetaMask app locally, you need to do the tests with a built frontend instance instead of using `yarn dev`