### PR TITLE
frontend: fix mobile layout to fit small screens

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,9 @@
 <template>
-  <img class="w-[30rem] absolute top-12 left-12" src="@/assets/images/logo.svg" alt="logo" />
+  <img
+    class="w-[30rem] hidden md:block absolute top-12 left-12"
+    src="@/assets/images/logo.svg"
+    alt="logo"
+  />
   <div v-if="configurationLoaded">
     <router-view v-if="!isBlacklistedWallet" class="z-10" />
     <div

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <img class="w-[30rem] absolute top-12 left-12" src="@/assets/images/logo.svg" alt="logo" />
   <div v-if="configurationLoaded">
-    <router-view v-if="!isBlacklistedWallet" class="flex-auto z-10" />
+    <router-view v-if="!isBlacklistedWallet" class="z-10" />
     <div
       v-else
       class="text-red h-[90vh] w-full flex justify-center items-center text-4xl text-center px-4"
@@ -9,7 +9,7 @@
       Your address is on the blocked list.
     </div>
   </div>
-  <div v-else class="flex-auto flex flex-col items-center justify-center">
+  <div v-else class="flex flex-grow items-center justify-center">
     <div class="w-48 h-48">
       <spinner size="48"></spinner>
     </div>

--- a/frontend/src/components/RequestDialog.vue
+++ b/frontend/src/components/RequestDialog.vue
@@ -23,7 +23,7 @@
   <Teleport v-if="signer" to="#action-button-portal">
     <div v-if="transferFundsButtonVisible" class="flex flex-col items-center">
       <div v-if="DISCLAIMER_REQUIRED" class="relative">
-        <div class="absolute -top-11 -left-44 w-96 m-auto flex flex-row gap-5">
+        <div class="absolute -top-10 -left-44 w-96 m-auto flex flex-row gap-5">
           <!--  
             There seems to be a problem with tailwind and escaping the backslash in the TS variable. 
             For this reason the content rule is added separately here in the HTML.


### PR DESCRIPTION
fixes #935 

Logo was removed on mobile devices since it was just being overlayed by the dialog and no other design solution was provided.
Aligned with Olympe and for now we will stick to this approach.