### PR TITLE
Store invalid fill ids in request

### DIFF
--- a/beamer/models/claim.py
+++ b/beamer/models/claim.py
@@ -44,6 +44,7 @@ class Claim(StateMachine):
         started.to(claimer_winning)
         | claimer_winning.to(claimer_winning)
         | challenger_winning.to(challenger_winning)
+        | invalidated_l1_resolved.to(invalidated_l1_resolved)
         | withdrawn.to(withdrawn)
     )
     challenge = (

--- a/beamer/models/request.py
+++ b/beamer/models/request.py
@@ -37,8 +37,10 @@ class Request(StateMachine):
         self.fill_tx: Optional[HexBytes] = None
         self.fill_timestamp: Optional[Timestamp] = None
         self.fill_id: Optional[FillId] = None
+        self.invalid_fill_ids: dict[FillId, tuple[HexBytes, int]] = {}
         self.l1_resolution_filler: Optional[ChecksumAddress] = None
         self.l1_resolution_fill_id: Optional[FillId] = None
+        self.l1_resolution_invalid_fill_ids: set[FillId] = set()
 
     pending = State("Pending", initial=True)
     filled = State("Filled")

--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -351,6 +351,7 @@ def _handle_request_resolved(event: RequestResolved, context: Context) -> Handle
     if request is not None:
         try:
             request.l1_resolve(event.filler, event.fill_id)
+            request.invalid_fill_ids.pop(event.fill_id, None)
         except TransitionNotAllowed:
             return False, None
     return True, None
@@ -358,18 +359,31 @@ def _handle_request_resolved(event: RequestResolved, context: Context) -> Handle
 
 def _handle_hash_invalidated(event: HashInvalidated, context: Context) -> HandlerResult:
     fill_block = context.fill_manager.web3.eth.get_block(event.block_number)
+    timestamp = fill_block.timestamp  # type: ignore
+    request = _find_request_by_request_hash(context, event.request_hash)
+
+    if request is not None:
+        # If we get more invalidation events for the same fill ID, just ignore them.
+        if event.fill_id in request.invalid_fill_ids:
+            return True, None
+        request.invalid_fill_ids[event.fill_id] = event.tx_hash, timestamp
+
     claims = _find_claims_by_fill_hash(context, event.fill_hash)
 
     for claim in claims:
-        claim.start_challenge(event.tx_hash, fill_block.timestamp)  # type: ignore
+        claim.start_challenge(event.tx_hash, timestamp)
 
     return True, None
 
 
 def _handle_fill_hash_invalidated(event: FillHashInvalidated, context: Context) -> HandlerResult:
     claims = _find_claims_by_fill_hash(context, event.fill_hash)
+
     for claim in claims:
         claim.l1_invalidate()
+        request = context.requests.get(claim.request_id)
+        assert request is not None
+        request.l1_resolution_invalid_fill_ids.add(claim.fill_id)
 
     return True, None
 

--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -285,6 +285,9 @@ def _handle_claim_made(event: ClaimMade, context: Context) -> HandlerResult:
         if claim.fill_id in request.invalid_fill_ids:
             tx_hash, timestamp = request.invalid_fill_ids[claim.fill_id]
             claim.start_challenge(tx_hash, timestamp)
+        if claim.fill_id in request.l1_resolution_invalid_fill_ids:
+            claim.start_challenge()
+            claim.l1_invalidate()
         context.claims.add(claim.id, claim)
 
         return True, None

--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -282,6 +282,9 @@ def _handle_claim_made(event: ClaimMade, context: Context) -> HandlerResult:
         if request.filler is None:
             challenge_back_off_timestamp += context.config.fill_wait_time
         claim = Claim(event, challenge_back_off_timestamp)
+        if claim.fill_id in request.invalid_fill_ids:
+            tx_hash, timestamp = request.invalid_fill_ids[claim.fill_id]
+            claim.start_challenge(tx_hash, timestamp)
         context.claims.add(claim.id, claim)
 
         return True, None


### PR DESCRIPTION
We need to store invalid fillIds in the request object. This is due to the fact, that due to not processing preceding events, the claim creation can happen after processing invalidation events.