### PR TITLE
frontend: Add missing unit tests for simple components

### DIFF
--- a/frontend/src/components/WalletConnectionDetails.vue
+++ b/frontend/src/components/WalletConnectionDetails.vue
@@ -1,16 +1,12 @@
 <template>
   <div class="h-28 flex flex-col justify-center items-center">
-    <ConnectionError v-slot="{ message }" data-test="error-component">
-      <div class="text-center text-red p-2 text-lg h-12">
-        {{ message }}
-      </div>
-    </ConnectionError>
+    <ConnectionError />
 
     <div v-if="signer" class="flex flex-row gap-4 justify-center items-center" data-test="details">
       <div class="h-7 w-7 rounded-50 border-[3px] border-solid border-sea-green bg-green"></div>
       <div class="flex flex-col w-full">
         <span class="text-lg">You are currently connected</span>
-        <Disconnect> </Disconnect>
+        <Disconnect />
       </div>
     </div>
   </div>

--- a/frontend/src/components/WalletMenu.vue
+++ b/frontend/src/components/WalletMenu.vue
@@ -11,6 +11,7 @@
       v-for="walletOption of walletOptions"
       :key="walletOption.name"
       class="w-[25rem] flex flex-col items-center my-5 py-5 bg-sea-green rounded-lg text-black gap-2"
+      :data-test="`connect-${walletOption.name}`"
       @click.stop="walletOption.connect"
     >
       <div v-if="walletOption.connecting" class="w-20 h-20 items-center justify-center flex">

--- a/frontend/src/components/wallet/ConnectionError.vue
+++ b/frontend/src/components/wallet/ConnectionError.vue
@@ -1,5 +1,7 @@
 <template>
-  <slot data-test="error" v-bind="{ message }"></slot>
+  <div class="text-center text-red p-2 text-lg h-12">
+    {{ message }}
+  </div>
 </template>
 
 <script lang="ts" setup>

--- a/frontend/src/composables/useWallet.ts
+++ b/frontend/src/composables/useWallet.ts
@@ -1,7 +1,7 @@
 import type { Ref } from 'vue';
 
 import { useAsynchronousTask } from '@/composables/useAsynchronousTask';
-import type { EthereumProvider } from '@/services/web3-provider';
+import type { IEthereumProvider } from '@/services/web3-provider';
 import {
   createMetaMaskProvider,
   createWalletConnectProvider,
@@ -10,7 +10,7 @@ import {
 import { WalletType } from '@/types/settings';
 
 export function useWallet(
-  provider: Ref<EthereumProvider | undefined>,
+  provider: Ref<IEthereumProvider | undefined>,
   connectedWallet: Ref<WalletType | undefined>,
   rpcUrls: Ref<{ [chainId: number]: string }>,
 ) {

--- a/frontend/tests/unit/components/WalletConnectionDetails.spec.ts
+++ b/frontend/tests/unit/components/WalletConnectionDetails.spec.ts
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { ref } from 'vue';
 
+import ConnectionError from '@/components/wallet/ConnectionError.vue';
 import Disconnect from '@/components/wallet/Disconnect.vue';
 import WalletConnectionDetails from '@/components/WalletConnectionDetails.vue';
 import * as useEthereumProviderComposable from '@/stores/ethereum-provider';
@@ -23,7 +24,7 @@ function createWrapper() {
 describe('WalletConnectionDetails.vue', () => {
   it('renders connection error component', () => {
     const wrapper = createWrapper();
-    const connectionError = wrapper.find('[data-test="error-component"]');
+    const connectionError = wrapper.findComponent(ConnectionError);
     expect(connectionError.exists()).toBe(true);
   });
 

--- a/frontend/tests/unit/components/WalletMenu.spec.ts
+++ b/frontend/tests/unit/components/WalletMenu.spec.ts
@@ -1,0 +1,132 @@
+import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+
+import WalletMenu from '@/components/WalletMenu.vue';
+import type { useWallet } from '@/composables/useWallet';
+import * as useWalletComposable from '@/composables/useWallet';
+import * as userAgent from '@/utils/userAgent';
+import { MockedEthereumProvider } from '~/utils/mocks/ethereum-provider';
+
+vi.mock('@ethersproject/providers');
+
+function createWrapper(options?: { provider: MockedEthereumProvider }) {
+  return mount(WalletMenu, {
+    shallow: true,
+    global: {
+      plugins: [
+        createTestingPinia({
+          initialState: {
+            ethereumProvider: {
+              provider: options?.provider ?? new MockedEthereumProvider(),
+            },
+          },
+        }),
+      ],
+    },
+  });
+}
+
+function createUseWalletComposableReturnValue(
+  partialReturnObject?: Partial<ReturnType<typeof useWallet>>,
+) {
+  return {
+    connectMetaMask: vi.fn(),
+    connectWalletConnect: vi.fn(),
+    connectingMetaMask: ref(false),
+    connectingWalletConnect: ref(false),
+    ...partialReturnObject,
+  };
+}
+
+describe('WalletMenu.vue', () => {
+  beforeEach(() => {
+    Object.defineProperty(useWalletComposable, 'useWallet', {
+      value: vi.fn().mockReturnValue(createUseWalletComposableReturnValue()),
+    });
+  });
+
+  it('renders all available options', () => {
+    const wrapper = createWrapper();
+    const text = wrapper.text();
+    expect(text).toMatch('MetaMask');
+    expect(text).toMatch('WalletConnect');
+  });
+
+  it('connects MetaMask on click', () => {
+    const connectMetaMask = vi.fn();
+    Object.defineProperty(useWalletComposable, 'useWallet', {
+      value: vi.fn().mockReturnValue(createUseWalletComposableReturnValue({ connectMetaMask })),
+    });
+    const wrapper = createWrapper();
+    const button = wrapper.get('[data-test="connect-MetaMask"]');
+
+    button.trigger('click');
+    expect(connectMetaMask).toHaveBeenCalledOnce();
+  });
+
+  it('connects WalletConnect on click', () => {
+    const connectWalletConnect = vi.fn();
+    Object.defineProperty(useWalletComposable, 'useWallet', {
+      value: vi
+        .fn()
+        .mockReturnValue(createUseWalletComposableReturnValue({ connectWalletConnect })),
+    });
+    const wrapper = createWrapper();
+    const button = wrapper.get('[data-test="connect-WalletConnect"]');
+
+    button.trigger('click');
+    expect(connectWalletConnect).toHaveBeenCalledOnce();
+  });
+
+  it('closes on click on close button', () => {
+    const wrapper = createWrapper();
+    const closeButton = wrapper.get('[data-test="close-button"]');
+
+    closeButton.trigger('click');
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('closes when signer is available', async () => {
+    const provider = new MockedEthereumProvider();
+    const wrapper = createWrapper({ provider });
+
+    provider.signer.value = new JsonRpcSigner(undefined, new JsonRpcProvider());
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  describe('on mobile', () => {
+    beforeEach(() => {
+      Object.defineProperty(userAgent, 'isMobile', {
+        value: vi.fn().mockReturnValue(true),
+      });
+    });
+
+    describe('if MetaMask is available', () => {
+      it('filters options to only include MetaMask provider', async () => {
+        vi.stubGlobal('ethereum', { isMetaMask: true });
+        const wrapper = createWrapper();
+        await wrapper.vm.$nextTick();
+
+        const text = wrapper.text();
+        expect(text).toMatch('MetaMask');
+        expect(text).not.toMatch('WalletConnect');
+      });
+    });
+
+    describe('if MetaMask is not available', () => {
+      it('filters options to only include mobile browser wallet providers', async () => {
+        vi.stubGlobal('ethereum', { isMetaMask: false });
+        const wrapper = createWrapper();
+        await wrapper.vm.$nextTick();
+
+        const text = wrapper.text();
+        expect(text).not.toMatch('MetaMask');
+        expect(text).toMatch('WalletConnect');
+      });
+    });
+  });
+});

--- a/frontend/tests/unit/components/layout/Tabs.spec.ts
+++ b/frontend/tests/unit/components/layout/Tabs.spec.ts
@@ -4,6 +4,8 @@ import { markRaw } from 'vue';
 import Tabs from '@/components/layout/Tabs.vue';
 import { getRandomString } from '~/utils/data_generators';
 
+const TEST_HTML_TAGS = ['foo', 'bar', 'baz'];
+
 function createWrapper(options?: {
   tabs: Array<{ label?: string; template?: string }>;
   activeTabLabel?: string;
@@ -16,6 +18,11 @@ function createWrapper(options?: {
   return mount(Tabs, {
     shallow: false,
     props: { tabs, activeTabLabel: options?.activeTabLabel },
+    global: {
+      config: {
+        compilerOptions: { isCustomElement: (tag: string) => TEST_HTML_TAGS.includes(tag) },
+      },
+    },
   });
 }
 
@@ -32,74 +39,74 @@ describe('Tabs.vue', () => {
   });
 
   it('shows first tab content per default', () => {
-    const tabs = [{ template: 'foo' }, { template: 'bar' }, { template: 'baz' }];
+    const tabs = [{ template: '<foo />' }, { template: '<bar />' }, { template: '<baz />' }];
     const wrapper = createWrapper({ tabs });
     const tabContent = wrapper.get('[data-test="tab-content"]');
 
-    expect(tabContent.html()).toContain('foo');
+    expect(tabContent.findComponent('foo').exists()).toBe(true);
   });
 
   it('can alternate first open tab via property', () => {
-    const tabs = [{ template: 'foo' }, { label: 'bar', template: 'bar' }];
+    const tabs = [{ template: '<foo />' }, { label: 'bar', template: '<bar />' }];
     const wrapper = createWrapper({ tabs, activeTabLabel: 'bar' });
     const tabContent = wrapper.get('[data-test="tab-content"]');
 
-    expect(tabContent.html()).toContain('bar');
+    expect(tabContent.findComponent('bar').exists()).toBe(true);
   });
 
   it('can switch tab content via clicks on the headers', async () => {
-    const tabs = [{ template: 'foo' }, { template: 'bar' }, { template: 'baz' }];
+    const tabs = [{ template: '<foo />' }, { template: '<bar />' }, { template: '<baz />' }];
     const wrapper = createWrapper({ tabs });
     const tabHeaders = wrapper.findAll('[data-test="tab-header"]');
     const tabContent = wrapper.get('[data-test="tab-content"]');
 
-    expect(tabContent.html()).toContain('foo');
+    expect(tabContent.findComponent('foo').exists()).toBe(true);
     await tabHeaders[1].trigger('click');
-    expect(tabContent.html()).toContain('bar');
+    expect(tabContent.findComponent('bar').exists()).toBe(true);
     await tabHeaders[2].trigger('click');
-    expect(tabContent.html()).toContain('baz');
+    expect(tabContent.findComponent('baz').exists()).toBe(true);
     await tabHeaders[1].trigger('click');
-    expect(tabContent.html()).toContain('bar');
+    expect(tabContent.findComponent('bar').exists()).toBe(true);
     await tabHeaders[0].trigger('click');
-    expect(tabContent.html()).toContain('foo');
+    expect(tabContent.findComponent('foo').exists()).toBe(true);
   });
 
   it('can switch tab content via alternating the related property', async () => {
     const tabs = [
-      { label: 'foo', template: 'foo' },
-      { label: 'bar', template: 'bar' },
-      { label: 'baz', template: 'baz' },
+      { label: 'foo', template: '<foo />' },
+      { label: 'bar', template: '<bar />' },
+      { label: 'baz', template: '<baz />' },
     ];
     const wrapper = createWrapper({ tabs });
     const tabContent = wrapper.get('[data-test="tab-content"]');
 
-    expect(tabContent.html()).toContain('foo');
+    expect(tabContent.findComponent('foo').exists()).toBe(true);
     await wrapper.setProps({ ...wrapper.props, activeTabLabel: 'bar' });
-    expect(tabContent.html()).toContain('bar');
+    expect(tabContent.findComponent('bar').exists()).toBe(true);
     await wrapper.setProps({ ...wrapper.props, activeTabLabel: 'baz' });
-    expect(tabContent.html()).toContain('baz');
+    expect(tabContent.findComponent('baz').exists()).toBe(true);
     await wrapper.setProps({ ...wrapper.props, activeTabLabel: 'bar' });
-    expect(tabContent.html()).toContain('bar');
+    expect(tabContent.findComponent('bar').exists()).toBe(true);
     await wrapper.setProps({ ...wrapper.props, activeTabLabel: 'foo' });
-    expect(tabContent.html()).toContain('foo');
+    expect(tabContent.findComponent('foo').exists()).toBe(true);
   });
 
   it('does nothing if trying to switch to unknown tab', async () => {
     const tabs = [
-      { label: 'foo', template: 'foo' },
-      { label: 'bar', template: 'bar' },
+      { label: 'foo', template: '<foo />' },
+      { label: 'bar', template: '<bar />' },
     ];
     const wrapper = createWrapper({ tabs });
     const tabContent = wrapper.get('[data-test="tab-content"]');
-    expect(tabContent.html()).toContain('foo');
+    expect(tabContent.findComponent('foo').exists()).toBe(true);
 
     await wrapper.setProps({ ...wrapper.props, activeTabLabel: 'baz' });
 
-    expect(tabContent.html()).toContain('foo');
+    expect(tabContent.findComponent('foo').exists()).toBe(true);
   });
 
   it('does not unload content component when tab changes', async () => {
-    const tabs = [{ template: '<input id="test-input" />' }, { template: 'bar' }];
+    const tabs = [{ template: '<input id="test-input" />' }, { template: '<bar />' }];
     const wrapper = createWrapper({ tabs });
     const tabHeaders = wrapper.findAll('[data-test="tab-header"]');
 

--- a/frontend/tests/unit/components/wallet/ConnectionError.spec.ts
+++ b/frontend/tests/unit/components/wallet/ConnectionError.spec.ts
@@ -2,30 +2,53 @@ import { createTestingPinia } from '@pinia/testing';
 import { mount } from '@vue/test-utils';
 
 import ConnectionError from '@/components/wallet/ConnectionError.vue';
+import type { BeamerConfig } from '@/types/config';
+import {
+  generateBeamerConfig,
+  generateChainWithTokens,
+  getRandomNumber,
+} from '~/utils/data_generators';
 import { MockedEthereumProvider } from '~/utils/mocks/ethereum-provider';
 
-describe('ConnectionError.vue', () => {
-  it('provides an error message when connected chain is not supported', () => {
-    const wrapper = mount(ConnectionError, {
+function createWrapper(options?: { connectedChainId?: number; config?: BeamerConfig }) {
+  return mount(ConnectionError, {
+    shallow: true,
+    global: {
       plugins: [
         createTestingPinia({
           initialState: {
             ethereumProvider: {
-              provider: new MockedEthereumProvider({ chainId: 5 }),
+              provider: new MockedEthereumProvider({
+                chainId: options?.connectedChainId ?? getRandomNumber(),
+              }),
             },
-            configuration: {
-              chains: { 6: {} },
-            },
+            configuration: options?.config ?? generateBeamerConfig(),
           },
         }),
       ],
-      slots: {
-        default: `<template v-slot="params">
-            <span>{{params.message}}</span>
-        </template>`,
-      },
+    },
+  });
+}
+
+describe('ConnectionError.vue', () => {
+  it('shows an error message when connected chain is not supported', () => {
+    const wrapper = createWrapper({
+      connectedChainId: 99,
+      config: generateBeamerConfig({
+        chains: { 101: generateChainWithTokens({ identifier: 101 }) },
+      }),
     });
 
     expect(wrapper.text()).toEqual('Connected chain is not supported');
+  });
+  it('shows no error message when connected chain is supported', () => {
+    const wrapper = createWrapper({
+      connectedChainId: 50,
+      config: generateBeamerConfig({
+        chains: { 50: generateChainWithTokens({ identifier: 50 }) },
+      }),
+    });
+
+    expect(wrapper.text()).toEqual('');
   });
 });

--- a/frontend/tests/unit/components/wallet/Disconnect.spec.ts
+++ b/frontend/tests/unit/components/wallet/Disconnect.spec.ts
@@ -8,7 +8,10 @@ vi.mock('@/composables/useWallet');
 
 const createWrapper = () => {
   return mount(Disconnect, {
-    plugins: [createTestingPinia()],
+    shallow: true,
+    global: {
+      plugins: [createTestingPinia()],
+    },
   });
 };
 


### PR DESCRIPTION
closes #587 

Adds the missing tests for the `WalletMenu`. Also refactors the `ConnectionError` to not use a slot in order to be consistent with the `Disconnect`. Hope this is fine. I must have overlooked it in the PR review.
Additionally, I fixed the warnings that were shown during test runs.