### PR TITLE
frontend: include matomo tracking script

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -45,5 +45,24 @@
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
     <script src="//embed.typeform.com/next/embed.js"></script>
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function () {
+        var u = 'https://beamerbridge.matomo.cloud/';
+        _paq.push(['setTrackerUrl', u + 'matomo.php']);
+        _paq.push(['setSiteId', '1']);
+        var d = document,
+          g = d.createElement('script'),
+          s = d.getElementsByTagName('script')[0];
+        g.async = true;
+        g.src = '//cdn.matomo.cloud/beamerbridge.matomo.cloud/matomo.js';
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <!-- End Matomo Code -->
   </body>
 </html>


### PR DESCRIPTION
Solves a small part of the issue: #1131 

Seems like [Piwik is not tracking](https://stackoverflow.com/questions/13688749/piwik-localhost-tracking) `localhost` activity by default therefore there was no need to avoid script loading inside dev environment.