### PR TITLE
frontend: fix "use max token balance" feature

### DIFF
--- a/frontend/src/components/RequestSourceInputs.vue
+++ b/frontend/src/components/RequestSourceInputs.vue
@@ -47,9 +47,9 @@
             autocorrect="off"
             placeholder="0.00"
             required
-            :valid="isSelectedAmountValid"
+            :valid="selectedAmount.length == 0 || isSelectedAmountValid"
           />
-          <InputValidationMessage v-if="!isSelectedAmountValid">
+          <InputValidationMessage v-if="!isSelectedAmountValid && selectedAmount.length > 0">
             {{ v$.$validationGroups && v$.$validationGroups.amount.$errors[0].$message }}
           </InputValidationMessage>
           <div v-else class="self-end">

--- a/frontend/src/composables/useMaxTransferableTokenAmount.ts
+++ b/frontend/src/composables/useMaxTransferableTokenAmount.ts
@@ -1,7 +1,7 @@
 import type { Ref } from 'vue';
 import { ref, watch } from 'vue';
 
-import { deriveBaseTransferableAmountFromTotalAmount } from '@/services/transactions/request-manager';
+import { getAmountBeforeFees } from '@/services/transactions/request-manager';
 import type { Chain } from '@/types/data';
 import { TokenAmount } from '@/types/token-amount';
 
@@ -14,10 +14,10 @@ export function useMaxTransferableTokenAmount(
 
   async function updateMaxTransferableTokenAmount(balance: TokenAmount, chain: Chain) {
     try {
-      const transferableAmount = await deriveBaseTransferableAmountFromTotalAmount(
+      const transferableAmount = await getAmountBeforeFees(
+        balance.uint256,
         chain.rpcUrl,
         chain.requestManagerAddress,
-        balance.uint256,
       );
       maxTransferableTokenAmount.value = TokenAmount.new(transferableAmount, balance.token);
     } catch (e) {

--- a/frontend/src/composables/useMaxTransferableTokenAmount.ts
+++ b/frontend/src/composables/useMaxTransferableTokenAmount.ts
@@ -1,0 +1,41 @@
+import type { Ref } from 'vue';
+import { ref, watch } from 'vue';
+
+import { deriveBaseTransferableAmountFromTotalAmount } from '@/services/transactions/request-manager';
+import type { Chain } from '@/types/data';
+import { TokenAmount } from '@/types/token-amount';
+
+export function useMaxTransferableTokenAmount(
+  totalTokenAmount: Ref<TokenAmount | undefined>,
+  chain: Ref<Chain | undefined>,
+) {
+  const maxTransferableTokenAmount: Ref<TokenAmount | undefined> = ref(undefined);
+  const loading = ref(false);
+
+  async function updateMaxTransferableTokenAmount(balance: TokenAmount, chain: Chain) {
+    try {
+      const transferableAmount = await deriveBaseTransferableAmountFromTotalAmount(
+        chain.rpcUrl,
+        chain.requestManagerAddress,
+        balance.uint256,
+      );
+      maxTransferableTokenAmount.value = TokenAmount.new(transferableAmount, balance.token);
+    } catch (e) {
+      maxTransferableTokenAmount.value = undefined;
+    }
+  }
+
+  async function handleBalanceChange() {
+    if (!totalTokenAmount.value || !chain.value) {
+      maxTransferableTokenAmount.value = undefined;
+      return;
+    }
+    loading.value = true;
+    await updateMaxTransferableTokenAmount(totalTokenAmount.value, chain.value);
+    loading.value = false;
+  }
+
+  watch(totalTokenAmount, handleBalanceChange, { immediate: true });
+
+  return { maxTransferableTokenAmount, loading };
+}

--- a/frontend/src/services/transactions/request-manager.ts
+++ b/frontend/src/services/transactions/request-manager.ts
@@ -9,10 +9,10 @@ import type { Cancelable } from '@/types/async';
 import type { EthereumAddress } from '@/types/data';
 import { UInt256 } from '@/types/uint-256';
 
-export async function deriveBaseTransferableAmountFromTotalAmount(
+export async function getAmountBeforeFees(
+  totalAmountWei: UInt256,
   rpcUrl: string,
   requestManagerAddress: string,
-  totalAmountWei: UInt256,
 ): Promise<UInt256> {
   const PARTS_IN_MILLION = new UInt256('1000000');
   const contract = getContract(rpcUrl, requestManagerAddress, RequestManager.abi);

--- a/frontend/src/services/transactions/utils.ts
+++ b/frontend/src/services/transactions/utils.ts
@@ -1,0 +1,14 @@
+import { JsonRpcProvider } from '@ethersproject/providers';
+import type { ContractInterface } from 'ethers';
+import { Contract } from 'ethers';
+
+import type { EthereumAddress } from '@/types/data';
+
+export function getContract(
+  rpcUrl: string,
+  address: EthereumAddress,
+  ABI: ContractInterface,
+): Contract {
+  const provider = new JsonRpcProvider(rpcUrl);
+  return new Contract(address, ABI, provider);
+}

--- a/frontend/src/types/uint-256.ts
+++ b/frontend/src/types/uint-256.ts
@@ -2,11 +2,21 @@ import { BigNumber, utils } from 'ethers';
 
 import type { Encodable } from '@/types/encoding';
 
+export enum EXCEPTIONS {
+  CONSTRUCT_NEGATIVE_VALUE = 'Cannot create UInt256 from a negative number',
+}
+
 export class UInt256 implements Encodable<UInt256Data> {
   private value: BigNumber;
 
   constructor(data: UInt256Data) {
-    this.value = BigNumber.from(data);
+    const value = BigNumber.from(data);
+
+    if (value.isNegative()) {
+      throw new Error(EXCEPTIONS.CONSTRUCT_NEGATIVE_VALUE);
+    }
+
+    this.value = value;
   }
 
   static parse(value: string, decimals?: number): UInt256 {
@@ -27,6 +37,18 @@ export class UInt256 implements Encodable<UInt256Data> {
 
   public add(value: UInt256): UInt256 {
     return new UInt256(this.value.add(value.value).toString());
+  }
+
+  public subtract(value: UInt256): UInt256 {
+    return new UInt256(this.value.sub(value.value).toString());
+  }
+
+  public multiply(value: UInt256): UInt256 {
+    return new UInt256(this.value.mul(value.value).toString());
+  }
+
+  public divide(value: UInt256): UInt256 {
+    return new UInt256(this.value.div(value.value).toString());
   }
 
   public isZero(): boolean {

--- a/frontend/tests/unit/composables/useMaxTransferableTokenAmount.spec.ts
+++ b/frontend/tests/unit/composables/useMaxTransferableTokenAmount.spec.ts
@@ -14,8 +14,8 @@ vi.mock('@/services/transactions/request-manager');
 
 describe('useMaxTransferableTokenAmount', () => {
   beforeEach(() => {
-    Object.defineProperty(requestManagerService, 'deriveBaseTransferableAmountFromTotalAmount', {
-      value: vi.fn().mockImplementation((rpcUrl, requestManagerAddress, amount) => amount),
+    Object.defineProperty(requestManagerService, 'getAmountBeforeFees', {
+      value: vi.fn().mockImplementation((amount) => amount),
     });
   });
   beforeEach(() => {
@@ -63,18 +63,18 @@ describe('useMaxTransferableTokenAmount', () => {
         new TokenAmount({ amount: '1000', token: TOKEN }),
       ) as Ref<TokenAmount>;
       const chain = ref(CHAIN);
-      const mockedDeriveBaseTransferableAmountFromTotalAmount = vi.fn().mockImplementation(() => {
+      const mockedGetAmountBeforeFees = vi.fn().mockImplementation(() => {
         throw new Error('error');
       });
 
-      Object.defineProperty(requestManagerService, 'deriveBaseTransferableAmountFromTotalAmount', {
-        value: mockedDeriveBaseTransferableAmountFromTotalAmount,
+      Object.defineProperty(requestManagerService, 'getAmountBeforeFees', {
+        value: mockedGetAmountBeforeFees,
       });
 
       const { maxTransferableTokenAmount } = useMaxTransferableTokenAmount(totalAmount, chain);
       await flushPromises();
 
-      expect(mockedDeriveBaseTransferableAmountFromTotalAmount).toHaveBeenCalled();
+      expect(mockedGetAmountBeforeFees).toHaveBeenCalled();
       expect(maxTransferableTokenAmount.value).toBeUndefined();
     });
   });

--- a/frontend/tests/unit/composables/useMaxTransferableTokenAmount.spec.ts
+++ b/frontend/tests/unit/composables/useMaxTransferableTokenAmount.spec.ts
@@ -1,0 +1,111 @@
+import { flushPromises } from '@vue/test-utils';
+import type { Ref } from 'vue';
+import { ref } from 'vue';
+
+import { useMaxTransferableTokenAmount } from '@/composables/useMaxTransferableTokenAmount';
+import * as requestManagerService from '@/services/transactions/request-manager';
+import { TokenAmount } from '@/types/token-amount';
+import { generateChain, generateToken } from '~/utils/data_generators';
+
+const TOKEN = generateToken();
+const CHAIN = generateChain();
+
+vi.mock('@/services/transactions/request-manager');
+
+describe('useMaxTransferableTokenAmount', () => {
+  beforeEach(() => {
+    Object.defineProperty(requestManagerService, 'deriveBaseTransferableAmountFromTotalAmount', {
+      value: vi.fn().mockImplementation((rpcUrl, requestManagerAddress, amount) => amount),
+    });
+  });
+  beforeEach(() => {
+    global.console.error = vi.fn();
+  });
+
+  describe('maxTransferableTokenAmount', () => {
+    it('is undefined when provided total amount is undefined', async () => {
+      const totalAmount = ref(undefined);
+      const chain = ref(CHAIN);
+
+      const { maxTransferableTokenAmount } = useMaxTransferableTokenAmount(totalAmount, chain);
+      await flushPromises();
+
+      expect(maxTransferableTokenAmount.value).toBeUndefined();
+    });
+
+    it('is undefined when provided chain is undefined', async () => {
+      const totalAmount = ref(
+        new TokenAmount({ amount: '1000', token: TOKEN }),
+      ) as Ref<TokenAmount>;
+      const chain = ref(undefined);
+
+      const { maxTransferableTokenAmount } = useMaxTransferableTokenAmount(totalAmount, chain);
+      await flushPromises();
+
+      expect(maxTransferableTokenAmount.value).toBeUndefined();
+    });
+
+    it('holds the actual transferable amount derived from the provided total amount by deducting the expected fees', async () => {
+      const totalAmount = ref(
+        new TokenAmount({ amount: '1000', token: TOKEN }),
+      ) as Ref<TokenAmount>;
+
+      const chain = ref(CHAIN);
+
+      const { maxTransferableTokenAmount } = useMaxTransferableTokenAmount(totalAmount, chain);
+      await flushPromises();
+
+      expect(maxTransferableTokenAmount.value).not.toBeUndefined();
+    });
+
+    it('is undefined when calculation fails with an exception', async () => {
+      const totalAmount = ref(
+        new TokenAmount({ amount: '1000', token: TOKEN }),
+      ) as Ref<TokenAmount>;
+      const chain = ref(CHAIN);
+      const mockedDeriveBaseTransferableAmountFromTotalAmount = vi.fn().mockImplementation(() => {
+        throw new Error('error');
+      });
+
+      Object.defineProperty(requestManagerService, 'deriveBaseTransferableAmountFromTotalAmount', {
+        value: mockedDeriveBaseTransferableAmountFromTotalAmount,
+      });
+
+      const { maxTransferableTokenAmount } = useMaxTransferableTokenAmount(totalAmount, chain);
+      await flushPromises();
+
+      expect(mockedDeriveBaseTransferableAmountFromTotalAmount).toHaveBeenCalled();
+      expect(maxTransferableTokenAmount.value).toBeUndefined();
+    });
+  });
+
+  describe('loading', () => {
+    it('indicates that a recalculation for maxTransferableTokenAmount is running', async () => {
+      const totalAmount = ref(
+        new TokenAmount({ amount: '1000', token: TOKEN }),
+      ) as Ref<TokenAmount>;
+      const chain = ref(CHAIN);
+
+      const { loading } = useMaxTransferableTokenAmount(totalAmount, chain);
+
+      expect(loading.value).toBe(true);
+      await flushPromises();
+      expect(loading.value).toBe(false);
+    });
+  });
+
+  it('watches for changes on the provided token amount and recalculates maxTransferableTokenAmount', async () => {
+    const totalAmount = ref(undefined) as Ref<TokenAmount | undefined>;
+    const chain = ref(CHAIN);
+
+    const { maxTransferableTokenAmount } = useMaxTransferableTokenAmount(totalAmount, chain);
+    await flushPromises();
+
+    expect(maxTransferableTokenAmount.value).toBeUndefined();
+
+    totalAmount.value = new TokenAmount({ amount: '1000', token: TOKEN });
+    await flushPromises();
+
+    expect(maxTransferableTokenAmount.value).not.toBeUndefined();
+  });
+});

--- a/frontend/tests/unit/services/transactions/request-manager.spec.ts
+++ b/frontend/tests/unit/services/transactions/request-manager.spec.ts
@@ -1,0 +1,132 @@
+import { deriveBaseTransferableAmountFromTotalAmount } from '@/services/transactions/request-manager';
+import * as transactionUtils from '@/services/transactions/utils';
+import { UInt256 } from '@/types/uint-256';
+import { getRandomEthereumAddress, getRandomUrl } from '~/utils/data_generators';
+
+vi.mock('@/services/transactions/utils');
+
+const PARTS_IN_PERCENT = 100;
+const PARTS_IN_MILLION = 1000000;
+
+function mockGetContractReturnValue(options?: {
+  minLpFeeWei?: UInt256;
+  lpFeePartsPerMillion?: UInt256;
+  protocolFeePartsPerMillion?: UInt256;
+}) {
+  Object.defineProperty(transactionUtils, 'getContract', {
+    value: vi.fn().mockReturnValue({
+      minLpFee: vi.fn().mockReturnValue(options?.minLpFeeWei?.asString ?? '0'),
+      lpFeePPM: vi.fn().mockReturnValue(options?.lpFeePartsPerMillion?.asString ?? '0'),
+      protocolFeePPM: vi
+        .fn()
+        .mockReturnValue(options?.protocolFeePartsPerMillion?.asString ?? '0'),
+    }),
+  });
+  return;
+}
+
+function transformPercentToPPM(percent: number): string {
+  return (percent * (PARTS_IN_MILLION / PARTS_IN_PERCENT)).toString();
+}
+
+describe('request-manager', () => {
+  beforeEach(() => {
+    global.console.error = vi.fn();
+  });
+  describe('deriveBaseAmountFromTotalTransferAmount()', () => {
+    describe('when percentage lp fee is higher than the minimal lp fee for the provided token amount', () => {
+      it('derives the base amount (amount before fees) from the provided total amount by using percentage fees', async () => {
+        const rpcUrl = getRandomUrl('rpc');
+        const requestManagerAddress = getRandomEthereumAddress();
+        const DECIMALS = 4;
+
+        const totalAmountDecimal = 1000;
+        const minLpFee = 1;
+        const lpFeePercent = 0.3;
+        const protocolFeePercent = 0.3;
+
+        const totalAmountWei = UInt256.parse(totalAmountDecimal.toString(), DECIMALS);
+        const minLpFeeWei = UInt256.parse(minLpFee.toString(), DECIMALS);
+        const lpFeePartsPerMillion = new UInt256(transformPercentToPPM(lpFeePercent));
+        const protocolFeePartsPerMillion = new UInt256(transformPercentToPPM(protocolFeePercent));
+
+        mockGetContractReturnValue({
+          minLpFeeWei,
+          lpFeePartsPerMillion,
+          protocolFeePartsPerMillion,
+        });
+
+        const baseAmount = await deriveBaseTransferableAmountFromTotalAmount(
+          rpcUrl,
+          requestManagerAddress,
+          totalAmountWei,
+        );
+
+        const decimalResult =
+          (totalAmountDecimal * PARTS_IN_PERCENT) /
+          (PARTS_IN_PERCENT + lpFeePercent + protocolFeePercent);
+
+        expect(baseAmount.format(DECIMALS)).toBeCloseTo(decimalResult, DECIMALS - 1);
+      });
+    });
+    describe('when percentage lp fee is lower than the minimal lp fee for the provided token amount', () => {
+      it('throws an exception when the base amount goes in the negative number range', async () => {
+        const rpcUrl = getRandomUrl('rpc');
+        const requestManagerAddress = getRandomEthereumAddress();
+        const DECIMALS = 0;
+
+        const totalAmountDecimal = 1;
+        const minLpFee = 2;
+        const lpFeePercent = 0.3;
+
+        const totalAmountWei = UInt256.parse(totalAmountDecimal.toString(), DECIMALS);
+        const minLpFeeWei = UInt256.parse(minLpFee.toString(), DECIMALS);
+        const lpFeePartsPerMillion = new UInt256(transformPercentToPPM(lpFeePercent));
+
+        mockGetContractReturnValue({ minLpFeeWei, lpFeePartsPerMillion });
+
+        expect(
+          deriveBaseTransferableAmountFromTotalAmount(
+            rpcUrl,
+            requestManagerAddress,
+            totalAmountWei,
+          ),
+        ).rejects.toThrow('Total amount is not high enough to cover the fees.');
+      });
+
+      it('derives the base amount (amount before fees) from the provided total amount by using protocol percentage fee & minimal lp fee in units', async () => {
+        const rpcUrl = getRandomUrl('rpc');
+        const requestManagerAddress = getRandomEthereumAddress();
+        const DECIMALS = 4;
+
+        const totalAmountDecimal = 1000;
+        const minLpFee = 10;
+        const lpFeePercent = 0.3;
+        const protocolFeePercent = 0.3;
+
+        const totalAmountWei = UInt256.parse(totalAmountDecimal.toString(), DECIMALS);
+        const minLpFeeWei = UInt256.parse(minLpFee.toString(), DECIMALS);
+        const lpFeePartsPerMillion = new UInt256(transformPercentToPPM(lpFeePercent));
+        const protocolFeePartsPerMillion = new UInt256(transformPercentToPPM(protocolFeePercent));
+
+        mockGetContractReturnValue({
+          minLpFeeWei,
+          lpFeePartsPerMillion,
+          protocolFeePartsPerMillion,
+        });
+
+        const baseAmount = await deriveBaseTransferableAmountFromTotalAmount(
+          rpcUrl,
+          requestManagerAddress,
+          totalAmountWei,
+        );
+
+        const decimalResult =
+          (totalAmountDecimal * PARTS_IN_PERCENT) / (PARTS_IN_PERCENT + protocolFeePercent) -
+          minLpFee;
+
+        expect(baseAmount.format(DECIMALS)).toBeCloseTo(decimalResult, DECIMALS - 1);
+      });
+    });
+  });
+});

--- a/frontend/tests/unit/services/transactions/utils.spec.ts
+++ b/frontend/tests/unit/services/transactions/utils.spec.ts
@@ -1,0 +1,28 @@
+import * as providers from '@ethersproject/providers';
+import * as ethers from 'ethers';
+
+import { getContract } from '@/services/transactions/utils';
+import { getRandomEthereumAddress, getRandomNumber, getRandomUrl } from '~/utils/data_generators';
+
+vi.mock('@ethersproject/providers');
+vi.mock('ethers');
+
+describe('utils', () => {
+  beforeEach(() => {
+    Object.defineProperty(providers, 'JsonRpcProvider', {
+      value: vi
+        .fn()
+        .mockReturnValue({ getBlockNumber: vi.fn().mockReturnValue(getRandomNumber()) }),
+    });
+  });
+
+  describe('getContract()', () => {
+    it('returns a contract instance', () => {
+      const rpcUrl = getRandomUrl('rpc');
+      const contractAddress = getRandomEthereumAddress();
+      const ABI = '';
+
+      expect(getContract(rpcUrl, contractAddress, ABI)).toBeInstanceOf(ethers.Contract);
+    });
+  });
+});

--- a/frontend/tests/unit/types/uint-256.spec.ts
+++ b/frontend/tests/unit/types/uint-256.spec.ts
@@ -1,4 +1,4 @@
-import { UInt256 } from '@/types/uint-256';
+import { EXCEPTIONS, UInt256 } from '@/types/uint-256';
 import { generateUInt256Data } from '~/utils/data_generators';
 
 function createUInt256Pair(numberOne: string, numberTwo: string) {
@@ -8,6 +8,10 @@ function createUInt256Pair(numberOne: string, numberTwo: string) {
   ];
 }
 describe('UInt256', () => {
+  it('cannot be instantiated for a negative number', () => {
+    expect(() => new UInt256('-50')).toThrow(EXCEPTIONS.CONSTRUCT_NEGATIVE_VALUE);
+  });
+
   describe('parse()', () => {
     it('correctly parses integer number according to decimals', () => {
       const number = UInt256.parse('2', 4);
@@ -25,12 +29,6 @@ describe('UInt256', () => {
       const number = UInt256.parse('1', 0);
 
       expect(number.asString).toBe('1');
-    });
-
-    it('can parse negative numbers', () => {
-      const number = UInt256.parse('-1');
-
-      expect(number.asString).toBe('-1');
     });
 
     it('can parse numbers larger then the maximum JavaScript integer', () => {
@@ -72,8 +70,29 @@ describe('UInt256', () => {
 
   describe('add()', () => {
     it('returns sum of two numbers', () => {
-      const [numberOne, numberTwo] = createUInt256Pair('100', '-50');
-      expect(numberOne.add(numberTwo).asString).toBe('50');
+      const [numberOne, numberTwo] = createUInt256Pair('100', '50');
+      expect(numberOne.add(numberTwo).asString).toBe('150');
+    });
+  });
+
+  describe('subtract()', () => {
+    it('returns the difference between two numbers', () => {
+      const [numberOne, numberTwo] = createUInt256Pair('100', '50');
+      expect(numberOne.subtract(numberTwo).asString).toBe('50');
+    });
+  });
+
+  describe('multiply()', () => {
+    it('returns the multiplication result of the two numbers', () => {
+      const [numberOne, numberTwo] = createUInt256Pair('4', '4');
+      expect(numberOne.multiply(numberTwo).asString).toBe('16');
+    });
+  });
+
+  describe('divide()', () => {
+    it('returns the result of the divison between the two numbers', () => {
+      const [numberOne, numberTwo] = createUInt256Pair('4', '4');
+      expect(numberOne.divide(numberTwo).asString).toBe('1');
     });
   });
 


### PR DESCRIPTION
Fixes #1127 

I adjusted the `UInt256` abstraction to not support creation of negative integers since that was contradictory to what this class is supposed/expected to do (unsigned should stand for positive only). It was necessary to adjust it as so since i introduced arithmetic operations over it.

Also includes a solution to [Manuel's suggestion](https://github.com/beamer-bridge/beamer/issues/1127#issuecomment-1278048533)