### PR TITLE
Added subdomain tracking

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -49,6 +49,9 @@
     <script>
       var _paq = (window._paq = window._paq || []);
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['setDocumentTitle', document.domain + '/' + document.title]);
+      _paq.push(['setCookieDomain', '*.beamerbridge.com']);
+      _paq.push(['setDomains', ['*.beamerbridge.com']]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function () {


### PR DESCRIPTION
closes #1155

Added:

tracking visitors across all subdomains
prepend the site domain to the page title when tracking outlines report hide clicks known alias URLS of beamer based on https://developer.matomo.org/guides/tracking-javascript-guide#measuring-domains-andor-sub-domains