### PR TITLE
frontend: avoid unallowed token amount input state

### DIFF
--- a/frontend/src/validation/validators.ts
+++ b/frontend/src/validation/validators.ts
@@ -11,7 +11,7 @@ export const isValidEthAddress: ValidatorFunction<string> = function (value: str
 };
 
 export const isUnsignedNumeric: ValidatorFunction<string> = function (value: string): boolean {
-  return /^\d*\.?\d*$/.test(value);
+  return /^\d*(\.\d+)?$/.test(value);
 };
 
 export const makeMatchingDecimalsValidator =

--- a/frontend/tests/unit/validation/validators.spec.ts
+++ b/frontend/tests/unit/validation/validators.spec.ts
@@ -33,12 +33,23 @@ describe('validators', () => {
       const value = '123.123';
       expect(isUnsignedNumeric(value)).toBe(true);
     });
-    it('returns false if provided value is not a numeric value', () => {
+    it('returns true if provided value is an usigned numeric value that contains only decimals', () => {
+      const value = '.123';
+      expect(isUnsignedNumeric(value)).toBe(true);
+    });
+    it('returns false if provided value contains alpha characters', () => {
       const value = 'asdf';
       expect(isUnsignedNumeric(value)).toBe(false);
     });
     it('returns false if provided value contains multiple decimal separators', () => {
       const value = '1.1.1';
+      expect(isUnsignedNumeric(value)).toBe(false);
+    });
+    it('returns false if provided value contains only symbols', () => {
+      let value = '.';
+      expect(isUnsignedNumeric(value)).toBe(false);
+
+      value = ',';
       expect(isUnsignedNumeric(value)).toBe(false);
     });
   });


### PR DESCRIPTION
closes #1152

Note on the discussion we had for limiting the user input to only valid numeric values: 
It's not going to be included in this PR as i didn't want to block the merging of this bugfix. In any case, that implementation would still not fix the bug described in #1152 so these 2 things are unrelated. I created a separate issue for this [here](https://github.com/beamer-bridge/beamer/issues/1165)