### PR TITLE
.github: go back to prettier-solidity-plugin 1.0.0-beta.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - attach_workspace:
           at: "~"
-      - run: npm install prettier prettier-plugin-solidity --location=global
+      - run: npm install prettier prettier-plugin-solidity@1.0.0-beta.19 --location=global
       - run: npm install solhint --location=global
       - run: npm install ganache --location=global
       - persist_to_workspace:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -81,7 +81,7 @@ jobs:
           cname: docs.beamerbridge.com
 
       - name: Install prettier for solidity
-        run: npm install prettier prettier-plugin-solidity --global
+        run: npm install prettier prettier-plugin-solidity@1.0.0-beta.19 --global
 
       - name: Check formatting of contracts
         run: prettier --list-different 'contracts/**/*.sol'


### PR DESCRIPTION
The newer 1.0.0-rc.1 causes unnecessary formatting changes and this is intended to fix our CI until we decide how to handle those changes.