### PR TITLE
frontend: Add explorer URL to wallet

### DIFF
--- a/frontend/config/chains/10.json
+++ b/frontend/config/chains/10.json
@@ -1,6 +1,6 @@
 {
   "identifier": 10,
-  "explorerTransactionUrl": "https://optimistic.etherscan.io/tx/",
+  "explorerUrl": "https://optimistic.etherscan.io",
   "rpcUrl": "https://opt-mainnet.g.alchemy.com/v2/umLO_ve2OzJ_7rAVebkVbUsuM37cCFoN",
   "name": "Optimism Mainnet",
   "imageUrl": "/images/optimism.png",

--- a/frontend/config/chains/1337.json
+++ b/frontend/config/chains/1337.json
@@ -1,6 +1,6 @@
 {
   "identifier": 1337,
-  "explorerTransactionUrl": "",
+  "explorerUrl": "",
   "rpcUrl": "http://localhost:8545/",
   "name": "Ganache",
   "tokenSymbols": ["TST"]

--- a/frontend/config/chains/28.json
+++ b/frontend/config/chains/28.json
@@ -1,7 +1,7 @@
 {
   "identifier": 28,
-  "explorerTransactionUrl": "https://blockexplorer.rinkeby.boba.network/tx/",
-  "rpcUrl": "https://rinkeby.boba.network/",
+  "explorerUrl": "https://blockexplorer.rinkeby.boba.network",
+  "rpcUrl": "https://rinkeby.boba.network",
   "name": "Boba Rinkeby",
   "imageUrl": "/images/boba.svg",
   "tokenSymbols": ["TST"]

--- a/frontend/config/chains/288.json
+++ b/frontend/config/chains/288.json
@@ -1,6 +1,6 @@
 {
   "identifier": 288,
-  "explorerTransactionUrl": "https://bobascan.com/tx/",
+  "explorerUrl": "https://bobascan.com",
   "rpcUrl": "https://replica.boba.network",
   "name": "Boba Mainnet",
   "imageUrl": "/images/boba.svg",

--- a/frontend/config/chains/588.json
+++ b/frontend/config/chains/588.json
@@ -1,6 +1,6 @@
 {
   "identifier": 588,
-  "explorerTransactionUrl": "https://stardust-explorer.metis.io/tx/",
+  "explorerUrl": "https://stardust-explorer.metis.io",
   "rpcUrl": "https://stardust.metis.io/?owner=588",
   "name": "Metis Stardust",
   "imageUrl": "/images/metis.png",

--- a/frontend/config/chains/chain.ts
+++ b/frontend/config/chains/chain.ts
@@ -5,7 +5,7 @@ import { readFileJsonContent } from '../utils';
 
 export class ChainMetadata {
   readonly identifier: number;
-  readonly explorerTransactionUrl: string;
+  readonly explorerUrl: string;
   readonly rpcUrl: string;
   readonly name: string;
   readonly imageUrl?: string;
@@ -13,7 +13,7 @@ export class ChainMetadata {
 
   constructor(data: ChainMetadataData) {
     this.identifier = data.identifier;
-    this.explorerTransactionUrl = data.explorerTransactionUrl;
+    this.explorerUrl = data.explorerUrl;
     this.rpcUrl = data.rpcUrl;
     this.name = data.name;
     this.imageUrl = data.imageUrl;
@@ -48,7 +48,7 @@ export class ChainMetadata {
 
 export type ChainMetadataData = {
   identifier: number;
-  explorerTransactionUrl: string;
+  explorerUrl: string;
   rpcUrl: string;
   name: string;
   imageUrl?: string;

--- a/frontend/config/schema.ts
+++ b/frontend/config/schema.ts
@@ -17,7 +17,7 @@ export const configSchema: JSONSchemaType<BeamerConfig> = {
               type: 'number',
               minimum: 0,
             },
-            explorerTransactionUrl: {
+            explorerUrl: {
               type: 'string',
             },
             rpcUrl: {
@@ -75,7 +75,7 @@ export const configSchema: JSONSchemaType<BeamerConfig> = {
           },
           required: [
             'identifier',
-            'explorerTransactionUrl',
+            'explorerUrl',
             'rpcUrl',
             'name',
             'tokens',

--- a/frontend/src/components/Transfer.vue
+++ b/frontend/src/components/Transfer.vue
@@ -51,9 +51,9 @@ const isExpanded = ref(props.transfer.active);
 const formattedAmount = computed(() => props.transfer.sourceAmount.format());
 
 const requestTransactionUrl = computed(() => {
-  const { explorerTransactionUrl } = props.transfer.sourceChain;
+  const { explorerUrl } = props.transfer.sourceChain;
   const { transactionHash } = props.transfer.requestInformation ?? {};
-  return transactionHash ? `${explorerTransactionUrl}${transactionHash}` : undefined;
+  return transactionHash ? `${explorerUrl}/tx/${transactionHash}` : undefined;
 });
 
 const summary = computed(() => ({

--- a/frontend/src/composables/useChainSelection.ts
+++ b/frontend/src/composables/useChainSelection.ts
@@ -32,7 +32,7 @@ export function getChainSelectorOption(
       rpcUrl: chains[chainId].rpcUrl,
       requestManagerAddress: chains[chainId].requestManagerAddress,
       fillManagerAddress: chains[chainId].fillManagerAddress,
-      explorerTransactionUrl: chains[chainId].explorerTransactionUrl,
+      explorerUrl: chains[chainId].explorerUrl,
       imageUrl: chains[chainId].imageUrl,
     };
     return { value: chain, label: chain.name, imageUrl: chain.imageUrl };

--- a/frontend/src/services/web3-provider/types.ts
+++ b/frontend/src/services/web3-provider/types.ts
@@ -2,7 +2,7 @@ import type { Block, ExternalProvider, JsonRpcSigner } from '@ethersproject/prov
 import type { Contract } from 'ethers';
 import type { Ref, ShallowRef } from 'vue';
 
-import type { Chain } from '@/types/data';
+import type { Chain, Token } from '@/types/data';
 
 export interface IEthereumProvider {
   signer: ShallowRef<JsonRpcSigner | undefined>;
@@ -13,7 +13,7 @@ export interface IEthereumProvider {
   connectContract(contract: Contract): Contract;
   switchChainSafely(newChain: Chain): Promise<boolean>;
   getChainId(): Promise<number>;
-  addToken(tokenData: TokenData): Promise<void>;
+  addToken(token: Token): Promise<void>;
 }
 export interface EventEmitter {
   on(eventName: string, listener: (...args: unknown[]) => void): void;
@@ -22,19 +22,6 @@ export interface EventEmitter {
 export interface ISigner {
   requestSigner(): Promise<void>;
 }
-
-export type ChainData = {
-  chainId: number | string;
-  rpcUrl: string;
-  name: string;
-};
-
-export type TokenData = {
-  address: string;
-  symbol?: string;
-  decimals?: number;
-  image?: string;
-};
 
 interface RequestArguments {
   readonly method: string;

--- a/frontend/src/types/data.ts
+++ b/frontend/src/types/data.ts
@@ -8,7 +8,7 @@ export type Chain = {
   rpcUrl: string; // TODO: restrict more
   requestManagerAddress: EthereumAddress;
   fillManagerAddress: EthereumAddress;
-  explorerTransactionUrl: string; // TODO: restrict more
+  explorerUrl: string; // TODO: restrict more
   imageUrl?: string; // TODO: restrict more
 };
 

--- a/frontend/tests/unit/components/Transfer.spec.ts
+++ b/frontend/tests/unit/components/Transfer.spec.ts
@@ -107,7 +107,7 @@ describe('Transfer.vue', () => {
       }),
       sourceChain: generateChain({
         name: 'Source Chain',
-        explorerTransactionUrl: 'https://test.explorer/tx/',
+        explorerUrl: 'https://test.explorer',
       }),
       targetChain: generateChain({ name: 'Target Chain' }),
       targetAccount: '0xTargetAccount',

--- a/frontend/tests/utils/data_generators.ts
+++ b/frontend/tests/utils/data_generators.ts
@@ -83,7 +83,7 @@ export function generateChain(partialChain?: Partial<Chain>): Chain {
     rpcUrl: getRandomUrl('rpc'),
     requestManagerAddress: getRandomEthereumAddress(),
     fillManagerAddress: getRandomEthereumAddress(),
-    explorerTransactionUrl: getRandomUrl('explorer'),
+    explorerUrl: getRandomUrl('explorer'),
     ...partialChain,
   };
 }
@@ -193,7 +193,7 @@ export function generateChainMetadata(
     identifier: getRandomNumber(),
     name: getRandomChainName(),
     rpcUrl: getRandomUrl('rpc'),
-    explorerTransactionUrl: getRandomUrl('explorer'),
+    explorerUrl: getRandomUrl('explorer'),
     tokenSymbols: [getRandomTokenSymbol()],
     ...partialChainMetadata,
   });


### PR DESCRIPTION
Closes #1124 

When adding a chain to the connected wallet, the explorer URL is now added. This also changes our config files by renaming `explorerTransactionUrl` to `explorerUrl` and removing the `/tx` path from the urls. This can be safely done as explorer routes are standardized in EIP-3091. Furthermore, the `addChain` was changed in that way that it now consumes the usual `Chain` type instead of the `ChainData` type. The `ChainData` type was added when we did not have the split types of the configuration and is redundant now. Same goes for `Token` and `TokenData`.