### PR TITLE
contracts: allow claim until validUntil + claimRequestExtension

### DIFF
--- a/beamer/agent.py
+++ b/beamer/agent.py
@@ -56,6 +56,8 @@ class Agent:
         if not request_manager.functions.allowedLps(config.account.address).call():
             raise RuntimeError("Agent address is not whitelisted on RequestManager")
 
+        claim_request_extension = request_manager.functions.claimRequestExtension().call()
+
         self.context = Context(
             requests=Tracker(),
             claims=Tracker(),
@@ -67,6 +69,7 @@ class Agent:
             config=config,
             web3_l1=w3_l1,
             task_pool=self._task_pool,
+            claim_request_extension=claim_request_extension,
             l1_resolutions={},
         )
 

--- a/beamer/chain.py
+++ b/beamer/chain.py
@@ -337,7 +337,7 @@ def claim_request(request: Request, context: Context) -> None:
         return
 
     block = context.latest_blocks[request.source_chain_id]
-    if block["timestamp"] >= request.valid_until:
+    if block["timestamp"] >= request.valid_until + context.claim_request_extension:
         log.info("Request expired, ignoring", request=request)
         request.ignore()
         return

--- a/beamer/state_machine.py
+++ b/beamer/state_machine.py
@@ -52,6 +52,7 @@ class Context:
     config: Config
     web3_l1: Web3
     task_pool: Executor
+    claim_request_extension: int
     l1_resolutions: dict[tuple[RequestId, ClaimId], Future]
     finality_periods: dict[ChainId, int] = field(default_factory=dict)
 

--- a/beamer/tests/agent/unit/test_handlers.py
+++ b/beamer/tests/agent/unit/test_handlers.py
@@ -32,7 +32,7 @@ def test_claim_after_expiry(claim_request_extension, claimable):
     context, config = make_context()
     valid_until = TIMESTAMP - claim_request_extension
     assert valid_until > 0
-    
+
     if claimable:
         valid_until += 1
 

--- a/beamer/tests/agent/unit/utils.py
+++ b/beamer/tests/agent/unit/utils.py
@@ -163,6 +163,7 @@ def make_context() -> Tuple[Context, Config]:
         config=config,
         web3_l1=MagicMock(),
         task_pool=MagicMock(),
+        claim_request_extension=100,
         l1_resolutions={},
     )
     context.request_manager.functions.claimStake().call.return_value = 1  # type: ignore

--- a/beamer/tests/conftest.py
+++ b/beamer/tests/conftest.py
@@ -56,6 +56,11 @@ def claim_stake():
 
 
 @pytest.fixture
+def claim_request_extension():
+    return 100
+
+
+@pytest.fixture
 def claim_period():
     return 100
 
@@ -80,6 +85,7 @@ def contracts(
     deployer,
     forward_state,
     claim_stake,
+    claim_request_extension,
     claim_period,
     finality_period,
     challenge_period_extension,
@@ -97,7 +103,11 @@ def contracts(
 
     # L2a contracts
     request_manager = deployer.deploy(
-        RequestManager, claim_stake, claim_period, challenge_period_extension
+        RequestManager,
+        claim_stake,
+        claim_request_extension,
+        claim_period,
+        challenge_period_extension,
     )
 
     # Add allowed LPs

--- a/beamer/tests/constants.py
+++ b/beamer/tests/constants.py
@@ -5,6 +5,7 @@ FILL_ID = FillId("abc".zfill(64))
 FILL_ID_EMPTY = FillId(bytes(32))
 
 # request fields
+RM_R_FIELD_VALID_UNTIL = 4
 RM_R_FIELD_LP_FEE = 5
 RM_R_FIELD_PROTOCOL_FEE = 6
 RM_R_FIELD_FILLER = 9

--- a/docs/source/protocol.rst
+++ b/docs/source/protocol.rst
@@ -10,6 +10,7 @@ Summary
 .. code::
 
     claimStake = k * avg\_gp\_l2a * (gas_{challenge} + gas_{withdraw})
+    claimRequestExtension = max(offline rollup) = 1 day
     claimPeriod = max(offline rollup) = 1 day
     challengePeriod = finalityPeriod[targetRollup] + buffer = 8 days
     challengePeriodExtension = 1 day
@@ -61,6 +62,23 @@ Proposed Values
 
 We propose a value of ``k = 1.3`` so that honest challengers are rewarded with a minimum of 30% of the challenge gas
 costs. The other parameters should be determined at time of deployment.
+
+claimRequestExtension
+---------------------
+
+``claimRequestExtension`` defines the period after a request expiry in which an agent is still
+allowed to make a claim for this request.
+
+The minimum claim request extension must ensure that the honest agent is able to claim a request. After the time has
+passed, no claiming is possible anymore. This is necessary so that an expired request can be withdrawn by the user
+eventually. Practical influencing factors also include experienced downtimes of existing rollups. Experienced downtimes
+were as high as 17 hours.
+
+
+Proposed Values
+^^^^^^^^^^^^^^^
+
+``claimRequestExtension = 1 day``
 
 claimPeriod
 -----------
@@ -135,6 +153,9 @@ expiration times. While setting a very low expiration time most likely leads to 
 by any LP, an upper boundary ensures that funds can eventually be withdrawn. With the current setup
 of fixed fees and a race between LPs, we introduce a safety net for LPs to ensure that there is
 enough time to register a claim of a filled request *before* it expires.
+An LP is able to claim a request after its expiry date. The period in which an LP can do that is
+defined by ``claimRequestExtension``. Note that during this time, the user can also withdraw the funds
+if there are no active claims.
 
 Proposed Values
 ^^^^^^^^^^^^^^^

--- a/scripts/deployment/arbitrum-local-template.json
+++ b/scripts/deployment/arbitrum-local-template.json
@@ -14,6 +14,7 @@
             "l2_messenger": "ArbitrumL2Messenger",
             "request_manager_arguments": {
                 "claim_stake": 0.00047,
+                "claim_request_extension": 3600,
                 "claim_period": 3600,
                 "challenge_period_extension": 3600
             }

--- a/scripts/deployment/ganache-local.json
+++ b/scripts/deployment/ganache-local.json
@@ -14,6 +14,7 @@
             "l2_messenger": "TestL2Messenger",
             "request_manager_arguments": {
                 "claim_stake": 0.00047,
+                "claim_request_extension": 3600,
                 "claim_period": 3600,
                 "challenge_period_extension": 3600
             }

--- a/scripts/deployment/main.py
+++ b/scripts/deployment/main.py
@@ -102,6 +102,7 @@ def deploy_beamer(
 
     request_manager_arguments = l2_config["request_manager_arguments"]
     claim_stake = to_wei(request_manager_arguments["claim_stake"], "ether")
+    claim_request_extension = request_manager_arguments["claim_request_extension"]
     claim_period = request_manager_arguments["claim_period"]
     challenge_period_extension = request_manager_arguments["challenge_period_extension"]
 
@@ -110,6 +111,7 @@ def deploy_beamer(
         (
             "RequestManager",
             claim_stake,
+            claim_request_extension,
             claim_period,
             challenge_period_extension,
         ),

--- a/scripts/deployment/mainnet.json
+++ b/scripts/deployment/mainnet.json
@@ -27,6 +27,7 @@
             "finality_period": 604800,
             "request_manager_arguments": {
                 "claim_stake": 0.0015,
+                "claim_request_extension": 86400,
                 "claim_period": 86400,
                 "challenge_period_extension": 86400
             }

--- a/scripts/deployment/optimism-local-template.json
+++ b/scripts/deployment/optimism-local-template.json
@@ -14,6 +14,7 @@
             "l2_messenger": "OptimismL2Messenger",
             "request_manager_arguments": {
                 "claim_stake": 0.00047,
+                "claim_request_extension": 3600,
                 "claim_period": 3600,
                 "challenge_period_extension": 3600
             }

--- a/scripts/deployment/rinkeby_testnets.json
+++ b/scripts/deployment/rinkeby_testnets.json
@@ -27,6 +27,7 @@
             "finality_period": 604800,
             "request_manager_arguments": {
                 "claim_stake": 0.00047,
+                "claim_request_extension": 3600,
                 "claim_period": 3600,
                 "challenge_period_extension": 3600
             }


### PR DESCRIPTION
Allows claiming after request expiry. Time is bounded by claimRequestExtension.

I went for the strict approach to introduce a new variable `claimRequestExtension`. Same as we did with claimPeriod and challengePeriodExtension which follow the same principle: Give an actor enough time to react.
In the future we can think about merging these values together, but for now I wanted to keep the pattern and create an explicit value.