### PR TITLE
contracts: Add isWithdrawn() function to request manager

### DIFF
--- a/contracts/contracts/RequestManager.sol
+++ b/contracts/contracts/RequestManager.sol
@@ -643,6 +643,25 @@ contract RequestManager is Ownable, LpWhitelist, RestrictedCalls {
         token.safeTransfer(claimer, request.amount + request.lpFee);
     }
 
+    /// Returns whether a request's deposit was withdrawn or not
+    ///
+    /// This can be true in two cases:
+    /// 1. The deposit was withdrawn after the request was claimed and filled.
+    /// 2. The submitter withdrew the deposit after the request's expiry.
+    /// .. seealso:: :sol:func:`withdraw`
+    /// .. seealso:: :sol:func:`withdrawExpiredRequest`
+    ///
+    /// @param requestId The request ID
+    /// @return Whether the deposit corresponding to the given request ID was withdrawn
+    function isWithdrawn(bytes32 requestId)
+        public
+        view
+        validRequestId(requestId)
+        returns (bool)
+    {
+        return requests[requestId].withdrawClaimId != 0;
+    }
+
     /// Withdraw protocol fees collected by the contract.
     ///
     /// Protocol fees are paid in token transferred.


### PR DESCRIPTION
Closes #1051

This enables easily checking if the deposit for a request was withdrawn or not.
For the tests, I added calls to the new function in the withdrawal test functions, in order to not duplicate the whole test setup for this simple function. Only the withdrawal state for a new request got its own test.