### PR TITLE
Arbitrum support, continued

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -6,7 +6,7 @@ project_structure:
     tests: contracts/tests
 
 dependencies:
-  - OpenZeppelin/openzeppelin-contracts@4.7.3
+  - OpenZeppelin/openzeppelin-contracts@4.8.0
 
 compiler:
   evm_version: london

--- a/contracts/contracts/FillManager.sol
+++ b/contracts/contracts/FillManager.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/token/ERC20/IERC20.sol";
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/token/ERC20/utils/SafeERC20.sol";
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/access/Ownable.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/token/ERC20/IERC20.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/token/ERC20/utils/SafeERC20.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/access/Ownable.sol";
 import "./LpWhitelist.sol";
 import "../interfaces/IMessenger.sol";
 import "./BeamerUtils.sol";

--- a/contracts/contracts/LpWhitelist.sol
+++ b/contracts/contracts/LpWhitelist.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/access/Ownable.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/access/Ownable.sol";
 
 /// Liquidity Provider Whitelist.
 ///

--- a/contracts/contracts/MintableToken.sol
+++ b/contracts/contracts/MintableToken.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/token/ERC20/ERC20.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/token/ERC20/ERC20.sol";
 
 contract MintableToken is ERC20 {
     constructor(uint256 initialSupply) ERC20("Test", "TST") {

--- a/contracts/contracts/RequestManager.sol
+++ b/contracts/contracts/RequestManager.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/token/ERC20/IERC20.sol";
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/token/ERC20/utils/SafeERC20.sol";
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/utils/math/Math.sol";
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/access/Ownable.sol";
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/security/Pausable.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/token/ERC20/IERC20.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/token/ERC20/utils/SafeERC20.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/utils/math/Math.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/access/Ownable.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/security/Pausable.sol";
 
 import "./BeamerUtils.sol";
 import "./RestrictedCalls.sol";

--- a/contracts/contracts/Resolver.sol
+++ b/contracts/contracts/Resolver.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/access/Ownable.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/access/Ownable.sol";
 import "../interfaces/IMessenger.sol";
 import "./RequestManager.sol";
 import "./RestrictedCalls.sol";

--- a/contracts/contracts/RestrictedCalls.sol
+++ b/contracts/contracts/RestrictedCalls.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/access/Ownable.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/access/Ownable.sol";
 import "../interfaces/IMessenger.sol";
 
 /// A helper contract that provides a way to restrict callers of restricted functions

--- a/contracts/contracts/StandardToken.sol
+++ b/contracts/contracts/StandardToken.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/token/ERC20/ERC20.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/token/ERC20/ERC20.sol";
 
 // solhint-disable-next-line no-empty-blocks
 abstract contract StandardToken is ERC20 {

--- a/contracts/contracts/chains/arbitrum/ArbitrumMessengers.sol
+++ b/contracts/contracts/chains/arbitrum/ArbitrumMessengers.sol
@@ -35,18 +35,6 @@ contract ArbitrumL1Messenger is IMessenger, RestrictedCalls {
         return sender == caller;
     }
 
-    // This is copied verbatim from the Arbitrum Nitro repo.
-    // TODO: remove once OpenZeppelin is updated with new Nitro contracts.
-    // See https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3692.
-    function calculateRetryableSubmissionFee(
-        uint256 dataLength,
-        uint256 baseFee
-    ) public view returns (uint256) {
-        // Use current block basefee if baseFee parameter is 0
-        return
-            (1400 + 6 * dataLength) * (baseFee == 0 ? block.basefee : baseFee);
-    }
-
     function deposit() external payable {
         deposits[msg.sender] += msg.value;
     }
@@ -66,7 +54,7 @@ contract ArbitrumL1Messenger is IMessenger, RestrictedCalls {
         external
         restricted(block.chainid)
     {
-        uint256 submissionFee = calculateRetryableSubmissionFee(
+        uint256 submissionFee = inbox.calculateRetryableSubmissionFee(
             message.length,
             0
         );

--- a/contracts/contracts/chains/arbitrum/ArbitrumMessengers.sol
+++ b/contracts/contracts/chains/arbitrum/ArbitrumMessengers.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/vendor/arbitrum/IArbSys.sol";
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/vendor/arbitrum/IBridge.sol";
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/vendor/arbitrum/IInbox.sol";
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/vendor/arbitrum/IOutbox.sol";
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/access/Ownable.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/vendor/arbitrum/IArbSys.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/vendor/arbitrum/IBridge.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/vendor/arbitrum/IInbox.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/vendor/arbitrum/IOutbox.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/access/Ownable.sol";
 
 import "../../../interfaces/IMessenger.sol";
 import "../../RestrictedCalls.sol";

--- a/contracts/contracts/chains/optimism/OptimismMessengers.sol
+++ b/contracts/contracts/chains/optimism/OptimismMessengers.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.12;
 import "../../../interfaces/IMessenger.sol";
 
 import "../../RestrictedCalls.sol";
-import "OpenZeppelin/openzeppelin-contracts@4.7.3/contracts/vendor/optimism/ICrossDomainMessenger.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.8.0/contracts/vendor/optimism/ICrossDomainMessenger.sol";
 import "./Lib_PredeployAddresses.sol";
 
 abstract contract OptimismMessengerBase is IMessenger, RestrictedCalls {


### PR DESCRIPTION
This PR updates OpenZeppelin to 4.8.0, which is the version that has the latest Nitro contracts. We also update the Arbitrum nitro submodule to latest master. Finally, we remove the now unnecessary `calculateRetryableSubmissionFee` implementation.