### PR TITLE
Contracts: claim on behalf of others

### DIFF
--- a/beamer/tests/contracts/test_fill_manager.py
+++ b/beamer/tests/contracts/test_fill_manager.py
@@ -44,7 +44,7 @@ def test_fill_request(fill_manager, token):
     blacklist_tx = fill_manager.removeAllowedLp(filler)
     assert "LpRemoved" in blacklist_tx.events
 
-    with brownie.reverts("Sender not whitelisted"):
+    with brownie.reverts("Not allowed"):
         fill_manager.fillRequest(
             chain_id,
             token.address,

--- a/contracts/contracts/FillManager.sol
+++ b/contracts/contracts/FillManager.sol
@@ -84,7 +84,7 @@ contract FillManager is Ownable, LpWhitelist {
         address targetReceiverAddress,
         uint256 amount,
         uint96 nonce
-    ) external onlyWhitelist returns (bytes32) {
+    ) external onlyAllowed(msg.sender) returns (bytes32) {
         address _l1Resolver = l1Resolver;
         require(_l1Resolver != address(0), "Resolver address not set");
         bytes32 requestId = BeamerUtils.createRequestId(
@@ -98,8 +98,11 @@ contract FillManager is Ownable, LpWhitelist {
 
         require(fills[requestId] == bytes32(0), "Already filled");
 
-        IERC20 token = IERC20(targetTokenAddress);
-        token.safeTransferFrom(msg.sender, targetReceiverAddress, amount);
+        IERC20(targetTokenAddress).safeTransferFrom(
+            msg.sender,
+            targetReceiverAddress,
+            amount
+        );
 
         bytes32 fillId = generateFillId();
         fills[requestId] = fillId;

--- a/contracts/contracts/LpWhitelist.sol
+++ b/contracts/contracts/LpWhitelist.sol
@@ -20,12 +20,12 @@ contract LpWhitelist is Ownable {
     /// .. seealso:: :sol:func:`removeAllowedLp`
     event LpRemoved(address lp);
 
-    /// The set of liquidity providers that are added to the whitelist.
+    /// The mapping indicating whether liquidity providers have allowance or not
     mapping(address => bool) public allowedLps;
 
-    /// Modifier to check whether the sender is whitelisted
-    modifier onlyWhitelist() {
-        require(allowedLps[msg.sender], "Sender not whitelisted");
+    /// Modifier to check whether the passed address is an allowed LP
+    modifier onlyAllowed(address addressToCheck) {
+        require(allowedLps[addressToCheck], "Not allowed");
         _;
     }
 

--- a/contracts/contracts/RequestManager.sol
+++ b/contracts/contracts/RequestManager.sol
@@ -369,7 +369,7 @@ contract RequestManager is Ownable, LpWhitelist, RestrictedCalls, Pausable {
         external
         payable
         validRequestId(requestId)
-        onlyWhitelist
+        onlyAllowed(msg.sender)
         returns (uint96)
     {
         Request storage request = requests[requestId];


### PR DESCRIPTION
Closes #1201 

This overloads the `claimRequest` function with an additional parameter for setting the claimer. This means the claim can be initiated by another address than the claimer address. The initiator pays the stake. The claimer gets the stake distribution back. Adds a new modifier to the LpWhitelist in order to check if the given claimer is whitelisted.