### PR TITLE
relayer: add unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,8 @@ workflows:
             beamer/.* backend-updated true
             contracts/.* backend-updated true
             docker/.* backend-updated true
-            relayer/.* backend-updated true
             scripts/.* backend-updated true
+            relayer/.* relayer-updated true
             docs/.* docs-updated true
             frontend/.* frontend-updated true
             subgraph/.* subgraph-updated true
@@ -33,3 +33,4 @@ workflows:
             .circleci/.* backend-updated true              
             .circleci/.* docs-updated true                 
             .circleci/.* subgraph-updated true
+            .circleci/.* relayer-updated true

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -140,7 +140,7 @@ jobs:
           at: /
       - restore-node-packages
       - ensure-node-environment
-      - run: make ~/beamer relayers
+      - run: make relayers
       - persist_to_workspace:
           root: /
           paths:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -62,6 +62,9 @@ parameters:
   subgraph-updated:
     type: boolean
     default: false
+  relayer-updated:
+    type: boolean
+    default: false
 
 executors:
   vm:
@@ -256,6 +259,22 @@ jobs:
           name: Unit tests
           command: yarn test:unit
 
+  test-relayer:
+    executor: node/default
+    working_directory: ~/beamer/relayer
+    steps:
+      - checkout:
+          path: ~/beamer
+      - node/install-packages:
+          pkg-manager: yarn
+          app-dir: ~/beamer/relayer
+      - run:
+          name: Lint
+          command: yarn lint
+      - run:
+          name: Unit tests
+          command: yarn test:unit
+
   build-and-publish-container-image:
     executor: vm
     environment:
@@ -330,6 +349,11 @@ workflows:
     when: <<pipeline.parameters.frontend-updated>>
     jobs:
       - build-and-test-frontend
+
+  relayer:
+    when: <<pipeline.parameters.relayer-updated>>
+    jobs:
+      - test-relayer
 
   build-and-publish-container-image:
     when:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -353,6 +353,13 @@ workflows:
   relayer:
     when: <<pipeline.parameters.relayer-updated>>
     jobs:
+      - checkout
+      - install-npm-packages:
+          requires:
+              - checkout
+      - create-relayers:
+          requires:
+            - install-npm-packages
       - test-relayer
 
   build-and-publish-container-image:

--- a/relayer/.gitignore
+++ b/relayer/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 build/
+coverage/

--- a/relayer/jest.config.ts
+++ b/relayer/jest.config.ts
@@ -9,5 +9,6 @@ export default async (): Promise<Config> => {
       "^~/(.*)$": "<rootDir>/tests/$1",
     },
     resetMocks: true,
+    collectCoverageFrom: ["src/**/*.ts*"],
   };
 };

--- a/relayer/package.json
+++ b/relayer/package.json
@@ -16,7 +16,8 @@
     "start": "ts-node ./src/service.ts",
     "lint": "eslint --ext .js,.ts --ignore-path .gitignore --max-warnings 0 .",
     "lint:fix": "eslint --ext .js,.ts --ignore-path .gitignore --fix .",
-    "test": "jest"
+    "test:unit": "jest unit",
+    "test:coverage": "jest --collect-coverage"
   },
   "dependencies": {
     "@arbitrum/sdk": "3.0.0",

--- a/relayer/src/map.ts
+++ b/relayer/src/map.ts
@@ -1,7 +1,7 @@
 import { ArbitrumRelayerService, BobaRelayerService, OptimismRelayerService } from "./services";
-import type { BaseRelayerService, BaseRelayerServiceConstructor } from "./services/types";
+import type { BaseRelayerService, ExtendedRelayerService } from "./services/types";
 
-export const SERVICES: Record<number, BaseRelayerServiceConstructor> = {
+export const SERVICES: Record<number, ExtendedRelayerService> = {
   42161: ArbitrumRelayerService,
   421613: ArbitrumRelayerService,
   2888: BobaRelayerService,
@@ -12,11 +12,11 @@ export const SERVICES: Record<number, BaseRelayerServiceConstructor> = {
 
 export function createRelayer(
   networkId: number,
-  args: ConstructorParameters<BaseRelayerServiceConstructor>,
+  args: ConstructorParameters<typeof BaseRelayerService>,
 ): BaseRelayerService {
   const Relayer = SERVICES[networkId];
 
-  if (networkId) {
+  if (Relayer) {
     return new Relayer(...args);
   } else {
     const errorMessage = `No relayer program found for ${networkId}!`;

--- a/relayer/src/relayer-program.ts
+++ b/relayer/src/relayer-program.ts
@@ -21,6 +21,7 @@ export function validateArgs(args: ProgramOptions): Array<string> {
 
   return validationErrors;
 }
+
 export class RelayerProgram {
   constructor(
     readonly l2RelayerFrom: BaseRelayerService,
@@ -33,18 +34,14 @@ export class RelayerProgram {
     const toL2ChainId = await getNetworkId(options.l2RelayToRpcUrl);
 
     const relayerFrom = createRelayer(fromL2ChainId, [
-      {
-        l1RpcURL: options.l1RpcUrl,
-        l2RpcURL: options.l2RelayFromRpcUrl,
-        privateKey: options.walletPrivateKey,
-      },
+      options.l1RpcUrl,
+      options.l2RelayFromRpcUrl,
+      options.walletPrivateKey,
     ]);
     const relayerTo = createRelayer(toL2ChainId, [
-      {
-        l1RpcURL: options.l1RpcUrl,
-        l2RpcURL: options.l2RelayToRpcUrl,
-        privateKey: options.walletPrivateKey,
-      },
+      options.l1RpcUrl,
+      options.l2RelayToRpcUrl,
+      options.walletPrivateKey,
     ]);
 
     return new this(relayerFrom, relayerTo, options.l2TransactionHash);

--- a/relayer/src/services/types.ts
+++ b/relayer/src/services/types.ts
@@ -2,21 +2,24 @@ import type { Provider } from "@ethersproject/providers";
 import { JsonRpcProvider } from "@ethersproject/providers";
 import { Wallet } from "ethers";
 
+import type { ArbitrumRelayerService } from "./arbitrum";
+import type { BobaRelayerService } from "./boba";
+import type { OptimismRelayerService } from "./optimism";
+
 export type TransactionHash = string;
 
-export type BaseRelayerServiceConstructor = new (params: {
-  l1RpcURL: string;
-  l2RpcURL: string;
-  privateKey: string;
-}) => BaseRelayerService;
+export type ExtendedRelayerService =
+  | typeof ArbitrumRelayerService
+  | typeof BobaRelayerService
+  | typeof OptimismRelayerService;
 
 export abstract class BaseRelayerService {
   readonly l1Wallet: Wallet;
   readonly l2Wallet: Wallet;
 
-  constructor(params: { l1RpcURL: string; l2RpcURL: string; privateKey: string }) {
-    this.l1Wallet = new Wallet(params.privateKey, new JsonRpcProvider(params.l1RpcURL));
-    this.l2Wallet = new Wallet(params.privateKey, new JsonRpcProvider(params.l2RpcURL));
+  constructor(l1RpcURL: string, l2RpcURL: string, privateKey: string) {
+    this.l1Wallet = new Wallet(privateKey, new JsonRpcProvider(l1RpcURL));
+    this.l2Wallet = new Wallet(privateKey, new JsonRpcProvider(l2RpcURL));
   }
 
   get l2RpcProvider(): Provider {

--- a/relayer/tests/unit/common/network.spec.ts
+++ b/relayer/tests/unit/common/network.spec.ts
@@ -1,0 +1,16 @@
+import type { Network } from "@ethersproject/providers";
+import { JsonRpcProvider } from "@ethersproject/providers";
+
+import { getNetworkId } from "@/common/network";
+
+describe("getNetworkId", () => {
+  it("returns the network id", async () => {
+    const chainId = 99999;
+    const network: Network = { chainId, name: "testchain" };
+    jest.spyOn(JsonRpcProvider.prototype, "getNetwork").mockResolvedValue(network);
+
+    const returnedChainId = await getNetworkId("http://rpc.test");
+
+    expect(returnedChainId).toBe(chainId);
+  });
+});

--- a/relayer/tests/unit/common/process.spec.ts
+++ b/relayer/tests/unit/common/process.spec.ts
@@ -1,0 +1,38 @@
+import { killOnParentProcessChange } from "@/common/process";
+
+describe("killOnParentProcessChange", () => {
+  jest.useFakeTimers();
+  const startPpid = 123;
+
+  let ppid: number;
+  beforeEach(() => {
+    console.log = jest.fn();
+    ppid = process.ppid;
+    Object.defineProperty(process, "ppid", { value: startPpid });
+  });
+  afterEach(() => {
+    Object.defineProperty(process, "ppid", { value: ppid });
+  });
+
+  it("calls exit when pid changes", async () => {
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation();
+
+    killOnParentProcessChange(startPpid);
+    Object.defineProperty(process, "ppid", { value: startPpid + 1 });
+    jest.runOnlyPendingTimers();
+    await Promise.resolve();
+
+    expect(exitSpy).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("never exits when pid does not change", async () => {
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation();
+
+    killOnParentProcessChange(startPpid);
+    jest.runOnlyPendingTimers();
+    await Promise.resolve();
+
+    expect(exitSpy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/relayer/tests/unit/map.spec.ts
+++ b/relayer/tests/unit/map.spec.ts
@@ -1,0 +1,52 @@
+import { createRelayer } from "@/map";
+import { ArbitrumRelayerService, BobaRelayerService, OptimismRelayerService } from "@/services";
+import type { BaseRelayerService } from "@/services/types";
+import { getRandomPrivateKey, getRandomUrl } from "~/utils/data_generators";
+
+describe("createRelayer", () => {
+  const testArgs: ConstructorParameters<typeof BaseRelayerService> = [
+    getRandomUrl("l1"),
+    getRandomUrl("l2"),
+    getRandomPrivateKey(),
+  ];
+
+  it("maps arbitrum chain ids to an ArbitrumRelayerService", () => {
+    const chainId = 42161;
+    const goerliChainId = 421613;
+
+    const relayer = createRelayer(chainId, testArgs);
+    const goerliRelayer = createRelayer(goerliChainId, testArgs);
+
+    expect(relayer instanceof ArbitrumRelayerService).toBe(true);
+    expect(goerliRelayer instanceof ArbitrumRelayerService).toBe(true);
+  });
+
+  it("maps boba chain ids to an BobaRelayerService", () => {
+    const chainId = 288;
+    const goerliChainId = 2888;
+
+    const relayer = createRelayer(chainId, testArgs);
+    const goerliRelayer = createRelayer(goerliChainId, testArgs);
+
+    expect(relayer instanceof BobaRelayerService).toBe(true);
+    expect(goerliRelayer instanceof BobaRelayerService).toBe(true);
+  });
+
+  it("maps optimism chain ids to an OptimismRelayerService", () => {
+    const chainId = 10;
+    const goerliChainId = 420;
+
+    const relayer = createRelayer(chainId, testArgs);
+    const goerliRelayer = createRelayer(goerliChainId, testArgs);
+
+    expect(relayer instanceof OptimismRelayerService).toBe(true);
+    expect(goerliRelayer instanceof OptimismRelayerService).toBe(true);
+  });
+
+  it("throws for unknown chain ids", () => {
+    const chainId = 9372855;
+    expect(() => createRelayer(chainId, testArgs)).toThrow(
+      `No relayer program found for ${chainId}!`,
+    );
+  });
+});

--- a/relayer/tests/unit/relayer-program.spec.ts
+++ b/relayer/tests/unit/relayer-program.spec.ts
@@ -1,0 +1,101 @@
+import { getNetworkId } from "@/common/network";
+import { SERVICES } from "@/map";
+import type { ProgramOptions } from "@/relayer-program";
+import { RelayerProgram, validateArgs } from "@/relayer-program";
+import {
+  getRandomPrivateKey,
+  getRandomTransactionHash,
+  getRandomUrl,
+} from "~/utils/data_generators";
+
+jest.mock("@/common/network");
+
+const validOptions: ProgramOptions = {
+  l1RpcUrl: getRandomUrl("l1"),
+  l2RelayFromRpcUrl: getRandomUrl("l2.from"),
+  l2RelayToRpcUrl: getRandomUrl("l2.to"),
+  walletPrivateKey: getRandomPrivateKey(),
+  l2TransactionHash: getRandomTransactionHash(),
+};
+
+describe("validateArgs", () => {
+  it("gives no error for valid ProgramOptions", () => {
+    const errors = validateArgs(validOptions);
+    expect(errors).toEqual([]);
+  });
+
+  it("gives an error for invalid transactions hashes", () => {
+    const invalidTransactionHashes = [
+      getRandomTransactionHash() + "A",
+      getRandomTransactionHash().slice(2),
+    ];
+
+    for (const hash of invalidTransactionHashes) {
+      const errors = validateArgs(Object.assign({}, validOptions, { l2TransactionHash: hash }));
+
+      expect(errors).toEqual([
+        `Invalid argument value for "--l2-transaction-hash": "${hash}" doesn't look like a txn hash...`,
+      ]);
+    }
+  });
+});
+
+describe("RelayerProgram", () => {
+  it("can be created from args", async () => {
+    const fromChainId = Number(Object.keys(SERVICES)[0]);
+    const toChainId = Number(Object.keys(SERVICES)[3]);
+    (getNetworkId as jest.Mock)
+      .mockResolvedValueOnce(fromChainId)
+      .mockResolvedValueOnce(toChainId);
+
+    const program = await RelayerProgram.createFromArgs(validOptions);
+
+    expect(program.l2RelayerFrom instanceof SERVICES[fromChainId]).toBe(true);
+    expect(program.l2RelayerTo instanceof SERVICES[toChainId]).toBe(true);
+    expect(program.l2TransactionHash).toBe(validOptions.l2TransactionHash);
+  });
+
+  describe("run()", () => {
+    it("runs all the necessary methods for successful relaying of a transaction", async () => {
+      const fromChainId = Number(Object.keys(SERVICES)[0]);
+      const toChainId = Number(Object.keys(SERVICES)[3]);
+      (getNetworkId as jest.Mock)
+        .mockResolvedValueOnce(fromChainId)
+        .mockResolvedValueOnce(toChainId);
+
+      const program = await RelayerProgram.createFromArgs(validOptions);
+
+      jest.spyOn(program.l2RelayerTo, "prepare");
+      jest
+        .spyOn(program.l2RelayerFrom, "relayTxToL1")
+        .mockResolvedValue(getRandomTransactionHash());
+      jest.spyOn(program.l2RelayerTo, "finalize");
+
+      await program.run();
+
+      expect(program.l2RelayerTo.prepare).toHaveBeenCalled();
+      expect(program.l2RelayerFrom.relayTxToL1).toHaveBeenCalled();
+      expect(program.l2RelayerTo.finalize).toHaveBeenCalled();
+    });
+
+    it("ignores the `finalize` step when l1 transaction hash was not returned by the `relayTxToL1` step", async () => {
+      const fromChainId = Number(Object.keys(SERVICES)[0]);
+      const toChainId = Number(Object.keys(SERVICES)[3]);
+      (getNetworkId as jest.Mock)
+        .mockResolvedValueOnce(fromChainId)
+        .mockResolvedValueOnce(toChainId);
+
+      const program = await RelayerProgram.createFromArgs(validOptions);
+
+      jest.spyOn(program.l2RelayerTo, "prepare");
+      jest.spyOn(program.l2RelayerFrom, "relayTxToL1").mockResolvedValue(undefined);
+      jest.spyOn(program.l2RelayerTo, "finalize");
+
+      await program.run();
+
+      expect(program.l2RelayerTo.prepare).toHaveBeenCalled();
+      expect(program.l2RelayerFrom.relayTxToL1).toHaveBeenCalled();
+      expect(program.l2RelayerTo.finalize).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/relayer/tests/utils/data_generators.ts
+++ b/relayer/tests/utils/data_generators.ts
@@ -1,0 +1,26 @@
+import type { TransactionHash } from "@/services/types";
+
+const HEXADECIMAL_CHARACTERS = "0123456789abcdefABCDEF";
+const ALPHABET_CHARACTERS = "abcdefghijklmnopqrstuvwxyz";
+
+export function getRandomString(charSet = ALPHABET_CHARACTERS, length = 5, prefix = ""): string {
+  let output = prefix;
+
+  for (let i = 0; i < length; i++) {
+    output += charSet.charAt(Math.floor(Math.random() * charSet.length));
+  }
+
+  return output;
+}
+
+export function getRandomTransactionHash(): TransactionHash {
+  return getRandomString(HEXADECIMAL_CHARACTERS, 64, "0x");
+}
+
+export function getRandomPrivateKey(): TransactionHash {
+  return getRandomString(HEXADECIMAL_CHARACTERS, 64);
+}
+
+export function getRandomUrl(subDomain: string): string {
+  return getRandomString(ALPHABET_CHARACTERS, 8, `https://${subDomain}.`);
+}

--- a/relayer/tsconfig.json
+++ b/relayer/tsconfig.json
@@ -12,9 +12,15 @@
     "noLib": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "typeRoots": ["node_modules/@types"],
-    "outDir": "build"
+    "outDir": "build",
+    "types": ["node", "jest"],
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "~/*": ["tests/*"]
+    }
   },
-  "include": ["src/**/*.ts", "src/**/*.json"],
+  "include": ["src/**/*.ts", "src/**/*.json", "tests/**/*.ts",],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Closes #1296 

This adds basic unit test coverage for the relayer. As discussed with @GabrielBuragev the actual relaying services are not tested as they rely on libraries and would involve heavy mocking. For the same reason there are no tests for the `service.ts` file.