### PR TITLE
Downgrade poetry to 1.2.2 on circle ci

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -87,12 +87,8 @@ jobs:
 
       - run: pyenv install --skip-existing 3.10.6
       - run: pyenv global 3.10.6
-      - run: pip install -U pip poetry
-
-      - restore_cache:
-          keys:
-            - beamer-dependencies-v4-{{ checksum "poetry.lock" }}
-            - beamer-dependencies-v4
+      - run: pip install -U pip poetry==1.2.2
+      - restore-python-packages
       - run: poetry install
       - run: echo "source $(poetry env info -p)/bin/activate" >> ~/.bashrc
 


### PR DESCRIPTION
Poetry 1.3.3 does not seem to work on CircleCI. It fails upon poetry install.

Until we have found a solution ´, we have to downgrade poetry to the last known working version