### PR TITLE
Fix agent -> relayer communication

### DIFF
--- a/beamer/l1_resolution.py
+++ b/beamer/l1_resolution.py
@@ -28,7 +28,7 @@ def run_relayer_for_tx(
     l1_rpc: URL,
     l2_relay_from_rpc_url: URL,
     l2_relay_to_rpc_url: URL,
-    privkey: str,
+    privkey: HexBytes,
     tx_hash: HexBytes,
 ) -> None:
     relayer = get_relayer_executable()
@@ -47,9 +47,9 @@ def run_relayer_for_tx(
             "--l2-relay-from-rpc-url",
             l2_relay_from_rpc_url,
             "--wallet-private-key",
-            privkey,
+            privkey.hex(),
             "--l2-transaction-hash",
-            tx_hash,
+            tx_hash.hex(),
         ],
         capture_output=True,
         encoding="utf-8",


### PR DESCRIPTION
fixes https://github.com/beamer-bridge/beamer/issues/1318

This PR fixes the failing L1 resolution in the case when the agent calls the relayer as a subprocess.
The problem was coming from the types of the arguments that are passed when calling the subprocess. Node.js doesnt recognize the HexBytes type and therefore the program crashes.

The relayer itself didn't require any fixes as it was concluded after the numerous manual tests (by running it as a standalone unit).