### PR TITLE
frontend: Hotfix for MetaMask throwing disconnect events when switching chain

### DIFF
--- a/frontend/src/services/web3-provider/ethereum-provider.ts
+++ b/frontend/src/services/web3-provider/ethereum-provider.ts
@@ -18,6 +18,8 @@ export abstract class EthereumProvider extends EventEmitter implements IEthereum
   protected web3Provider: Web3Provider;
   protected externalProvider: Eip1193Provider;
 
+  private isSwitchingNetwork = false;
+
   constructor(_provider: Eip1193Provider) {
     super();
     this.web3Provider = new Web3Provider(_provider);
@@ -31,7 +33,9 @@ export abstract class EthereumProvider extends EventEmitter implements IEthereum
   }
 
   async switchChainSafely(newChain: Chain): Promise<boolean> {
+    let successful = true;
     if (newChain.identifier !== this.chainId.value) {
+      this.isSwitchingNetwork = true;
       try {
         const isSuccessfulSwitch = await this.switchChain(newChain.identifier);
         if (!isSuccessfulSwitch) {
@@ -41,14 +45,15 @@ export abstract class EthereumProvider extends EventEmitter implements IEthereum
         // (e.g. after an add the switch is not performed automatically),
         // this is the safest way to ensure we are on the correct chain.
         if (newChain.identifier !== this.chainId.value) {
-          return false;
+          successful = false;
         }
       } catch (error) {
         console.error(error);
-        return false;
+        successful = false;
       }
+      setTimeout(() => (this.isSwitchingNetwork = false), 1000);
     }
-    return true;
+    return successful;
   }
 
   // Returns false in case the provider does not have the chain.
@@ -130,6 +135,14 @@ export abstract class EthereumProvider extends EventEmitter implements IEthereum
   }
 
   disconnect(): void {
+    // This is a hotfix. MetaMask sometimes throws a disconnect event when
+    // switching the chain. In this case we need to ignore the event, because
+    // the account is actually still connected. If this is fixed on their side,
+    // this flag can be removed.
+    // See: https://github.com/MetaMask/metamask-extension/issues/13375
+    if (this.isSwitchingNetwork) {
+      return;
+    }
     this.signer.value = undefined;
     this.signerAddress.value = undefined;
     this.emit('disconnect');

--- a/frontend/tests/unit/services/web3-provider/ethereum-provider.spec.ts
+++ b/frontend/tests/unit/services/web3-provider/ethereum-provider.spec.ts
@@ -71,6 +71,7 @@ describe('EthereumProvider', () => {
 
       expect(ethereumProvider.switchChain).toHaveBeenNthCalledWith(1, newChainId);
     });
+
     describe('when chain is not recognized by wallet provider', () => {
       it('triggers a call to add chain to wallet configuration', async () => {
         const currentChainId = 1;
@@ -274,6 +275,26 @@ describe('EthereumProvider', () => {
 
       expect(ethereumProvider.signer.value).toBeUndefined();
       expect(ethereumProvider.signerAddress.value).toBeUndefined();
+    });
+
+    it('should not disconnect after a chain switch', async () => {
+      const web3Provider = mockWeb3Provider();
+      web3Provider.getSigner = vi.fn().mockImplementation((signer) => signer);
+
+      const currentChainId = 1;
+      const newChainId = 2;
+      const chain = generateChain({ identifier: newChainId });
+
+      const ethereumProvider = new TestEthereumProvider();
+      ethereumProvider.setSigner(getRandomEthereumAddress());
+      ethereumProvider.chainId.value = currentChainId;
+      ethereumProvider.switchChain = vi.fn().mockResolvedValue(true);
+
+      await ethereumProvider.switchChainSafely(chain);
+      ethereumProvider.disconnect();
+
+      expect(ethereumProvider.signer.value).not.toBeUndefined();
+      expect(ethereumProvider.signerAddress.value).not.toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Fixes #1118 

MetaMask sometimes throws a disconnect event when switching the chain. In this case we need to ignore the event, because the account is actually still connected. This adds a flag that is true for 1 second after a chain switch happened. A short time period is necessary because the event is not directly thrown when the `wallet_switchEthereumChain` rpc method returns. If this is fixed on the side of MetaMask, we can remove the flag again.