### PR TITLE
frontend: Fix fee query on transfer creation

### DIFF
--- a/frontend/src/composables/useTransferRequest.ts
+++ b/frontend/src/composables/useTransferRequest.ts
@@ -26,7 +26,7 @@ export function useTransferRequest() {
 
     const validityPeriod = new UInt256(VALIDITY_PERIOD_SECONDS);
     const { rpcUrl, requestManagerAddress } = options.sourceChain;
-    const requestFee = await getRequestFee(rpcUrl, requestManagerAddress, targetTokenAmount);
+    const requestFee = await getRequestFee(rpcUrl, requestManagerAddress, sourceTokenAmount);
     const fees = TokenAmount.new(requestFee, sourceTokenAmount.token);
 
     const transfer = reactive(

--- a/frontend/tests/unit/composables/useTransferRequest.spec.ts
+++ b/frontend/tests/unit/composables/useTransferRequest.spec.ts
@@ -4,6 +4,7 @@ import { ref } from 'vue';
 import { Transfer } from '@/actions/transfers';
 import { useTransferRequest } from '@/composables/useTransferRequest';
 import * as requestManagerService from '@/services/transactions/request-manager';
+import { TokenAmount } from '@/types/token-amount';
 import { UInt256 } from '@/types/uint-256';
 import {
   generateChain,
@@ -20,29 +21,53 @@ const SIGNER = new JsonRpcSigner(undefined, new JsonRpcProvider());
 const SIGNER_ADDRESS = '0xSigner';
 
 describe('useTransferRequest', () => {
+  let generatedFee: UInt256;
+
   beforeEach(() => {
+    generatedFee = new UInt256(generateUInt256Data());
     Object.defineProperty(requestManagerService, 'getRequestFee', {
-      value: vi.fn().mockResolvedValue(new UInt256(generateUInt256Data())),
+      value: vi.fn().mockResolvedValue(generatedFee),
     });
   });
 
   describe('create()', () => {
     it('creates and returns a new transfer object', async () => {
-      const { create } = useTransferRequest();
+      const sourceChain = generateChain();
+      const sourceAmount = '123';
+      const targetAmount = '123';
+      const targetChain = generateChain();
+      const toAddress = getRandomEthereumAddress();
+      const sourceToken = generateToken();
+      const targetToken = generateToken();
 
-      const transfer = await create({
-        sourceChain: generateChain(),
-        sourceAmount: '123',
-        targetChain: generateChain(),
-        toAddress: getRandomEthereumAddress(),
-        sourceToken: generateToken(),
-        targetToken: generateToken(),
+      const { create } = useTransferRequest();
+      const transfer: Transfer = await create({
+        sourceChain,
+        sourceAmount,
+        targetChain,
+        toAddress,
+        sourceToken,
+        targetToken,
       });
 
+      const sourceTokenAmount = TokenAmount.parse(sourceAmount, sourceToken);
+      const targetTokenAmount = TokenAmount.parse(targetAmount, targetToken);
+      const feeAmount = TokenAmount.new(generatedFee, sourceToken);
+      expect(requestManagerService.getRequestFee).toHaveBeenCalledOnce();
+      expect(requestManagerService.getRequestFee).toHaveBeenCalledWith(
+        sourceChain.rpcUrl,
+        sourceChain.requestManagerAddress,
+        sourceTokenAmount,
+      );
       expect(transfer).toBeDefined();
       expect(transfer).toBeInstanceOf(Transfer);
+      expect(transfer.sourceChain).toEqual(sourceChain);
+      expect(transfer.sourceAmount).toEqual(sourceTokenAmount);
+      expect(transfer.targetChain).toEqual(targetChain);
+      expect(transfer.targetAmount).toEqual(targetTokenAmount);
+      expect(transfer.targetAccount).toEqual(toAddress);
+      expect(transfer.fees).toEqual(feeAmount);
     });
-    // Todo: check if created instance holds correct values
   });
 
   describe('execute()', () => {


### PR DESCRIPTION
closes #1340 

When creating a transfer, the request manager was queried for the fees of the target token address (which only exists on the target chain). This obviously returns an erroneous value as the request manager only knows about the source token address. This led to the bug that the fees were not taken into account for the getting the token allowance. This simply changes the `getRequestFee` call to use the correct variable.