### PR TITLE
relayer: reduce max message length

### DIFF
--- a/relayer/src/services/arbitrum.ts
+++ b/relayer/src/services/arbitrum.ts
@@ -22,7 +22,7 @@ const L1_CONTRACTS: Record<number, { ARBITRUM_L1_MESSENGER: string }> = {
 };
 
 export class ArbitrumRelayerService extends BaseRelayerService {
-  static readonly MAX_MESSAGE_LENGTH_BYTES = 1_000_000;
+  static readonly MAX_MESSAGE_LENGTH_BYTES = 5_000;
 
   async prepare(): Promise<boolean> {
     console.log("Preparing Arbitrum Messenger for forwarding the L1 message...");


### PR DESCRIPTION
Reducing the `MAX_MESSAGE_LENGTH_BYTES` so we avoid depositing unnecessary huge amount of funds on ArbitrumL1Messenger contract.

Read commit message for more info.