### PR TITLE
Frontend/claims after request expiry

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -67,6 +67,8 @@ import { useConfiguration } from '@/stores/configuration';
 import { useEthereumProvider } from '@/stores/ethereum-provider';
 import { useTransferHistory } from '@/stores/transfer-history';
 
+import { useClaimCountListeners } from './composables/useClaimCountListeners';
+
 const enableFeedback = process.env.NODE_ENV === 'production' && true;
 
 const { setConfiguration } = useConfiguration();
@@ -77,6 +79,7 @@ const { isBlacklistedWallet } = storeToRefs(useEthereumProvider());
 
 const { transfers, loaded } = storeToRefs(useTransferHistory());
 useContinueInterruptedTransfers(transfers as Ref<Array<Transfer>>, loaded);
+useClaimCountListeners(transfers as Ref<Array<Transfer>>);
 
 onMounted(loadConfiguration);
 </script>

--- a/frontend/src/components/Transfer.vue
+++ b/frontend/src/components/Transfer.vue
@@ -95,7 +95,8 @@ const {
 
 const withdrawProperties = computed(() => ({
   withdrawn: props.transfer.withdrawn,
-  active: withdrawTransferActive.value,
+  withdrawable: props.transfer.withdrawable,
+  withdrawInProgress: withdrawTransferActive.value,
   errorMessage: withdrawTransferError.value?.message,
 }));
 

--- a/frontend/src/components/TransferWithdrawer.vue
+++ b/frontend/src/components/TransferWithdrawer.vue
@@ -1,19 +1,34 @@
 <template>
   <div class="text-center">
     <template v-if="!withdrawn">
-      <span
-        v-if="!active"
-        class="cursor-pointer underline text-red hover:opacity-90"
-        data-test="recover-tokens-button"
-        @click="emitWithdraw"
-      >
-        Recover Tokens
-      </span>
-
-      <Spinner v-if="active" size-classes="w-7" border="2" class="border-t-teal" />
+      <template v-if="!withdrawInProgress">
+        <Tooltip v-if="!withdrawable" show-outside-of-closest-reference-element class="text-left">
+          <template #hint>
+            <span data-test="dispute-description">
+              Someone claimed that the request has been filled on your destination rollup.
+              <br />
+              If you have not received any funds as expected, you will be able to withdraw your
+              tokens here. <br />
+              Please, wait until the claim dispute has been resolved. Please note, that this can
+              take up to several days.
+            </span>
+          </template>
+          <span data-test="dispute-message">Waiting for dispute resolution </span>
+          <WaitingDots />
+        </Tooltip>
+        <button
+          v-else
+          class="underline text-red hover:opacity-90"
+          data-test="recover-tokens-button"
+          @click="emitWithdraw"
+        >
+          Recover Tokens
+        </button>
+      </template>
+      <Spinner v-else size="7" border="2" class="border-t-teal" />
     </template>
-
     <div v-else class="text-green">Tokens Withdrawn</div>
+
     <span v-if="errorMessage" class="text-red"><br />{{ errorMessage }}</span>
   </div>
 </template>
@@ -21,9 +36,13 @@
 <script setup lang="ts">
 import Spinner from '@/components/Spinner.vue';
 
+import Tooltip from './layout/Tooltip.vue';
+import WaitingDots from './layout/WaitingDots.vue';
+
 interface Props {
   withdrawn: boolean;
-  active: boolean;
+  withdrawable: boolean;
+  withdrawInProgress: boolean;
   errorMessage?: string;
 }
 

--- a/frontend/src/composables/useClaimCountListeners.ts
+++ b/frontend/src/composables/useClaimCountListeners.ts
@@ -1,0 +1,36 @@
+import type { Ref } from 'vue';
+import { computed, watch } from 'vue';
+
+import type { Transfer } from '@/actions/transfers';
+
+export function useClaimCountListeners(transfers: Ref<Array<Transfer>>) {
+  const expiredAndNotWithdrawnTransfers = computed(() =>
+    transfers.value.filter((transfer) => transfer.expired && !transfer.withdrawn),
+  );
+
+  const expiredAndWithdrawnTransfers = computed(() =>
+    transfers.value.filter((transfer) => transfer.expired && transfer.withdrawn),
+  );
+
+  watch(
+    expiredAndNotWithdrawnTransfers,
+    (transfers) => {
+      transfers.forEach(async (transfer) => {
+        // Sync state of transfers before subscribing to events
+        await transfer.checkAndUpdateState();
+        if (!transfer.hasActiveListeners && !transfer.withdrawn) {
+          transfer.startClaimEventListeners();
+        }
+      });
+    },
+    { immediate: true },
+  );
+
+  watch(expiredAndWithdrawnTransfers, (transfers) => {
+    transfers.forEach((transfer) => {
+      if (transfer.hasActiveListeners) {
+        transfer.stopEventListeners();
+      }
+    });
+  });
+}

--- a/frontend/src/services/transactions/request-manager.ts
+++ b/frontend/src/services/transactions/request-manager.ts
@@ -347,16 +347,18 @@ export async function withdrawRequest(
   }
 }
 
+type TransactionError = { code?: number; data?: { data?: { reason: string } } };
+
 function getTransactionErrorMessage(error: unknown): string {
-  const maybeErrorCode = (error as { code?: number }).code;
+  const maybeError = error as TransactionError;
 
   // TODO move all custom errors to error handling library
   if (error instanceof Error) {
     return error.message;
-  } else if (maybeErrorCode && maybeErrorCode === 4001) {
+  } else if (maybeError.code && maybeError.code === 4001) {
     return 'Transaction got rejected!';
-  } else if (maybeErrorCode && maybeErrorCode === -32603) {
-    return 'Insufficient balance!';
+  } else if (maybeError.code && maybeError.code === -32603) {
+    return maybeError.data?.data?.reason || 'Internal JSON-RPC error';
   } else {
     return 'Unknown failure!';
   }

--- a/frontend/tests/unit/components/Transfer.spec.ts
+++ b/frontend/tests/unit/components/Transfer.spec.ts
@@ -174,7 +174,7 @@ describe('Transfer.vue', () => {
       expect(withdrawer.exists()).toBeTruthy();
       expect(withdrawer.isVisible()).toBeTruthy();
       expect(withdrawer.props()).toContain({ withdrawn: false });
-      expect(withdrawer.props()).toContain({ active: true });
+      expect(withdrawer.props()).toContain({ withdrawInProgress: true });
       expect(withdrawer.props()).toContain({ errorMessage: 'test error' });
     });
 

--- a/frontend/tests/unit/components/TransferWithdrawer.spec.ts
+++ b/frontend/tests/unit/components/TransferWithdrawer.spec.ts
@@ -5,21 +5,30 @@ import TransferWithdrawer from '@/components/TransferWithdrawer.vue';
 
 function createWrapper(options?: {
   withdrawn?: boolean;
-  active?: boolean;
+  withdrawable?: boolean;
+  withdrawInProgress?: boolean;
   errorMessage?: string;
 }) {
   return mount(TransferWithdrawer, {
     shallow: true,
+    global: {
+      stubs: {
+        Tooltip: {
+          template: `<div><slot/><slot name="hint"/></div>`,
+        },
+      },
+    },
     props: {
       withdrawn: options?.withdrawn ?? false,
-      active: options?.active ?? false,
+      withdrawable: options?.withdrawable ?? true,
+      withdrawInProgress: options?.withdrawInProgress ?? false,
       errorMessage: options?.errorMessage,
     },
   });
 }
 describe('TransferWithdrawer.vue', () => {
   it('emits withdraw event when user clicks button', async () => {
-    const wrapper = createWrapper();
+    const wrapper = createWrapper({ withdrawable: true });
     const button = wrapper.get('[data-test="recover-tokens-button"]');
 
     await button.trigger('click');
@@ -27,15 +36,15 @@ describe('TransferWithdrawer.vue', () => {
     expect(wrapper.emitted('withdraw')).toBeTruthy();
   });
 
-  it('hides button when set to be active', () => {
-    const wrapper = createWrapper({ active: true });
+  it('hides button when a withdraw is in progress', () => {
+    const wrapper = createWrapper({ withdrawInProgress: true });
     const button = wrapper.find('[data-test="recover-tokens-button"]');
 
     expect(button.exists()).toBeFalsy();
   });
 
-  it('shows spinner when set to be active', () => {
-    const wrapper = createWrapper({ active: true });
+  it('shows spinner when a withdraw is in progress', () => {
+    const wrapper = createWrapper({ withdrawInProgress: true });
     const spinner = wrapper.findComponent(Spinner);
 
     expect(spinner.exists()).toBeTruthy();
@@ -48,9 +57,33 @@ describe('TransferWithdrawer.vue', () => {
     expect(wrapper.text()).toContain('test error');
   });
 
-  it('shows that tokens are withdrawn it set to be withdrawn', () => {
+  it('shows that tokens are withdrawn if set to be withdrawn', () => {
     const wrapper = createWrapper({ withdrawn: true });
 
     expect(wrapper.text()).toBe('Tokens Withdrawn');
+  });
+
+  describe('when withdrawable is set to false', () => {
+    it('shows a simple message indicating the status', () => {
+      const wrapper = createWrapper({
+        withdrawable: false,
+      });
+
+      const messageElement = wrapper.find('[data-test="dispute-message"]');
+
+      expect(messageElement.text()).toContain('Waiting for dispute resolution');
+    });
+
+    it('shows a tooltip message explaining the status', () => {
+      const wrapper = createWrapper({
+        withdrawable: false,
+      });
+
+      const descriptionElement = wrapper.find('[data-test="dispute-description"]');
+
+      expect(descriptionElement.text()).toContain(
+        'Someone claimed that the request has been filled on your destination rollup.',
+      );
+    });
   });
 });

--- a/frontend/tests/unit/composables/useClaimCountListeners.spec.ts
+++ b/frontend/tests/unit/composables/useClaimCountListeners.spec.ts
@@ -1,0 +1,135 @@
+import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
+import { flushPromises } from '@vue/test-utils';
+import type { Ref } from 'vue';
+import { ref } from 'vue';
+
+import { Transfer } from '@/actions/transfers';
+import { useClaimCountListeners } from '@/composables/useClaimCountListeners';
+import * as requestManager from '@/services/transactions/request-manager';
+import {
+  generateRequestInformationData,
+  generateTransferData,
+  getRandomString,
+} from '~/utils/data_generators';
+import { MockedEthereumProvider } from '~/utils/mocks/ethereum-provider';
+
+vi.mock('@/services/transactions/request-manager');
+vi.mock('@ethersproject/providers');
+
+describe('useClaimCountListeners', () => {
+  beforeEach(() => {
+    Object.defineProperties(requestManager, {
+      listenOnClaimCountChange: {
+        value: vi.fn().mockReturnValue({ cancel: vi.fn() }),
+      },
+      getRequestData: {
+        value: vi.fn().mockReturnValue({
+          withdrawn: false,
+          activeClaims: 0,
+        }),
+      },
+    });
+  });
+
+  it('ignores transfer requests that are not expired', async () => {
+    const data = generateTransferData({
+      expired: false,
+      requestInformation: generateRequestInformationData({ identifier: getRandomString() }),
+    });
+    const transfer = ref(new Transfer(data));
+
+    transfer.value.startClaimEventListeners = vi.fn();
+    transfer.value.checkAndUpdateState = vi.fn();
+
+    const transfers = ref([transfer.value]) as Ref<Transfer[]>;
+
+    useClaimCountListeners(transfers);
+
+    await flushPromises();
+
+    expect(transfer.value.startClaimEventListeners).not.toHaveBeenCalled();
+  });
+
+  it('syncs the state of the expired transfers before starting the listeners', async () => {
+    const data = generateTransferData({
+      expired: true,
+      withdrawn: false,
+      claimCount: 2,
+      requestInformation: generateRequestInformationData({ identifier: getRandomString() }),
+    });
+    const transfer = ref(new Transfer(data));
+
+    const transfers = ref([transfer.value, transfer.value]) as Ref<Transfer[]>;
+    transfer.value.startClaimEventListeners = vi.fn();
+    transfer.value.stopEventListeners = vi.fn();
+
+    Object.defineProperties(requestManager, {
+      getRequestData: {
+        value: vi.fn().mockReturnValue({
+          withdrawn: true,
+          activeClaims: 0,
+        }),
+      },
+    });
+
+    useClaimCountListeners(transfers);
+
+    await flushPromises();
+
+    expect(transfer.value.startClaimEventListeners).not.toHaveBeenCalled();
+    expect(transfer.value.stopEventListeners).not.toHaveBeenCalled();
+  });
+
+  it('starts the claim count listeners on transfer requests that were expired and not yet withdrawn', async () => {
+    const data = generateTransferData({
+      expired: true,
+      withdrawn: false,
+      requestInformation: generateRequestInformationData({ identifier: getRandomString() }),
+    });
+    const transfer = ref(new Transfer(data));
+
+    transfer.value.startClaimEventListeners = vi.fn();
+    transfer.value.checkAndUpdateState = vi.fn();
+    const transfers = ref([transfer.value]) as Ref<Transfer[]>;
+
+    useClaimCountListeners(transfers);
+
+    await flushPromises();
+
+    expect(transfer.value.startClaimEventListeners).toHaveBeenCalled();
+  });
+
+  it('stops all the claim count listeners on transfer requests once they are withdrawn', async () => {
+    const data = generateTransferData({
+      expired: true,
+      withdrawn: false,
+      requestInformation: generateRequestInformationData({ identifier: getRandomString() }),
+    });
+    const transfer = ref(new Transfer(data));
+
+    transfer.value.stopEventListeners = vi.fn();
+    const transfers = ref([transfer.value]) as Ref<Transfer[]>;
+
+    useClaimCountListeners(transfers);
+
+    await flushPromises();
+
+    // Withdraw transfer
+    Object.defineProperties(requestManager, {
+      getRequestData: {
+        value: vi.fn().mockReturnValue({
+          withdrawn: false,
+          activeClaims: 0,
+        }),
+      },
+    });
+    const signer = new JsonRpcSigner(undefined, new JsonRpcProvider());
+    const provider = new MockedEthereumProvider({
+      chainId: transfer.value.sourceChain.identifier,
+      signer,
+    });
+    await transfer.value.withdraw(provider);
+
+    expect(transfer.value.stopEventListeners).toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/utils/data_generators.ts
+++ b/frontend/tests/utils/data_generators.ts
@@ -130,6 +130,7 @@ export function generateTransferData(partialTransferData?: Partial<TransferData>
     validityPeriod: generateUInt256Data(),
     fees: generateTokenAmountData(),
     date: Date.now(),
+    claimCount: getRandomNumber(),
     ...partialTransferData,
   };
 }

--- a/frontend/tests/utils/mocks/beamer.ts
+++ b/frontend/tests/utils/mocks/beamer.ts
@@ -56,6 +56,7 @@ export class MockedRequestManagerContract {
 
   filters = {
     ClaimStakeWithdrawn: vi.fn(),
+    ClaimMade: vi.fn(),
   };
 
   interface = {

--- a/frontend/tests/utils/mocks/beamer.ts
+++ b/frontend/tests/utils/mocks/beamer.ts
@@ -29,17 +29,13 @@ export class MockedToken {
   }
 }
 export class MockedRequest {
-  readonly validUntil: MockedBigNumber;
-  readonly activeClaims: MockedBigNumber;
+  readonly validUntil: number;
+  readonly activeClaims: number;
   readonly withdrawClaimId: MockedBigNumber;
 
   constructor(options?: { validUntil?: number; activeClaims?: number; withdrawClaimId?: number }) {
-    this.validUntil = new MockedBigNumber(
-      options?.validUntil?.toString() ?? getRandomNumber().toString(),
-    );
-    this.activeClaims = new MockedBigNumber(
-      options?.activeClaims?.toString() ?? getRandomNumber().toString(),
-    );
+    this.validUntil = options?.validUntil ?? getRandomNumber();
+    this.activeClaims = options?.activeClaims ?? getRandomNumber();
     this.withdrawClaimId = new MockedBigNumber(
       options?.withdrawClaimId?.toString() ?? getRandomNumber().toString(),
     );


### PR DESCRIPTION
Fixes #1211 

The request life-cycle changed in the contracts v1. 
In the previous version of the contracts, requests that have expired couldn't be claimed anymore.
In the new version, requests can be claimed even after expiry until a specific moment in the future.

This means that we need to watch and react on the `ClaimMade` & `ClaimStakeWithdrawn` events in order to update the transfer state so we can disable withdrawing until the claims have been withdrawn.

This mostly focuses on the case where a request has expired without a fill event but yet someone claims to have filled the event. The withdraw button will only be visible when all the claims have been withdrawn / dispute has been resolved.

I decided to provide a real-time user experience. 

This solution can be further improved by grouping all the event listeners to use array of topics instead, like so:
```
const reduceFilter = contract.filters.ClaimStakeWithdrawn(undefined, [requestId1, requestId2]);
const increaseFilter = contract.filters.ClaimMade([requestId1, requestId2]);
```
More info on this can be found here: https://docs.ethers.org/v5/concepts/events/#events--filters 

Creted a follow-up issue here: https://github.com/beamer-bridge/beamer/issues/1371