### PR TITLE
frontend: optimize request transfer

### DIFF
--- a/frontend/src/actions/transfers/transfer.ts
+++ b/frontend/src/actions/transfers/transfer.ts
@@ -240,8 +240,6 @@ export class Transfer extends MultiStepAction implements Encodable<TransferData>
       throw new Error('Missing wallet connection!');
     }
 
-    const blockNumberOnTargetChain = await getCurrentBlockNumber(this.targetChain.internalRpcUrl);
-
     const transactionHash = await sendRequestTransaction(
       signer,
       this.sourceAmount.uint256,
@@ -252,6 +250,8 @@ export class Transfer extends MultiStepAction implements Encodable<TransferData>
       this.targetAccount,
       this.validityPeriod,
     );
+
+    const blockNumberOnTargetChain = await getCurrentBlockNumber(this.targetChain.internalRpcUrl);
 
     this._requestInformation = new RequestInformation({
       transactionHash,


### PR DESCRIPTION
Previously, the code didn't account for the fact that it takes a certain amount of time from the moment
a user initiates a transfer request until he actually submits it via his wallet provider.
The transfer object was fetching & storing the target chain block at the moment of triggering a "createRequest" transaction call instead of after successful submission of the transaction call.