### PR TITLE
frontend: deal better with reverted txs

### DIFF
--- a/frontend/src/services/transactions/request-manager.ts
+++ b/frontend/src/services/transactions/request-manager.ts
@@ -139,14 +139,24 @@ export async function getRequestIdentifier(
     provider,
   );
   const receipt = await provider.waitForTransaction(transactionHash, 1);
+
   if (receipt) {
-    const event = contract.interface.parseLog(receipt.logs[0]);
-    if (event) {
-      return event.args.requestId;
+    if (receipt.status === 1) {
+      try {
+        const event = contract.interface.parseLog(receipt.logs[0]);
+
+        if (event) {
+          return event.args.requestId;
+        }
+      } catch (e) {
+        throw new Error("Request Failed. Couldn't retrieve Request ID.");
+      }
+    } else {
+      throw new Error('Transaction reverted on chain.');
     }
   }
 
-  throw new Error("Request Failed. Couldn't retrieve Request ID");
+  throw new Error('Transaction not found.');
 }
 
 export type RequestData = {

--- a/frontend/tests/utils/mocks/ethers.ts
+++ b/frontend/tests/utils/mocks/ethers.ts
@@ -7,12 +7,20 @@ export class MockedBigNumber {
   lt = vi.fn();
   isZero = vi.fn();
 }
+
 export class MockedTransaction {
   wait = vi.fn();
 }
+
 export class MockedTransactionReceipt {
   logs = [];
+  status = 1;
+
+  constructor(public props: Partial<MockedTransactionReceipt> = {}) {
+    Object.assign(this, props);
+  }
 }
+
 export class MockedERC20TokenContract {
   allowance = vi.fn();
   approve = vi.fn().mockImplementation(() => new MockedTransaction());


### PR DESCRIPTION
We were fetching the transaction receipt and were always assuming that if we have a tx receipt we have a succesfull tx. In some situations though, we had reverted transaction. We were trying to parse the logs on those, which triggered a js error: `Cannot read properties of undefined (reading 'topics')`

We now check the receipt status and try to parse the logs only if it is succesful.