### PR TITLE
Fix docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -52,7 +52,7 @@ number at the time of deployment.
 
 The rest of the files contain contract ABI information which is needed by the agent.
 
-.. _deployment on Goerli:: https://github.com/beamer-bridge/beamer/tree/main/deployments/goerli
+.. _deployment on Goerli: https://github.com/beamer-bridge/beamer/tree/main/deployments/goerli
 
 .. _agent-container:
 


### PR DESCRIPTION
This fixes a broken link and converts sphinx warnings into errors. The latter could have prevented the broken link ending in the repo, if we had it.