### PR TITLE
frontend: prevent user from submitting a second tx

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="app-content">
+  <div class="app-content relative">
     <div
       class="flex h-16 w-full flex-col justify-center bg-fire text-center text-xl font-semibold text-rosa lg:text-2xl"
     >
@@ -42,19 +42,19 @@
         </div>
       </div>
       <feedback v-if="enableFeedback"></feedback>
-      <footer class="my-8 text-lg text-center text-sea-green">
-        Powered by
-        <a href="https://beamerbridge.com" target="_blank" class="hover:underline">Beamer</a>
-        &bull;
-        <a href="https://beamerbridge.com/imprint.html" target="_blank" class="hover:underline"
-          >Imprint</a
-        >
-        &bull;
-        <a href="https://beamerbridge.com/terms.html" target="_blank" class="hover:underline"
-          >Terms of Service</a
-        >
-      </footer>
     </div>
+    <footer class="absolute bottom-0 my-4 text-lg text-center text-sea-green right-0 left-0">
+      Powered by
+      <a href="https://beamerbridge.com" target="_blank" class="hover:underline">Beamer</a>
+      &bull;
+      <a href="https://beamerbridge.com/imprint.html" target="_blank" class="hover:underline"
+        >Imprint</a
+      >
+      &bull;
+      <a href="https://beamerbridge.com/terms.html" target="_blank" class="hover:underline"
+        >Terms of Service</a
+      >
+    </footer>
   </div>
 </template>
 

--- a/frontend/src/components/RequestDialog.vue
+++ b/frontend/src/components/RequestDialog.vue
@@ -22,6 +22,13 @@
 
   <Teleport v-if="signer" to="#action-button-portal">
     <div v-if="transferFundsButtonVisible" class="flex flex-col items-center">
+      <div
+        v-if="hasPendingTransactions"
+        class="text-center rounded-tl-lg rounded-lg bg-teal px-6 py-4 mb-8 md:px-8 md:py-8 text-sm"
+      >
+        You have a pending transaction, that needs to complete before being able to make a new
+        transfer.
+      </div>
       <ActionButton :disabled="submitDisabled" @click="submitForm">
         <span v-if="!creatingTransaction"> Transfer Funds </span>
         <spinner v-else size-classes="w-8 h-8" border="4"></spinner>
@@ -88,8 +95,16 @@ const formValid = computed(() => {
   return !requestSourceInputsRef.value.v$.$invalid && !requestTargetInputsRef.value.v$.$invalid;
 });
 
+const hasPendingTransactions = computed(() => {
+  const selectedChainId = requestSource.value.sourceChain?.value.identifier;
+  if (!selectedChainId) {
+    return false;
+  }
+  return transferHistory.hasPendingTransactionsForChain(selectedChainId);
+});
+
 const submitDisabled = computed(() => {
-  return !formValid.value || creatingTransaction.value;
+  return !formValid.value || creatingTransaction.value || hasPendingTransactions.value;
 });
 
 const submitForm = async () => {

--- a/frontend/src/components/TransferWithdrawer.vue
+++ b/frontend/src/components/TransferWithdrawer.vue
@@ -25,7 +25,7 @@
           Recover Tokens
         </button>
       </template>
-      <Spinner v-else size="7" border="2" class="border-t-teal" />
+      <Spinner v-else size-classes="w-6 h-6" border="2" class="border-t-teal" />
     </template>
     <div v-else class="text-green">Tokens Withdrawn</div>
 

--- a/frontend/src/stores/transfer-history/store.ts
+++ b/frontend/src/stores/transfer-history/store.ts
@@ -27,6 +27,23 @@ export const useTransferHistory = defineStore(getStoreName(getAppMajorVersion(AP
       this.transfers.unshift(transfer);
     },
   },
+  getters: {
+    hasPendingTransactionsForChain:
+      (state) =>
+      (chainId: number): boolean => {
+        const pendingTransactions = state.transfers.filter((transfer) => {
+          const hasActiveSteps = transfer.steps.slice(0, 3).some((step) => step.active);
+          return (
+            transfer.sourceChain.identifier === chainId &&
+            !transfer.expired &&
+            !transfer.withdrawn &&
+            hasActiveSteps
+          );
+        }) as Transfer[];
+
+        return pendingTransactions.length > 0;
+      },
+  },
   persist: {
     serializer: transferHistorySerializer,
   },

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="home flex justify-center">
     <div
-      class="w-[22rem] sm:w-[25rem] md:w-[27rem] lg:w-[27rem] flex flex-col xl:justify-center xl:items-center"
+      class="w-[22rem] sm:w-[25rem] md:w-[27rem] lg:w-[27rem] flex flex-col xl:justify-center xl:items-center pb-44"
     >
       <WalletConnectionDetails></WalletConnectionDetails>
 


### PR DESCRIPTION
If the user has another transfer pending, we prevent the user from submitting a second transfer.

We don’t treat a transfer to be pending if the user has signed all transactions and they’ve been mined. If that is the case and an agent still hasn’t fullfiled the request - this is not a pending transaction.

The reason we do that is that before submiting a transaction we check the allowance and create an allowance tx. But if the actual transaction that submit the money to the contract is not mined yet, then the second tx that the user starts has an incorrect allowance and the tx that sends the money to the contract fails with "incorrect allowance".

We are currently outputting this message:
![image](https://user-images.githubusercontent.com/693770/213492098-9e2a77e1-b045-4316-bce4-ab78473c96a1.png)

I've moved the footer to an absolute position and suck it on the bottom of the page. I applied bottom padding to the main container so that on smaller screens the footer is always some pixels below the content & they don't overlap
![image](https://user-images.githubusercontent.com/693770/213492408-db7d2b16-218f-4234-a626-1fa79c6f6c8c.png)
