### PR TITLE
frontend: add GPL license

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "beamer-request-interface",
   "version": "2.0.0",
   "private": true,
+  "license": "GPL-3.0-or-later",
   "scripts": {
     "dev": "vite",
     "build": "yarn configure && vite build",

--- a/relayer/package.json
+++ b/relayer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beamer-relayer",
   "version": "0.0.1",
-  "license": "MIT",
+  "license": "GPL-3.0-or-later",
   "author": "brainbot technologies AG",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The frontend had no license specified in its `package.json`.