### PR TITLE
frontend: Add MatomoConsentPopup

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -48,6 +48,8 @@
     <!-- Matomo -->
     <script>
       var _paq = (window._paq = window._paq || []);
+      /* require user tracking consent before processing data */
+      _paq.push(['requireConsent']);
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -55,6 +55,7 @@
         >Terms of Service</a
       >
     </footer>
+    <MatomoConsentPopup />
   </div>
 </template>
 
@@ -72,6 +73,7 @@ import { useConfiguration } from '@/stores/configuration';
 import { useEthereumProvider } from '@/stores/ethereum-provider';
 import { useTransferHistory } from '@/stores/transfer-history';
 
+import MatomoConsentPopup from './components/MatomoConsentPopup.vue';
 import { useClaimCountListeners } from './composables/useClaimCountListeners';
 
 const enableFeedback = process.env.NODE_ENV === 'production' && true;

--- a/frontend/src/components/MatomoConsentPopup.vue
+++ b/frontend/src/components/MatomoConsentPopup.vue
@@ -27,18 +27,22 @@
   </div>
 </template>
 <script lang="ts" setup>
+import { storeToRefs } from 'pinia';
 import { ref } from 'vue';
 
-import SimpleTextButton from './layout/SimpleTextButton.vue';
+import SimpleTextButton from '@/components/layout/SimpleTextButton.vue';
+import { useSettings } from '@/stores/settings';
 
 const _paq = (window._paq = window._paq || []);
+
+const { matomoConsentDeclined } = storeToRefs(useSettings());
 
 const displayed = ref(false);
 
 _paq.push([
   function () {
     const rememberedConsent = this.getRememberedConsent();
-    displayed.value = !rememberedConsent;
+    displayed.value = !rememberedConsent && !matomoConsentDeclined.value;
   },
 ]);
 
@@ -48,6 +52,7 @@ const allowConsent = () => {
 };
 
 const disallowConsent = () => {
+  matomoConsentDeclined.value = true;
   displayed.value = false;
 };
 </script>

--- a/frontend/src/components/MatomoConsentPopup.vue
+++ b/frontend/src/components/MatomoConsentPopup.vue
@@ -1,0 +1,53 @@
+<template>
+  <div
+    v-if="displayed"
+    class="fixed w-full h-full flex justify-center items-center z-50 backdrop-blur"
+    data-test="consent-popup"
+  >
+    <div class="max-w-lg py-6 px-6 bg-teal-dark rounded-md">
+      This site uses Matomo to analyze traffic and help us to improve your user experience. We
+      process your IP address and cookies are stored on your browser for 13 months. This data is
+      only processed by us and our web hosting platform. Please read our
+      <a
+        href="https://beamerbridge.com/privacy.html"
+        target="_blank"
+        class="text-sea-green hover:underline"
+        >Privacy Policy</a
+      >
+      to learn more.
+      <div class="flex flex-row justify-evenly mt-6">
+        <SimpleTextButton class="!text-base" data-test="accept-consent" @click="allowConsent"
+          >Accept</SimpleTextButton
+        >
+        <SimpleTextButton class="!text-base" data-test="decline-consent" @click="disallowConsent"
+          >Decline</SimpleTextButton
+        >
+      </div>
+    </div>
+  </div>
+</template>
+<script lang="ts" setup>
+import { ref } from 'vue';
+
+import SimpleTextButton from './layout/SimpleTextButton.vue';
+
+const _paq = (window._paq = window._paq || []);
+
+const displayed = ref(false);
+
+_paq.push([
+  function () {
+    const rememberedConsent = this.getRememberedConsent();
+    displayed.value = !rememberedConsent;
+  },
+]);
+
+const allowConsent = () => {
+  _paq.push(['rememberConsentGiven']);
+  displayed.value = false;
+};
+
+const disallowConsent = () => {
+  displayed.value = false;
+};
+</script>

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -5,6 +5,7 @@ import type { WalletType } from '@/types/settings';
 export const useSettings = defineStore('settings', {
   state: () => ({
     connectedWallet: undefined as WalletType | undefined,
+    matomoConsentDeclined: false,
   }),
   persist: true,
 });

--- a/frontend/tests/unit/components/MatomoConsentPopup.spec.ts
+++ b/frontend/tests/unit/components/MatomoConsentPopup.spec.ts
@@ -1,6 +1,8 @@
+import { createTestingPinia } from '@pinia/testing';
 import { mount } from '@vue/test-utils';
 
 import MatomoConsentPopup from '@/components/MatomoConsentPopup.vue';
+import { useSettings } from '@/stores/settings';
 
 describe('MatomoConsentPopup.vue', () => {
   let _paq: unknown[];
@@ -13,6 +15,9 @@ describe('MatomoConsentPopup.vue', () => {
   async function createWrapper() {
     const wrapper = mount(MatomoConsentPopup, {
       shallow: true,
+      global: {
+        plugins: [createTestingPinia()],
+      },
     });
 
     const init = _paq.pop() as Array<() => void>;
@@ -36,11 +41,13 @@ describe('MatomoConsentPopup.vue', () => {
 
   it('allows to decline consent', async () => {
     const wrapper = await createWrapper();
+    const settings = useSettings();
 
     const trigger = wrapper.find('[data-test="decline-consent"]');
     await trigger.trigger('click');
 
     expect(_paq).toHaveLength(0);
     expect(wrapper.find('[data-test="consent-popup"]').exists()).toBeFalsy();
+    expect(settings.matomoConsentDeclined).toBe(true);
   });
 });

--- a/frontend/tests/unit/components/MatomoConsentPopup.spec.ts
+++ b/frontend/tests/unit/components/MatomoConsentPopup.spec.ts
@@ -1,0 +1,46 @@
+import { mount } from '@vue/test-utils';
+
+import MatomoConsentPopup from '@/components/MatomoConsentPopup.vue';
+
+describe('MatomoConsentPopup.vue', () => {
+  let _paq: unknown[];
+
+  beforeEach(() => {
+    _paq = [];
+    Object.defineProperty(global.window, '_paq', { value: _paq, writable: true });
+  });
+
+  async function createWrapper() {
+    const wrapper = mount(MatomoConsentPopup, {
+      shallow: true,
+    });
+
+    const init = _paq.pop() as Array<() => void>;
+    const context = { getRememberedConsent: () => null };
+    init[0].bind(context)();
+    await wrapper.vm.$nextTick();
+
+    return wrapper;
+  }
+
+  it('allows to give consent', async () => {
+    const wrapper = await createWrapper();
+
+    const trigger = wrapper.find('[data-test="accept-consent"]');
+    await trigger.trigger('click');
+
+    expect(_paq).toHaveLength(1);
+    expect(_paq[0]).toEqual(['rememberConsentGiven']);
+    expect(wrapper.find('[data-test="consent-popup"]').exists()).toBeFalsy();
+  });
+
+  it('allows to decline consent', async () => {
+    const wrapper = await createWrapper();
+
+    const trigger = wrapper.find('[data-test="decline-consent"]');
+    await trigger.trigger('click');
+
+    expect(_paq).toHaveLength(0);
+    expect(wrapper.find('[data-test="consent-popup"]').exists()).toBeFalsy();
+  });
+});

--- a/frontend/tests/unit/stores/settings.spec.ts
+++ b/frontend/tests/unit/stores/settings.spec.ts
@@ -15,6 +15,11 @@ describe('settings store', () => {
       const settings = useSettings();
       expect(settings.$state.connectedWallet).toBeUndefined();
     });
+
+    it('initialize settings store matomoConsentDeclined with false', () => {
+      const settings = useSettings();
+      expect(settings.$state.matomoConsentDeclined).toBe(false);
+    });
   });
 
   describe('connected wallet', () => {
@@ -22,6 +27,14 @@ describe('settings store', () => {
       const settings = useSettings();
       settings.connectedWallet = WalletType.MetaMask;
       expect(settings.$state.connectedWallet).toBe(WalletType.MetaMask);
+    });
+  });
+
+  describe('matomo consent declined', () => {
+    it('can decline the matomo consent', () => {
+      const settings = useSettings();
+      settings.matomoConsentDeclined = true;
+      expect(settings.$state.matomoConsentDeclined).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Closes #1375 

Stops Matomo tracking until the user accepts it in the pop up. Consent information is stored in Matomo.

@olympe-silve please check in the screenshot if the styling of the pop up is ok like this:
![Screen Shot 2023-02-01 at 23 14 47](https://user-images.githubusercontent.com/34456797/216175780-22d21481-8741-419f-b23e-3ac176caaf85.png)
