### PR TITLE
agent: allow lists of event callbacks to be added to the EventMonitor

### DIFF
--- a/beamer/agent.py
+++ b/beamer/agent.py
@@ -88,7 +88,7 @@ class Agent:
             web3=w3_l2a,
             contracts=(request_manager,),
             deployment_block=l2a_contracts_info["RequestManager"].deployment_block,
-            on_new_events=self._event_processor.add_events,
+            on_new_events=[self._event_processor.add_events],
             on_sync_done=self._event_processor.mark_sync_done,
             poll_period=POLL_PERIOD,
         )
@@ -97,7 +97,7 @@ class Agent:
             web3=w3_l2b,
             contracts=(fill_manager,),
             deployment_block=l2b_contracts_info["FillManager"].deployment_block,
-            on_new_events=self._event_processor.add_events,
+            on_new_events=[self._event_processor.add_events],
             on_sync_done=self._event_processor.mark_sync_done,
             poll_period=POLL_PERIOD,
         )

--- a/beamer/chain.py
+++ b/beamer/chain.py
@@ -48,7 +48,7 @@ class EventMonitor:
         web3: Web3,
         contracts: tuple[Contract, ...],
         deployment_block: BlockNumber,
-        on_new_events: Callable[[list[Event]], None],
+        on_new_events: list[Callable[[list[Event]], None]],
         on_sync_done: Callable[[], None],
         poll_period: int,
     ):
@@ -86,15 +86,19 @@ class EventMonitor:
         fetcher = EventFetcher(self._web3, self._contracts, self._deployment_block)
         events = fetcher.fetch()
         if events:
-            self._on_new_events(events)
+            self._call_on_new_events(events)
         self._on_sync_done()
         self._log.info("Sync done")
         while not self._stop:
             events = fetcher.fetch()
             if events:
-                self._on_new_events(events)
+                self._call_on_new_events(events)
             time.sleep(self._poll_period)
         self._log.info("EventMonitor stopped")
+
+    def _call_on_new_events(self, events: list[Event]) -> None:
+        for on_new_events in self._on_new_events:
+            on_new_events(events)
 
 
 class EventProcessor:


### PR DESCRIPTION
implements: #1425 

I decided to not go for a method to add a callback, as all EventProcessors will be static for now. They will all be created before the EventMonitor is initialized.