### PR TITLE
Handle ConnectionError on sync

### DIFF
--- a/beamer/chain.py
+++ b/beamer/chain.py
@@ -84,7 +84,10 @@ class EventMonitor:
         )
 
         fetcher = EventFetcher(self._web3, self._contracts, self._deployment_block)
-        events = fetcher.fetch()
+        current_block = self._web3.eth.block_number
+        events = []
+        while fetcher.synced_block < current_block:
+            events = fetcher.fetch()
         if events:
             self._on_new_events(events)
         self._on_sync_done()

--- a/beamer/chain.py
+++ b/beamer/chain.py
@@ -87,7 +87,7 @@ class EventMonitor:
         current_block = self._web3.eth.block_number
         events = []
         while fetcher.synced_block < current_block:
-            events = fetcher.fetch()
+            events.extend(fetcher.fetch())
         if events:
             self._on_new_events(events)
         self._on_sync_done()

--- a/beamer/events.py
+++ b/beamer/events.py
@@ -285,7 +285,8 @@ class EventFetcher:
 
     def fetch(self) -> list[Event]:
         try:
-            block_number = BlockNumber(self._web3.eth.block_number)
+            block_data = self._web3.eth.get_block("latest")
+            block_number = BlockNumber(block_data["number"])
         except requests.exceptions.RequestException:
             return []
 

--- a/beamer/events.py
+++ b/beamer/events.py
@@ -225,6 +225,10 @@ class EventFetcher:
                 self._chain_id == contract.web3.eth.chain_id
             ), f"Chain id mismatch for {contract}"
 
+    @property
+    def synced_block(self) -> BlockNumber:
+        return BlockNumber(self._next_block_number - 1)
+
     def _fetch_range(
         self, from_block: BlockNumber, to_block: BlockNumber
     ) -> Optional[list[Event]]:
@@ -281,7 +285,7 @@ class EventFetcher:
 
     def fetch(self) -> list[Event]:
         try:
-            block_number = self._web3.eth.block_number
+            block_number = BlockNumber(self._web3.eth.block_number)
         except requests.exceptions.RequestException:
             return []
 

--- a/beamer/tests/util.py
+++ b/beamer/tests/util.py
@@ -9,8 +9,8 @@ from typing import Any, List, Optional
 import brownie
 import requests
 import web3
+from eth_abi.packed import encode_packed
 
-from eth_abi.packed import encode_abi_packed
 from eth_utils import keccak, to_canonical_address
 
 from beamer.tests.constants import RM_T_FIELD_TRANSFER_LIMIT
@@ -234,7 +234,7 @@ def create_request_id(
     source_chain_id, target_chain_id, target_token_address, receiver_address, amount, nonce
 ):
     return keccak(
-        encode_abi_packed(
+        encode_packed(
             ["uint256", "uint256", "address", "address", "uint256", "uint96"],
             [
                 source_chain_id,


### PR DESCRIPTION
I saw two solutions: 
Either throwing the error up until the point where `on_sync_done()`, namely the EventMonitor. I didn't like that option because I think handling request exceptions inside of the EventFetcher is the right place.

The other option, was to check whether the fetch call synced up until a certain point. I went with that option. Fetching the BlockNumber before calling fetch() for the sync. Exposing the latest synced block by a property in the EventFetcher. And checking whether the fetcher synced at least until this block.

I realized that not only the ConnectionError described in #1435  is a problem, also a RequestException during fetching the blockNumber in https://github.com/beamer-bridge/beamer/blob/9935c4ab77044d17645329e68c0e259639cebab0/beamer/events.py#L288 results in the same problem.