### PR TITLE
frontend: Fix wallet disconnection after chain switch

### DIFF
--- a/frontend/src/services/web3-provider/metamask-provider.ts
+++ b/frontend/src/services/web3-provider/metamask-provider.ts
@@ -53,4 +53,8 @@ export class MetaMaskProvider extends EthereumProvider implements ISigner {
       throw error;
     }
   }
+
+  listenToEvents(): void {
+    this.listenToChangeEvents();
+  }
 }

--- a/frontend/tests/unit/services/web3-provider/ethereum-provider.spec.ts
+++ b/frontend/tests/unit/services/web3-provider/ethereum-provider.spec.ts
@@ -276,26 +276,6 @@ describe('EthereumProvider', () => {
       expect(ethereumProvider.signer.value).toBeUndefined();
       expect(ethereumProvider.signerAddress.value).toBeUndefined();
     });
-
-    it('should not disconnect after a chain switch', async () => {
-      const web3Provider = mockWeb3Provider();
-      web3Provider.getSigner = vi.fn().mockImplementation((signer) => signer);
-
-      const currentChainId = 1;
-      const newChainId = 2;
-      const chain = generateChain({ identifier: newChainId });
-
-      const ethereumProvider = new TestEthereumProvider();
-      ethereumProvider.setSigner(getRandomEthereumAddress());
-      ethereumProvider.chainId.value = currentChainId;
-      ethereumProvider.switchChain = vi.fn().mockResolvedValue(true);
-
-      await ethereumProvider.switchChainSafely(chain);
-      ethereumProvider.disconnect();
-
-      expect(ethereumProvider.signer.value).not.toBeUndefined();
-      expect(ethereumProvider.signerAddress.value).not.toBeUndefined();
-    });
   });
 
   describe('listenToEvents()', () => {

--- a/frontend/tests/unit/services/web3-provider/metamask-provider.spec.ts
+++ b/frontend/tests/unit/services/web3-provider/metamask-provider.spec.ts
@@ -121,5 +121,20 @@ describe('metamask-provider', () => {
         expect(metamaskProvider.signerAddress.value).toBeUndefined();
       });
     });
+
+    describe('listenToEvents()', () => {
+      it('attaches necessary event listeners for the wallet provider', () => {
+        const eipProvider = new MockedEip1193Provider({ isMetaMask: true });
+        const metamaskProvider = new MetaMaskProvider(eipProvider);
+
+        metamaskProvider.listenToEvents();
+
+        expect(eipProvider.on).toHaveBeenCalledWith('accountsChanged', expect.anything());
+        expect(eipProvider.on).toHaveBeenCalledWith('chainChanged', expect.anything());
+        // There is a bug with the disconnect event in MetaMask
+        // See https://github.com/MetaMask/metamask-extension/issues/13375
+        expect(eipProvider.on).not.toHaveBeenCalledWith('disconnect', expect.anything());
+      });
+    });
   });
 });


### PR DESCRIPTION
Closes #1118 

Slow RPCs can still lead to the problem that after a chain switch a wallet disconnection occurs. Looks like the timeout of 1 second is not enough. To fix it deterministically, I removed the listener on the disconnect event completely. The listener was used to catch the case when a user clicks disconnect inside MetaMask. In this case also an accountsChanged event is fired. We can simply rely on this event to call our disconnect function. I also removed the no disconnection after chain switch test as it is not applicable anymore. There is no test, because I think the new behavior is not coverable in a unit test.