### PR TITLE
Create only one process created per resolution and invalidation

### DIFF
--- a/beamer/agent.py
+++ b/beamer/agent.py
@@ -80,6 +80,7 @@ class Agent:
             task_pool=self._task_pool,
             claim_request_extension=claim_request_extension,
             l1_resolutions={},
+            l1_invalidations={},
         )
 
         self._event_processor = EventProcessor(self.context)

--- a/beamer/tests/agent/unit/utils.py
+++ b/beamer/tests/agent/unit/utils.py
@@ -174,6 +174,7 @@ def make_context() -> Tuple[Context, Config]:
         task_pool=MagicMock(),
         claim_request_extension=100,
         l1_resolutions={},
+        l1_invalidations={},
     )
     context.request_manager.functions.claimStake().call.return_value = 1  # type: ignore
     return context, config


### PR DESCRIPTION
Although we stored the future of the relayer process in a dictionary, we did not  check whether there was a process running on a new InitiateL1Resolution event.

Additionally, we also stored invalidations in `context.l1_resolutions` which would lead to invalidation relayer processes blocking l1 resolutions. we need to separate that into their own dicts. 