### PR TITLE
frontend: Fix app release version repository URL

### DIFF
--- a/frontend/src/components/Version.vue
+++ b/frontend/src/components/Version.vue
@@ -1,15 +1,18 @@
 <template>
-  <div v-if="commitHash" class="text-xs">
+  <div v-if="visible" class="text-xs">
     Build version:
-    <a :href="gitRepositoryAtCommitURL" target="_blank" class="underline" data-test="commit-hash">
-      {{ commitHash }}
+    <a :href="gitRepositoryAtCommitURL" target="_blank" class="underline" data-test="version">
+      {{ version }}
     </a>
   </div>
 </template>
 
 <script lang="ts" setup>
 const commitHash = APP_RELEASE.COMMIT_HASH;
+const version = APP_RELEASE.VERSION;
 const gitRepositoryURL = APP_RELEASE.REPOSITORY;
 
 const gitRepositoryAtCommitURL = `${gitRepositoryURL}/tree/${commitHash}`;
+
+const visible = commitHash && import.meta.env.MODE !== 'development';
 </script>

--- a/frontend/tests/unit/components/Version.spec.ts
+++ b/frontend/tests/unit/components/Version.spec.ts
@@ -2,29 +2,57 @@ import { mount } from '@vue/test-utils';
 
 import Version from '@/components/Version.vue';
 
-const envCopy = Object.assign({}, APP_RELEASE);
+const globalCopy = Object.assign({}, APP_RELEASE);
+const importEnvCopy = Object.assign({}, import.meta.env);
 
-const resetEnvMock = () => {
-  Object.assign(APP_RELEASE, envCopy);
+const resetImportEnv = (): void => {
+  Object.assign(import.meta.env, importEnvCopy);
+};
+
+const resetGlobalVariables = (): void => {
+  Object.assign(APP_RELEASE, globalCopy);
 };
 
 describe('Version.vue', () => {
   afterEach(() => {
-    resetEnvMock();
+    resetImportEnv();
+    resetGlobalVariables();
   });
 
-  it('is hidden when no version is defined', () => {
+  it('is hidden when in development mode', () => {
+    Object.assign(import.meta.env, {
+      MODE: 'development',
+    });
+    const wrapper = mount(Version);
+
+    const commitHashEl = wrapper.find('[data-test="version"]');
+    expect(commitHashEl.exists()).toBe(false);
+  });
+
+  it('is visible when in production mode', () => {
+    Object.assign(import.meta.env, {
+      MODE: 'production',
+    });
+
+    const wrapper = mount(Version);
+
+    const commitHashEl = wrapper.find('[data-test="version"]');
+    expect(commitHashEl.exists()).toBe(true);
+  });
+
+  it('is hidden when commit hash is undefined', () => {
     Object.assign(APP_RELEASE, { COMMIT_HASH: undefined });
 
     const wrapper = mount(Version);
 
-    const commitHashEl = wrapper.find('[data-test="commit-hash"]');
+    const commitHashEl = wrapper.find('[data-test="version"]');
     expect(commitHashEl.exists()).toBe(false);
   });
-  it('displays the commit hash of the build', () => {
+
+  it('displays the release version of the build', () => {
     const wrapper = mount(Version);
 
-    const commitHashEl = wrapper.find('[data-test="commit-hash"]');
-    expect(commitHashEl.text()).toBe(APP_RELEASE.COMMIT_HASH);
+    const commitHashEl = wrapper.find('[data-test="version"]');
+    expect(commitHashEl.text()).toBe(APP_RELEASE.VERSION);
   });
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,9 +10,9 @@ const test_output_directory = path.resolve(test_directory, 'output');
 const config_directory = path.resolve(__dirname, 'config');
 
 // Release Info
-const VERSION = process.env.npm_package_version;
-const COMMIT_HASH = execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
-const REPOSITORY = execSync('git ls-remote --get-url', { encoding: 'utf-8' }).trim();
+const version = execSync('git describe --tags', { encoding: 'utf-8' }).trim();
+const commitHash = execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+const REPOSITORY = 'https://github.com/beamer-bridge/beamer';
 
 export default defineConfig({
   plugins: [vue()],
@@ -51,8 +51,8 @@ export default defineConfig({
   },
   define: {
     APP_RELEASE: {
-      VERSION,
-      COMMIT_HASH,
+      VERSION: version,
+      COMMIT_HASH: commitHash,
       REPOSITORY,
     },
   },


### PR DESCRIPTION
closes #1474 

Please note, this solution won't work with forked repositories so it is tailored only for use with our official repo (repository URL value is a static `https://github.com/beamer-bridge/beamer` instead of a dynamic value based on `git ls-remote --get-url`).

When using `git ls-remote --get-url` for determining the repository URL we had several problems for which i couldn't find a simple yet inclusive solution:
- determining the HTTPS URLs when the local repo config is using SSH URLs
- not exposing the sensitive information stored inside `git config` (like github access tokens etc.). Check #1474 for more info.

If someone has any suggestion on how to tackle all of this at once with a simple command please let me know.