### PR TITLE
.circleci: properly init the nitro submodule

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -209,6 +209,7 @@ jobs:
       - restore_cache:
           key: arbitrum-submodule-{{ checksum "/tmp/arbitrum-commit-hash" }}-{{ .Environment.CACHE_VERSION }}
       - run: |
+          git submodule update --init $ARBITRUM/nitro
           cd $ARBITRUM/nitro
           git submodule update --init blockscout brotli fastcache go-ethereum \
                                       arbitrator/wasm-libraries/soft-float/SoftFloat


### PR DESCRIPTION
It won't be initialized by default so we have to do it manually before initializing its submodules.