### PR TITLE
frontend: Add infinite token approval checkbox

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="app-content relative">
+  <div
+    class="app-content flex flex-col min-h-screen w-full font-sans antialiased text-white bg-gradient-to-b from-black to-teal"
+  >
     <div
       class="flex h-16 w-full flex-col justify-center bg-fire text-center text-xl font-semibold text-rosa lg:text-2xl"
     >
@@ -43,6 +45,7 @@
       </div>
       <feedback v-if="enableFeedback"></feedback>
     </div>
+    <div class="flex-auto"></div>
     <Footer />
     <MatomoConsentPopup />
   </div>
@@ -80,17 +83,3 @@ useClaimCountListeners(transfers as Ref<Array<Transfer>>);
 
 onMounted(loadConfiguration);
 </script>
-
-<style lang="css">
-.app-content {
-  font-family: 'Sora', sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  color: theme('colors.white');
-  background: linear-gradient(180deg, theme('colors.black') 0%, theme('colors.teal') 100%);
-  width: 100%;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-}
-</style>

--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="absolute bottom-0 my-4 text-lg text-center text-sea-green right-0 left-0">
+  <footer class="my-8 text-lg text-center text-sea-green">
     <div>
       Powered by
       <a href="https://beamerbridge.com" target="_blank" class="hover:underline">Beamer</a>

--- a/frontend/src/components/RequestDialog.vue
+++ b/frontend/src/components/RequestDialog.vue
@@ -24,10 +24,31 @@
     <div v-if="transferFundsButtonVisible" class="flex flex-col items-center">
       <div
         v-if="hasPendingTransactions"
-        class="text-center rounded-tl-lg rounded-lg bg-teal px-6 py-4 mb-8 md:px-8 md:py-8 text-sm"
+        class="text-center rounded-lg bg-teal px-6 py-4 mb-7 md:px-8 md:py-8 text-sm"
       >
         You have a pending transaction, that needs to complete before being able to make a new
         transfer.
+      </div>
+      <div class="flex flex-row gap-2 pl-2 items-center justify-center mb-7">
+        <input
+          v-model="approveInfiniteAmount"
+          type="checkbox"
+          class="appearance-none h-5 w-5 bg-sea-green shadow-inner rounded-md hover:opacity-90 checked:after:text-teal checked:after:text-2xl checked:after:leading-6 checked:after:content-['\2713']"
+        />
+        <span class="text-sm">Approve maximum token allowance</span>
+        <Tooltip>
+          <div class="h-full flex flex-col justify-center">
+            <img class="h-5 w-5 cursor-help" src="@/assets/images/help.svg" />
+          </div>
+          <template #hint>
+            <div class="max-w-sm">
+              Save time and money on transaction fees by ticking this box to skip the recurring
+              access permission step for future transfers with Beamer. You only need to approve
+              once per token and rollup/chain. Please keep in mind the risks if you use this
+              option.
+            </div>
+          </template>
+        </Tooltip>
       </div>
       <ActionButton :disabled="submitDisabled" @click="submitForm">
         <span v-if="!creatingTransaction"> Transfer Funds </span>
@@ -44,6 +65,7 @@ import type { Ref } from 'vue';
 import { computed, nextTick, ref, watch } from 'vue';
 
 import ActionButton from '@/components/layout/ActionButton.vue';
+import Tooltip from '@/components/layout/Tooltip.vue';
 import RequestSourceInputs from '@/components/RequestSourceInputs.vue';
 import RequestTargetInputs from '@/components/RequestTargetInputs.vue';
 import Spinner from '@/components/Spinner.vue';
@@ -83,6 +105,7 @@ const { getTokenForChain } = useConfiguration();
 
 const requestSource: Ref<RequestSource> = ref(EMPTY_SOURCE_DATA);
 const requestTarget: Ref<RequestTarget> = ref(EMPTY_TARGET_DATA);
+const approveInfiniteAmount = ref(false);
 
 const requestSourceInputsRef = ref<{ v$: Validation }>();
 const requestTargetInputsRef = ref<{ v$: Validation }>();
@@ -130,6 +153,7 @@ const submitForm = async () => {
     toAddress: validRequestTarget.value.toAddress,
     sourceToken: validRequestSource.value.token.value,
     targetToken,
+    approveInfiniteAmount: approveInfiniteAmount.value,
   });
 
   transferHistory.addTransfer(transfer);

--- a/frontend/src/composables/useTokenAllowance.ts
+++ b/frontend/src/composables/useTokenAllowance.ts
@@ -1,0 +1,36 @@
+import type { Ref } from 'vue';
+import { computed, ref, watch } from 'vue';
+
+import { getTokenAllowance } from '@/services/transactions/token';
+import type { IEthereumProvider } from '@/services/web3-provider';
+import type { Chain, Token } from '@/types/data';
+import type { TokenAmount } from '@/types/token-amount';
+import { UInt256 } from '@/types/uint-256';
+
+export function useTokenAllowance(
+  provider: Ref<IEthereumProvider | undefined>,
+  token: Ref<Token | undefined>,
+  sourceChain: Ref<Chain | undefined>,
+) {
+  const signerAddress = computed(() => provider.value?.signerAddress.value);
+  const allowance: Ref<TokenAmount | undefined> = ref(undefined);
+
+  const allowanceBelowMax = computed(() => allowance.value?.uint256.lt(UInt256.max()) ?? false);
+
+  async function updateTokenAllowance() {
+    if (token.value && provider.value && sourceChain.value && signerAddress.value) {
+      allowance.value = await getTokenAllowance(
+        provider.value,
+        token.value,
+        signerAddress.value,
+        sourceChain.value.requestManagerAddress,
+      );
+    } else {
+      allowance.value = undefined;
+    }
+  }
+
+  watch([token, sourceChain, signerAddress], updateTokenAllowance, { immediate: true });
+
+  return { allowance, allowanceBelowMax };
+}

--- a/frontend/src/composables/useTransferRequest.ts
+++ b/frontend/src/composables/useTransferRequest.ts
@@ -20,6 +20,7 @@ export function useTransferRequest() {
     toAddress: string;
     sourceToken: Token;
     targetToken: Token;
+    approveInfiniteAmount: boolean;
   }): Promise<Transfer> => {
     const sourceTokenAmount = TokenAmount.parse(options.sourceAmount, options.sourceToken);
     const targetTokenAmount = TokenAmount.parse(options.sourceAmount, options.targetToken);
@@ -38,7 +39,7 @@ export function useTransferRequest() {
         options.toAddress,
         validityPeriod,
         fees,
-        false,
+        options.approveInfiniteAmount,
       ),
     ) as Transfer;
 

--- a/frontend/src/composables/useTransferRequest.ts
+++ b/frontend/src/composables/useTransferRequest.ts
@@ -38,6 +38,7 @@ export function useTransferRequest() {
         options.toAddress,
         validityPeriod,
         fees,
+        false,
       ),
     ) as Transfer;
 

--- a/frontend/src/services/transactions/token.ts
+++ b/frontend/src/services/transactions/token.ts
@@ -47,6 +47,23 @@ export async function getTokenBalance(
   return TokenAmount.new(balance, token);
 }
 
+export async function getTokenAllowance(
+  provider: IEthereumProvider,
+  token: Token,
+  ownerAddress: EthereumAddress,
+  spenderAddress: EthereumAddress,
+): Promise<TokenAmount> {
+  const tokenContract = getReadOnlyContract<StandardToken>(
+    token.address,
+    StandardTokenDeployment.abi,
+    provider.getProvider(),
+  );
+  const allowance = new UInt256(
+    (await tokenContract.allowance(ownerAddress, spenderAddress)).toString(),
+  );
+  return TokenAmount.new(allowance, token);
+}
+
 export function listenOnTokenBalanceChange(options: {
   provider: IEthereumProvider;
   token: Token;

--- a/frontend/src/types/uint-256.ts
+++ b/frontend/src/types/uint-256.ts
@@ -23,6 +23,10 @@ export class UInt256 implements Encodable<UInt256Data> {
     return new this(utils.parseUnits(value, decimals ?? 0).toString());
   }
 
+  static max(): UInt256 {
+    return new this(BigNumber.from(2).pow(256).sub(1).toString());
+  }
+
   get asString(): string {
     return this.value.toString();
   }

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="home flex justify-center">
     <div
-      class="w-[22rem] sm:w-[25rem] md:w-[27rem] lg:w-[27rem] flex flex-col xl:justify-center xl:items-center pb-44"
+      class="w-[22rem] sm:w-[25rem] md:w-[27rem] lg:w-[27rem] flex flex-col xl:justify-center xl:items-center"
     >
       <WalletConnectionDetails></WalletConnectionDetails>
 
-      <div class="relative mb-5 mt-3 w-full h-[37.3rem] md:h-[40.2rem]">
+      <div class="relative mb-7 mt-3 w-full h-[37.3rem] md:h-[40.2rem]">
         <WalletMenu v-if="walletMenuIsOpen" class="absolute z-10" @close="closeWalletMenu" />
         <Tabs
           class="tooltip-reference-element"
@@ -15,16 +15,14 @@
           @tab-changed="onTabChanged"
         />
       </div>
-      <div class="h-28 mt-5">
-        <div
-          v-show="actionButtonPortalVisible"
-          id="action-button-portal"
-          class="flex justify-center gap-5"
-        >
-          <ActionButton v-if="!signer" class="bg-orange" @click="openWalletMenu"
-            >Connect to Wallet
-          </ActionButton>
-        </div>
+      <div
+        v-show="actionButtonPortalVisible"
+        id="action-button-portal"
+        class="flex justify-center gap-5"
+      >
+        <ActionButton v-if="!signer" class="bg-orange" @click="openWalletMenu"
+          >Connect to Wallet
+        </ActionButton>
       </div>
     </div>
   </div>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -36,6 +36,9 @@ module.exports = {
         xl: '45px',
         50: '50%',
       },
+      fontFamily: {
+        sans: ['Sora', 'sans-serif'],
+      },
     },
   },
   variants: {

--- a/frontend/tests/unit/actions/transfers/transfer.spec.ts
+++ b/frontend/tests/unit/actions/transfers/transfer.spec.ts
@@ -176,6 +176,30 @@ describe('transfer', () => {
         new UInt256('3'),
       );
     });
+
+    it('sets the allowance to the infinite amount if the approveInfiniteAmount flag is set', async () => {
+      const data = generateTransferData({
+        fees: generateTokenAmountData({ amount: '2' }),
+        sourceChain: generateChain({ requestManagerAddress: '0xRequestManager' }),
+        sourceAmount: generateTokenAmountData({
+          token: generateToken({ address: '0xSourceToken' }),
+          amount: '1',
+        }),
+        approveInfiniteAmount: true,
+      });
+      const transfer = new TestTransfer(data);
+      const signer = new JsonRpcSigner(undefined, new JsonRpcProvider());
+
+      await transfer.ensureTokenAllowance(signer);
+
+      expect(tokenUtils.ensureTokenAllowance).toHaveBeenCalledTimes(1);
+      expect(tokenUtils.ensureTokenAllowance).toHaveBeenLastCalledWith(
+        signer,
+        '0xSourceToken',
+        '0xRequestManager',
+        UInt256.max(),
+      );
+    });
   });
 
   describe('sendRequestTransaction()', () => {

--- a/frontend/tests/unit/composables/useTokenAllowance.spec.ts
+++ b/frontend/tests/unit/composables/useTokenAllowance.spec.ts
@@ -1,0 +1,93 @@
+import { flushPromises } from '@vue/test-utils';
+import { ref, shallowRef } from 'vue';
+
+import { useTokenAllowance } from '@/composables/useTokenAllowance';
+import * as tokenService from '@/services/transactions/token';
+import { TokenAmount } from '@/types/token-amount';
+import { UInt256 } from '@/types/uint-256';
+import { generateChain, generateToken, getRandomEthereumAddress } from '~/utils/data_generators';
+import { MockedEthereumProvider } from '~/utils/mocks/ethereum-provider';
+
+vi.mock('@/services/transactions/token');
+
+const PROVIDER = shallowRef(
+  new MockedEthereumProvider({
+    signerAddress: getRandomEthereumAddress(),
+  }),
+);
+const TOKEN = ref(generateToken());
+const SOURCE_CHAIN = ref(generateChain());
+
+describe('useTokenAllowance', () => {
+  describe('allowance', () => {
+    it('is undefined when provided ethereum provider is not defined', () => {
+      const provider = ref(undefined);
+
+      const { allowance } = useTokenAllowance(provider, TOKEN, SOURCE_CHAIN);
+
+      expect(allowance.value).toBeUndefined();
+    });
+
+    it('is undefined when provided token is not defined', () => {
+      const token = ref(undefined);
+
+      const { allowance } = useTokenAllowance(PROVIDER, token, SOURCE_CHAIN);
+
+      expect(allowance.value).toBeUndefined();
+    });
+
+    it('is undefined when provided token is not defined', () => {
+      const sourceChain = ref(undefined);
+
+      const { allowance } = useTokenAllowance(PROVIDER, TOKEN, sourceChain);
+
+      expect(allowance.value).toBeUndefined();
+    });
+
+    it('is undefined when provided ethereum provider lacks an ethereum address', () => {
+      const provider = shallowRef(new MockedEthereumProvider());
+
+      const { allowance } = useTokenAllowance(provider, TOKEN, SOURCE_CHAIN);
+
+      expect(allowance.value).toBeUndefined();
+    });
+
+    it('is defined when all conditions are met', async () => {
+      const token = ref(generateToken());
+      Object.defineProperty(tokenService, 'getTokenAllowance', {
+        value: vi.fn().mockResolvedValue(TokenAmount.parse('1', token.value)),
+      });
+      const { allowance } = useTokenAllowance(PROVIDER, token, SOURCE_CHAIN);
+      await flushPromises();
+
+      expect(allowance.value).not.toBeUndefined();
+      expect(allowance.value?.token).toEqual(token.value);
+    });
+  });
+
+  describe('allowanceBelowMax', () => {
+    it('is true when the allowance is below the maximum uint256 value', async () => {
+      const token = ref(generateToken());
+
+      Object.defineProperty(tokenService, 'getTokenAllowance', {
+        value: vi.fn().mockResolvedValue(TokenAmount.parse('1', token.value)),
+      });
+
+      const { allowanceBelowMax } = useTokenAllowance(PROVIDER, token, SOURCE_CHAIN);
+      await flushPromises();
+      expect(allowanceBelowMax.value).toBe(true);
+    });
+
+    it('is false when the allowance is the maximum uint256 value', async () => {
+      const token = ref(generateToken());
+
+      Object.defineProperty(tokenService, 'getTokenAllowance', {
+        value: vi.fn().mockResolvedValue(TokenAmount.parse(UInt256.max().asString, token.value)),
+      });
+
+      const { allowanceBelowMax } = useTokenAllowance(PROVIDER, token, SOURCE_CHAIN);
+      await flushPromises();
+      expect(allowanceBelowMax.value).toBe(false);
+    });
+  });
+});

--- a/frontend/tests/unit/composables/useTransferRequest.spec.ts
+++ b/frontend/tests/unit/composables/useTransferRequest.spec.ts
@@ -48,6 +48,7 @@ describe('useTransferRequest', () => {
         toAddress,
         sourceToken,
         targetToken,
+        approveInfiniteAmount: true,
       });
 
       const sourceTokenAmount = TokenAmount.parse(sourceAmount, sourceToken);
@@ -67,6 +68,7 @@ describe('useTransferRequest', () => {
       expect(transfer.targetAmount).toEqual(targetTokenAmount);
       expect(transfer.targetAccount).toEqual(toAddress);
       expect(transfer.fees).toEqual(feeAmount);
+      expect(transfer.approveInfiniteAmount).toBe(true);
     });
   });
 

--- a/frontend/tests/unit/services/transactions/token.spec.ts
+++ b/frontend/tests/unit/services/transactions/token.spec.ts
@@ -2,6 +2,7 @@ import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
 
 import {
   ensureTokenAllowance,
+  getTokenAllowance,
   getTokenBalance,
   listenOnTokenBalanceChange,
 } from '@/services/transactions/token';
@@ -86,6 +87,27 @@ describe('token', () => {
 
       expect(mockedTokenContract.balanceOf).toHaveBeenCalled();
       expect(result.uint256.asString).toBe('1000');
+    });
+  });
+
+  describe('getTokenAllowance()', () => {
+    it('returns the token allowance for the specified spender and owner', async () => {
+      const token = generateToken();
+      const ownerAddress = getRandomEthereumAddress();
+      const spenderAddress = getRandomEthereumAddress();
+
+      const mockedTokenContract = mockGetContract();
+      mockedTokenContract.allowance = vi.fn().mockReturnValue('99');
+
+      const result = await getTokenAllowance(
+        new MockedEthereumProvider(),
+        token,
+        ownerAddress,
+        spenderAddress,
+      );
+
+      expect(mockedTokenContract.allowance).toHaveBeenCalled();
+      expect(result.uint256.asString).toBe('99');
     });
   });
 

--- a/frontend/tests/unit/types/uint-256.spec.ts
+++ b/frontend/tests/unit/types/uint-256.spec.ts
@@ -36,6 +36,15 @@ describe('UInt256', () => {
     });
   });
 
+  describe('max()', () => {
+    it('correctly returns the maximum UInt256', () => {
+      const max = UInt256.max();
+      expect(max.asString).toBe(
+        '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+      );
+    });
+  });
+
   describe('format()', () => {
     it('converts number to decimals representation bases on decimals', () => {
       const number = new UInt256('123');


### PR DESCRIPTION
closes #1071 

Adds a checkbox below the transfer dialog which allows users to decide to approve an infinite amount of their tokens. Makes the token allowance transaction of future transfers obsolete for them.
I did some refactoring of the css of the app's main div, because we were not using tailwind there.