### PR TITLE
frontend: fix transfer history load failure

### DIFF
--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -8,6 +8,7 @@ interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
 interface ReleaseVariables {
+  SEMANTIC_VERSION: string;
   VERSION: string;
   COMMIT_HASH: string;
   REPOSITORY: string;

--- a/frontend/src/stores/transfer-history/store.ts
+++ b/frontend/src/stores/transfer-history/store.ts
@@ -18,7 +18,7 @@ export function getStoreName(appVersion: string): string {
 }
 
 export const useTransferHistory = defineStore(
-  getStoreName(getAppMajorVersion(APP_RELEASE.VERSION)),
+  getStoreName(getAppMajorVersion(APP_RELEASE.SEMANTIC_VERSION)),
   {
     state: (): TransferHistoryState => ({
       transfers: [],

--- a/frontend/tests/unit/stores/transfer-history/store.spec.ts
+++ b/frontend/tests/unit/stores/transfer-history/store.spec.ts
@@ -38,6 +38,15 @@ describe('configuration store', () => {
     setActivePinia(pinia);
   });
 
+  describe('instance', () => {
+    it('should include semantic version of the app inside its name', () => {
+      const history = useTransferHistory();
+      const semver = process.env.npm_package_version;
+
+      expect(history.$id).toBe(`transferHistory_${semver?.split('.')[0]}`);
+    });
+  });
+
   describe('addTransfer()', () => {
     it('adds new transfer to the beginning of the list', () => {
       const history = useTransferHistory();

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,7 @@ const test_output_directory = path.resolve(test_directory, 'output');
 const config_directory = path.resolve(__dirname, 'config');
 
 // Release Info
+const semanticVersion = process.env.npm_package_version;
 const version = execSync('git describe --tags', { encoding: 'utf-8' }).trim();
 const commitHash = execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
 const REPOSITORY = 'https://github.com/beamer-bridge/beamer';
@@ -51,6 +52,7 @@ export default defineConfig({
   },
   define: {
     APP_RELEASE: {
+      SEMANTIC_VERSION: semanticVersion,
       VERSION: version,
       COMMIT_HASH: commitHash,
       REPOSITORY,


### PR DESCRIPTION
After merging & deploying the commit hash url inside the footer we introduced a bug where the transfer history is reset to an empty array. This fixes it and will bring back the old transfer history for all the users.
However, users that used our app since Feb 14 will not see their new transfers but will see their old transfers that they made before Feb 14