### PR TITLE
beamer: tests: make HTTPProxy more generic

### DIFF
--- a/beamer/tests/agent/test_challenge.py
+++ b/beamer/tests/agent/test_challenge.py
@@ -9,7 +9,6 @@ import beamer.agent.agent
 from beamer.tests.constants import FILL_ID
 from beamer.tests.util import (
     EventCollector,
-    HTTPProxy,
     alloc_accounts,
     alloc_whitelisted_accounts,
     earnings,
@@ -250,16 +249,6 @@ def test_challenge_4(request_manager, fill_manager, token, config):
 def test_challenge_5(request_manager, fill_manager, token, config, honest_claim):
     requester, target = alloc_accounts(2)
     (charlie,) = alloc_whitelisted_accounts(1, {request_manager, fill_manager})
-    proxy_l2b = HTTPProxy(config.rpc_urls["l2b"])
-    proxy_l2b.delay_rpc({"eth_getLogs": 3})
-    proxy_l2b.start()
-
-    l2b_rpc_url = "http://%s:%s" % (
-        proxy_l2b.server_address[0],
-        proxy_l2b.server_address[1],
-    )
-
-    config.rpc_urls["l2b"] = l2b_rpc_url
     config.fill_wait_time = 5
 
     agent = beamer.agent.agent.Agent(config)
@@ -313,7 +302,6 @@ def test_challenge_5(request_manager, fill_manager, token, config, honest_claim)
         assert claim.lastChallenger == to_checksum_address(agent.address)
 
     agent.stop()
-    proxy_l2b.stop()
     agent.wait()
 
 

--- a/beamer/tests/agent/test_read_timeout.py
+++ b/beamer/tests/agent/test_read_timeout.py
@@ -1,0 +1,77 @@
+import functools
+import json
+import time
+
+import brownie
+
+from beamer.agent.agent import Agent
+from beamer.tests.util import HTTPProxy, alloc_accounts, make_request
+
+
+def _get_delay(request_data):
+    params = request_data["params"][0]
+    to_block = int(params["toBlock"], 16)
+    from_block = int(params["fromBlock"], 16)
+    num_blocks = to_block - from_block + 1
+    if num_blocks <= 200:
+        return 0
+    return 5
+
+
+def _post_with_delay(method, delay, handler, url, post_body):
+    request_data = json.loads(post_body)
+    if request_data["method"] == method:
+        if callable(delay):
+            delay = delay(request_data)
+        time.sleep(delay)
+
+    response = handler.forward_request(url, post_body)
+    if response is not None:
+        handler.complete(response)
+
+
+def test_read_timeout(config):
+    brownie.chain.mine(200)
+
+    delay_eth_get_logs = functools.partial(_post_with_delay, "eth_getLogs", _get_delay)
+
+    proxy_l2a = HTTPProxy(config.rpc_urls["l2a"], delay_eth_get_logs)
+    proxy_l2a.start()
+
+    proxy_l2b = HTTPProxy(config.rpc_urls["l2b"], delay_eth_get_logs)
+    proxy_l2b.start()
+
+    config.rpc_urls["l2a"] = proxy_l2a.url()
+    config.rpc_urls["l2b"] = proxy_l2b.url()
+
+    agent = Agent(config)
+    agent.start()
+    time.sleep(60)
+    agent.stop()
+    proxy_l2a.stop()
+    proxy_l2b.stop()
+
+
+# This test delays the processing of eth_sendRawTransaction so that an agent
+# sending a transaction gets a timeout. Previously, that would result in an
+# exception that would propagate upwards within the thread, causing the agent
+# to exit. With a proper fix the agent should catch the exception, continue
+# running and make a clean exit after our call agent.stop().
+def test_read_timeout_send_transaction(request_manager, token, config):
+    delay_period = 6
+    delay_eth_send_raw_tx = functools.partial(
+        _post_with_delay, "eth_sendRawTransaction", delay_period
+    )
+    proxy_l2a = HTTPProxy(config.rpc_urls["l2a"], delay_eth_send_raw_tx)
+    proxy_l2a.start()
+
+    config.rpc_urls["l2a"] = proxy_l2a.url()
+
+    requester, target = alloc_accounts(2)
+    make_request(request_manager, token, requester, target, 1, validity_period=1800)
+
+    agent = Agent(config)
+    agent.start()
+    time.sleep(delay_period)
+    agent.stop()
+    proxy_l2a.stop()

--- a/beamer/tests/agent/test_request.py
+++ b/beamer/tests/agent/test_request.py
@@ -23,62 +23,7 @@ from beamer.agent.typing import (
     TokenAmount,
 )
 from beamer.tests.agent.unit.utils import BLOCK_NUMBER
-from beamer.tests.util import HTTPProxy, Sleeper, Timeout, alloc_accounts, make_request
-
-
-def _get_delay(request_data):
-    params = request_data["params"][0]
-    to_block = int(params["toBlock"], 16)
-    from_block = int(params["fromBlock"], 16)
-    num_blocks = to_block - from_block + 1
-    if num_blocks <= 200:
-        return 0
-    return 5
-
-
-def test_read_timeout(config):
-    brownie.chain.mine(200)
-
-    proxy_l2a = HTTPProxy(config.rpc_urls["l2a"])
-    proxy_l2a.delay_rpc({"eth_getLogs": _get_delay})
-    proxy_l2a.start()
-
-    proxy_l2b = HTTPProxy(config.rpc_urls["l2b"])
-    proxy_l2b.delay_rpc({"eth_getLogs": _get_delay})
-    proxy_l2b.start()
-
-    config.rpc_urls["l2a"] = proxy_l2a.url()
-    config.rpc_urls["l2b"] = proxy_l2b.url()
-
-    agent = Agent(config)
-    agent.start()
-    time.sleep(60)
-    agent.stop()
-    proxy_l2a.stop()
-    proxy_l2b.stop()
-
-
-# This test delays the processing of eth_sendRawTransaction so that an agent
-# sending a transaction gets a timeout. Previously, that would result in an
-# exception that would propagate upwards within the thread, causing the agent
-# to exit. With a proper fix the agent should catch the exception, continue
-# running and make a clean exit after our call agent.stop().
-def test_read_timeout_send_transaction(request_manager, token, config):
-    delay_period = 6
-    proxy_l2a = HTTPProxy(config.rpc_urls["l2a"])
-    proxy_l2a.delay_rpc({"eth_sendRawTransaction": delay_period})
-    proxy_l2a.start()
-
-    config.rpc_urls["l2a"] = proxy_l2a.url()
-
-    requester, target = alloc_accounts(2)
-    make_request(request_manager, token, requester, target, 1, validity_period=1800)
-
-    agent = Agent(config)
-    agent.start()
-    time.sleep(delay_period)
-    agent.stop()
-    proxy_l2a.stop()
+from beamer.tests.util import Sleeper, Timeout, alloc_accounts, make_request
 
 
 def test_challenge_own_claim(config, request_manager, token, direction):

--- a/beamer/tests/util.py
+++ b/beamer/tests/util.py
@@ -1,5 +1,4 @@
 import contextlib
-import json
 import threading
 import time
 from http import HTTPStatus
@@ -65,28 +64,17 @@ class _HTTPRequestHandler(BaseHTTPRequestHandler):
         content_len = int(self.headers.get("Content-Length"))
         post_body = self.rfile.read(content_len)
         url = self.server.target_address
+        self.server.do_post(self, url, post_body)
 
-        rate_limiter = self.server.rate_limiter
-        if callable(rate_limiter) and rate_limiter(url, post_body):
-            self.send_response_only(HTTPStatus.TOO_MANY_REQUESTS)
-            self.end_headers()
-            return
-
+    def forward_request(self, url, post_body):
         try:
-            response = requests.post(url, data=post_body)
+            return requests.post(url, data=post_body)
         except requests.exceptions.ConnectionError:
             self.send_response_only(HTTPStatus.SERVICE_UNAVAILABLE)
             self.end_headers()
-            return
+        return None
 
-        data = json.loads(post_body)
-        method = data["method"]
-        delay = self.server.call_delays.get(method)
-        if delay is not None:
-            if callable(delay):
-                delay = delay(data)
-            time.sleep(delay)
-
+    def complete(self, response):
         try:
             self.send_response(response.status_code)
             self.end_headers()
@@ -97,11 +85,11 @@ class _HTTPRequestHandler(BaseHTTPRequestHandler):
 
 
 class HTTPProxy(HTTPServer):
-    def __init__(self, target_address):
+    def __init__(self, target_address, do_post):
         super().__init__(("", 0), _HTTPRequestHandler)
         self.target_address = target_address
-        self.call_delays = {}
-        self.rate_limiter = None
+        assert callable(do_post)
+        self.do_post = do_post
 
     def start(self) -> None:
         self._thread = threading.Thread(target=self.serve_forever)
@@ -110,12 +98,6 @@ class HTTPProxy(HTTPServer):
     def stop(self) -> None:
         self.shutdown()
         self._thread.join()
-
-    def delay_rpc(self, call_delays):
-        self.call_delays = call_delays
-
-    def set_rate_limiter(self, rate_limiter):
-        self.rate_limiter = rate_limiter
 
     def url(self):
         return "http://%s:%s" % self.server_address


### PR DESCRIPTION
This is to allow arbitrary behaviour when making POST requests.