### PR TITLE
Frontend: fix bugs in Bitkeep mobile wallet

### DIFF
--- a/frontend/src/components/RequestDialog.vue
+++ b/frontend/src/components/RequestDialog.vue
@@ -97,7 +97,7 @@ const EMPTY_TARGET_DATA: RequestTarget = {
 };
 
 const ethereumProvider = useEthereumProvider();
-const { signer, signerAddress, chainId, provider } = storeToRefs(ethereumProvider);
+const { signer, signerAddress, provider } = storeToRefs(ethereumProvider);
 const transferHistory = useTransferHistory();
 const { activated: transferFundsButtonVisible } = useToggleOnActivation();
 const {
@@ -192,12 +192,6 @@ function resetFormValidation() {
     requestTargetInputsRef.value.v$.$reset();
   }
 }
-
-watch(chainId, (_, oldChainId) => {
-  if (oldChainId !== -1) {
-    location.reload();
-  }
-});
 
 watch(signerAddress, (currSignerAddress, prevSignerAddress) => {
   const toAddress = requestTarget.value.toAddress;

--- a/frontend/src/services/web3-provider/metamask-provider.ts
+++ b/frontend/src/services/web3-provider/metamask-provider.ts
@@ -15,6 +15,17 @@ export async function createMetaMaskProvider(): Promise<MetaMaskProvider | undef
   let injectedMetamaskProvider;
 
   if (detectedProvider) {
+    // Monkey patch for the BitKeep wallet which uses a buggy window.ethereum API
+    // See this for more info: https://github.com/beamer-bridge/beamer/issues/1513
+    // May be removed if BitKeep fixes it on their side.
+    if (detectedProvider.request) {
+      const request = detectedProvider.request;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (detectedProvider.request as (request: any) => Promise<any>) = async (args) => {
+        return await request({ ...args, jsonrpc: '2.0' });
+      };
+    }
+
     if (detectedProvider.providers) {
       injectedMetamaskProvider = detectedProvider.providers.find(
         (provider) => provider.isMetaMask,

--- a/frontend/tests/unit/services/web3-provider/metamask-provider.spec.ts
+++ b/frontend/tests/unit/services/web3-provider/metamask-provider.spec.ts
@@ -168,7 +168,10 @@ describe('metamask-provider', () => {
         metamaskProvider.listenToEvents();
 
         expect(eipProvider.on).toHaveBeenCalledWith('accountsChanged', expect.anything());
-        expect(eipProvider.on).toHaveBeenCalledWith('chainChanged', expect.anything());
+        expect(metamaskProvider['web3Provider'].on).toHaveBeenCalledWith(
+          'network',
+          expect.anything(),
+        );
         // There is a bug with the disconnect event in MetaMask
         // See https://github.com/MetaMask/metamask-extension/issues/13375
         expect(eipProvider.on).not.toHaveBeenCalledWith('disconnect', expect.anything());

--- a/frontend/tests/utils/mocks/ethereum-provider.ts
+++ b/frontend/tests/utils/mocks/ethereum-provider.ts
@@ -15,6 +15,7 @@ export class MockedWeb3Provider {
   getNetwork = vi.fn();
   listAccounts = vi.fn();
   getSigner = vi.fn();
+  on = vi.fn();
 }
 export class MockedEip1193Provider implements Eip1193Provider {
   isMetaMask: boolean;


### PR DESCRIPTION
Closes #1513 

Ensures that no transfers are shown mistakenly as failing with Bitkeep. During testing I also found that the chain switching does not work properly with Bitkeep. This is also fixed. See commit messages for details.