### PR TITLE
agent: health: fix wrong example config

### DIFF
--- a/beamer/health/health-check-mainnet.conf
+++ b/beamer/health/health-check-mainnet.conf
@@ -1,5 +1,4 @@
-[default]
-agent-address=
+agent-address=""
 deployment-dir="../deployments/mainnet"
 cache-file-path="./"
 notification-system="telegram"
@@ -15,13 +14,13 @@ chat-id=""
 request-throttling-in-sec=0
 
 [chains.arbitrum]
-rpc-url=
-explorer=https://arbiscan.io/tx/
+rpc-url=""
+explorer="https://arbiscan.io/tx/"
 chain-id=42161
 
 [chains.optimism]
-rpc-url=
-explorer=https://optimistic.etherscan.io/tx/
+rpc-url=""
+explorer="https://optimistic.etherscan.io/tx/"
 chain-id=10
 
 [tokens]


### PR DESCRIPTION
In the process of reviewing: https://github.com/beamer-bridge/run-your-own-agent/pull/17 we found out that we had the wrong example config structure. This PR fixes it.