### PR TITLE
Frontend: Add Ethereum config files

### DIFF
--- a/frontend/config/chains/1.json
+++ b/frontend/config/chains/1.json
@@ -1,0 +1,14 @@
+{
+  "identifier": 1,
+  "explorerUrl": "https://etherscan.io/",
+  "rpcUrl": "https://eth.llamarpc.com",
+  "name": "Ethereum Mainnet",
+  "imageUrl": "/images/ethereum.svg",
+  "tokenSymbols": ["USDC", "DAI"],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "internalRpcUrl": "https://eth-mainnet.g.alchemy.com/v2/D8tfo1OggmNMe2Ck_AAuwaR6MQSNnXvw"
+}

--- a/frontend/config/chains/5.json
+++ b/frontend/config/chains/5.json
@@ -1,0 +1,14 @@
+{
+  "identifier": 5,
+  "explorerUrl": "https://goerli.etherscan.io",
+  "rpcUrl": "https://rpc.ankr.com/eth_goerli",
+  "name": "Ethereum Testnet Goerli",
+  "imageUrl": "/images/ethereum.svg",
+  "tokenSymbols": ["USDC", "DAI"],
+  "nativeCurrency": {
+    "name": "Goerli Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "internalRpcUrl": "https://eth-goerli.g.alchemy.com/v2/KJo1cVLxWEivInhB8FlVLf7XyI2orRSM"
+}

--- a/frontend/config/tokens/DAI.json
+++ b/frontend/config/tokens/DAI.json
@@ -3,6 +3,7 @@
   "decimals": 18,
   "imageUrl": "/images/tokens/dai.svg",
   "addresses": {
+    "1": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
     "10": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
     "288": "0xf74195Bb8a5cf652411867c5C2C5b8C2a402be35",
     "42161": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"

--- a/frontend/config/tokens/DAI.json
+++ b/frontend/config/tokens/DAI.json
@@ -4,6 +4,7 @@
   "imageUrl": "/images/tokens/dai.svg",
   "addresses": {
     "1": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+    "5": "0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844",
     "10": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
     "288": "0xf74195Bb8a5cf652411867c5C2C5b8C2a402be35",
     "42161": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"

--- a/frontend/config/tokens/USDC.json
+++ b/frontend/config/tokens/USDC.json
@@ -3,6 +3,7 @@
   "decimals": 6,
   "imageUrl": "/images/tokens/usdc.svg",
   "addresses": {
+    "1": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     "10": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
     "288": "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
     "42161": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8"

--- a/frontend/config/tokens/USDC.json
+++ b/frontend/config/tokens/USDC.json
@@ -4,6 +4,7 @@
   "imageUrl": "/images/tokens/usdc.svg",
   "addresses": {
     "1": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    "5": "0x07865c6E87B9F70255377e024ace6630C1Eaa37F",
     "10": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
     "288": "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
     "42161": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8"

--- a/frontend/public/images/ethereum.svg
+++ b/frontend/public/images/ethereum.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 26 26">
+    <g fill="none">
+        <path fill="#343434" d="M7.978 0L7.804 0.592 7.804 17.78 7.978 17.954 15.957 13.238z" transform="translate(4.875)"/>
+        <path fill="#8C8C8C" d="M7.978 0L0 13.238 7.978 17.954 7.978 9.612z" transform="translate(4.875)"/>
+        <path fill="#3C3C3B" d="M7.978 19.465L7.88 19.585 7.88 25.707 7.978 25.994 15.962 14.751z" transform="translate(4.875)"/>
+        <path fill="#8C8C8C" d="M7.978 25.994L7.978 19.465 0 14.751z" transform="translate(4.875)"/>
+        <path fill="#141414" d="M7.978 17.954L15.957 13.238 7.978 9.612z" transform="translate(4.875)"/>
+        <path fill="#393939" d="M0 13.238L7.978 17.954 7.978 9.612z" transform="translate(4.875)"/>
+    </g>
+</svg>


### PR DESCRIPTION
closes #1396 

Note: Ethereum will not be included as an option on the frontend until we deploy the contracts and update the files inside `deployments/mainnet` & `deployments/testnet` on main branch with that latest deployment. The frontend automated config script works in a way that it doesn't configure/display chains that cannot be found in those `deployment.json` files.

So, after merging this and until the moment we deploy and merge the deployment artifacts to main branch we are safe to re-deploy the frontend.