### PR TITLE
Update to python 3.10.10

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -93,6 +93,12 @@ jobs:
       - restore-python
       - restore-python-packages
 
+      # make sure pyenv is up to date and able to install our Python version
+      - run: |
+          cd $PYENV_ROOT
+          git fetch --tags
+          git checkout $(git tag --sort=-committerdate |head -n1)
+
       - run: pyenv install --skip-existing 3.10.10
       - run: pyenv global 3.10.10
       - run: pip install -U pip

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -103,8 +103,8 @@ jobs:
       - run: pyenv global 3.10.10
       - run: pip install -U pip
       - run: pip install poetry==1.4.1
-      - run: poetry install -vvv
-      - run: grep -q /home/circleci/.+/bin/activate ~/.bashrc || echo "source $(poetry env info -p)/bin/activate" >> ~/.bashrc
+      - run: poetry --no-ansi install -vvv
+      - run: grep -q /home/circleci/.+/bin/activate ~/.bashrc || echo "source $(poetry --no-ansi env info -p)/bin/activate" >> ~/.bashrc
 
       - save_cache:
           key: beamer-dependencies-{{ checksum "poetry.lock" }}-{{ .Environment.CACHE_VERSION }}
@@ -162,7 +162,7 @@ jobs:
     executor: vm
     steps:
       - initialize-environment
-      - run: poetry run ape test -s --gas beamer/tests/contracts
+      - run: poetry --no-ansi run ape test -s --gas beamer/tests/contracts
 
   compile-contracts:
     executor: vm
@@ -183,7 +183,7 @@ jobs:
     executor: vm
     steps:
       - initialize-environment
-      - run: poetry run ape test beamer/tests/{agent,health} -s --gas --cov beamer --cov-report=term
+      - run: poetry --no-ansi run ape test beamer/tests/{agent,health} -s --gas --cov beamer --cov-report=term
 
   e2e-test-ethereum:
     executor: vm

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -69,7 +69,7 @@ parameters:
 executors:
   vm:
     machine:
-      image: ubuntu-2204:2022.10.2
+      image: ubuntu-2204:2023.02.1
       docker_layer_caching: true
     working_directory: ~/beamer
 

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -96,7 +96,7 @@ jobs:
       - run: pyenv install --skip-existing 3.10.10
       - run: pyenv global 3.10.10
       - run: pip install -U pip
-      - run: pip install poetry==1.2.2
+      - run: pip install poetry==1.4.1
       - run: poetry install -vvv
       - run: grep -q /home/circleci/.+/bin/activate ~/.bashrc || echo "source $(poetry env info -p)/bin/activate" >> ~/.bashrc
 

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -9,7 +9,7 @@ commands:
       # Restore cached Python installation at /opt/circleci/.pyenv
       - restore_cache:
           name: Restore cached Python installation
-          key: python-3.10.6-{{ .Environment.CACHE_VERSION }}
+          key: python-3.10.10-{{ .Environment.CACHE_VERSION }}
 
   restore-python-packages:
     steps:
@@ -93,8 +93,8 @@ jobs:
       - restore-python
       - restore-python-packages
 
-      - run: pyenv install --skip-existing 3.10.6
-      - run: pyenv global 3.10.6
+      - run: pyenv install --skip-existing 3.10.10
+      - run: pyenv global 3.10.10
       - run: pip install -U pip
       - run: pip install poetry==1.2.2
       - run: poetry install -vvv
@@ -107,7 +107,7 @@ jobs:
             - ~/.bashrc
 
       - save_cache:
-          key: python-3.10.6-{{ .Environment.CACHE_VERSION }}
+          key: python-3.10.10-{{ .Environment.CACHE_VERSION }}
           paths:
             - /opt/circleci/.pyenv
 


### PR DESCRIPTION
This PR updates Python to 3.10.10, latest in the 3.10.x series as of now. Also poetry is updated to the latest version, 1.4.1.
(We have to use the `--no-ansi` option to actually make it work under CircleCI, see commit message for more details.)
Finally, we also update the VM image we are using so we get the newer versions of Docker, npm etc.