### PR TITLE
frontend: Use location.replace for reload after chain switch

### DIFF
--- a/frontend/src/services/web3-provider/ethereum-provider.ts
+++ b/frontend/src/services/web3-provider/ethereum-provider.ts
@@ -146,11 +146,9 @@ export abstract class EthereumProvider extends EventEmitter implements IEthereum
   protected listenToChangeEvents(): void {
     this.externalProvider.on('accountsChanged', () => this.tryAccessingDefaultSigner());
     this.web3Provider.on('network', (newNetwork: Network, oldNetwork: Network) => {
-      // Bitkeep wallet does not allow to reload the page by calling location.reload
-      // This ensures at least basic functionality after a chain switch
       this.chainId.value = newNetwork.chainId;
       if (oldNetwork) {
-        window.location.reload();
+        window.location.replace(window.location.pathname);
       }
     });
   }

--- a/frontend/tests/unit/services/web3-provider/ethereum-provider.spec.ts
+++ b/frontend/tests/unit/services/web3-provider/ethereum-provider.spec.ts
@@ -295,12 +295,12 @@ describe('EthereumProvider', () => {
       expect(eipProvider.on).toHaveBeenCalledWith('disconnect', expect.anything());
     });
 
-    it('attaches an event listener which triggers a location.reload on network change', () => {
-      const originalReload = window.location;
-      const mockReload = vi.fn();
+    it('attaches an event listener which triggers a location.replace on network change', () => {
+      const originalReplace = window.location.replace;
+      const mockReplace = vi.fn();
       Object.defineProperty(window, 'location', {
         configurable: true,
-        value: { reload: mockReload },
+        value: { replace: mockReplace },
       });
       const eipProvider = new MockedEip1193Provider();
       const ethereumProvider = new TestEthereumProvider(eipProvider);
@@ -317,11 +317,11 @@ describe('EthereumProvider', () => {
 
       networkEventCallback({ chainId: 5 }, { chainId: 10 });
 
-      expect(mockReload).toHaveBeenCalledWith();
+      expect(mockReplace).toHaveBeenCalledWith(window.location.pathname);
 
       Object.defineProperty(window, 'location', {
         configurable: true,
-        value: { reload: originalReload },
+        value: { reload: originalReplace },
       });
     });
   });


### PR DESCRIPTION
Closes #1575 

The location.reload function does not work in some Android webviews. I don't know the reason for that, but I could verify that the replace function works. This ensures our ethereum provider works properly after switching the chain.

We still have the issue that MetaMask mobile is not switching the chain after a user selects a different one in our UI. I will create a separate issue. It's hard to debug because they want devs to build there app themselves, otherwise the debugging mode for the dev console is not available.