### PR TITLE
frontend: Handle MetaMask Mobile error in switchChain of MetaMaskProvider

### DIFF
--- a/frontend/src/services/web3-provider/metamask-provider.ts
+++ b/frontend/src/services/web3-provider/metamask-provider.ts
@@ -67,7 +67,7 @@ export class MetaMaskProvider extends InjectedProvider implements ISigner {
       await this.web3Provider.send('wallet_switchEthereumChain', [{ chainId: newChainIdHex }]);
       return true;
     } catch (error) {
-      if ((error as { code: number })?.code === unrecognizedChainErrorCode) {
+      if (hasErrorCode(error as MetaMaskError, unrecognizedChainErrorCode)) {
         return false;
       }
       throw error;
@@ -77,4 +77,10 @@ export class MetaMaskProvider extends InjectedProvider implements ISigner {
   listenToEvents(): void {
     this.listenToChangeEvents();
   }
+}
+
+type MetaMaskError = { code?: number; data?: { originalError?: { code: number } } };
+
+function hasErrorCode(error: MetaMaskError, code: number) {
+  return error.code === code || error.data?.originalError?.code === code;
 }

--- a/frontend/tests/unit/actions/steps/multi-step-action.spec.ts
+++ b/frontend/tests/unit/actions/steps/multi-step-action.spec.ts
@@ -121,7 +121,7 @@ describe('MultiStepAction', () => {
   });
 
   describe('executeSteps()', () => {
-    it('fails if action has already failed', () => {
+    it('fails if action has already failed', async () => {
       const action = new TestMultiStepAction([
         new Step(generateStepData({ identifier: 'one' })),
         new Step(generateStepData({ identifier: 'two', errorMessage: 'error' })),
@@ -129,12 +129,12 @@ describe('MultiStepAction', () => {
       const methods = { one: vi.fn(), two: vi.fn() };
       expect(action.failed).toBeTruthy();
 
-      return expect(action.executeSteps(methods)).rejects.toThrow(
+      await expect(action.executeSteps(methods)).rejects.toThrow(
         'Attempt to run already failed action!',
       );
     });
 
-    it('fails if action is already active', () => {
+    it('fails if action is already active', async () => {
       const action = new TestMultiStepAction([
         new Step(generateStepData({ identifier: 'one' })),
         new Step(generateStepData({ identifier: 'two', active: true })),
@@ -142,12 +142,12 @@ describe('MultiStepAction', () => {
       const methods = { one: vi.fn(), two: vi.fn() };
       expect(action.active).toBeTruthy();
 
-      return expect(action.executeSteps(methods)).rejects.toThrow(
+      await expect(action.executeSteps(methods)).rejects.toThrow(
         'Attempt to run already in progress action!',
       );
     });
 
-    it('fails if any step has no method defined', () => {
+    it('fails if any step has no method defined', async () => {
       const action = new TestMultiStepAction([
         new Step(generateStepData({ identifier: 'one' })),
         new Step(generateStepData({ identifier: 'two' })),
@@ -155,12 +155,12 @@ describe('MultiStepAction', () => {
       ]);
       const methods = { one: vi.fn() };
 
-      return expect(action.executeSteps(methods)).rejects.toThrow(
+      await expect(action.executeSteps(methods)).rejects.toThrow(
         'Can not (continue) execution of action. Missing methods for steps: two,three',
       );
     });
 
-    it('ignores missing methods for already completed steps', () => {
+    it('ignores missing methods for already completed steps', async () => {
       const action = new TestMultiStepAction([
         new Step(generateStepData({ identifier: 'one', completed: true })),
         new Step(generateStepData({ identifier: 'two' })),
@@ -168,7 +168,7 @@ describe('MultiStepAction', () => {
       ]);
       const methods = { two: vi.fn() };
 
-      return expect(action.executeSteps(methods)).rejects.toThrow(
+      await expect(action.executeSteps(methods)).rejects.toThrow(
         'Can not (continue) execution of action. Missing methods for steps: three',
       );
     });

--- a/frontend/tests/unit/actions/transfers/transfer.spec.ts
+++ b/frontend/tests/unit/actions/transfers/transfer.spec.ts
@@ -146,12 +146,12 @@ describe('transfer', () => {
     });
   });
 
-  describe('ensureTokenAllowance()', () => {
+  describe('ensureTokenAllowance()', async () => {
     it('fails if given signer is undefined', async () => {
       const data = generateTransferData();
       const transfer = new TestTransfer(data);
 
-      return expect(transfer.ensureTokenAllowance()).rejects.toThrow('Missing wallet connection!');
+      await expect(transfer.ensureTokenAllowance()).rejects.toThrow('Missing wallet connection!');
     });
 
     it('makes a call to set the allowance for the source token with minimum value of source amount plus fees ', async () => {
@@ -203,20 +203,20 @@ describe('transfer', () => {
   });
 
   describe('sendRequestTransaction()', () => {
-    it('fails if given signer is undefined', () => {
+    it('fails if given signer is undefined', async () => {
       const data = generateTransferData();
       const transfer = new TestTransfer(data);
 
-      return expect(transfer.sendRequestTransaction(undefined, SIGNER_ADDRESS)).rejects.toThrow(
+      await expect(transfer.sendRequestTransaction(undefined, SIGNER_ADDRESS)).rejects.toThrow(
         'Missing wallet connection!',
       );
     });
 
-    it('fails if given signer address is undefined', () => {
+    it('fails if given signer address is undefined', async () => {
       const data = generateTransferData();
       const transfer = new TestTransfer(data);
 
-      return expect(transfer.sendRequestTransaction(SIGNER, undefined)).rejects.toThrow(
+      await expect(transfer.sendRequestTransaction(SIGNER, undefined)).rejects.toThrow(
         'Missing wallet connection!',
       );
     });
@@ -278,7 +278,7 @@ describe('transfer', () => {
       });
       const transfer = new TestTransfer(data);
 
-      return expect(transfer.waitForRequestEvent()).rejects.toThrow(
+      await expect(transfer.waitForRequestEvent()).rejects.toThrow(
         'Attempt to get request event before sending transaction!',
       );
     });
@@ -321,7 +321,7 @@ describe('transfer', () => {
         }),
       });
 
-      return expect(transfer.waitForFulfillment()).rejects.toThrow(
+      await expect(transfer.waitForFulfillment()).rejects.toThrow(
         'Attempting to wait for fulfillment without request identifier!',
       );
     });
@@ -427,21 +427,21 @@ describe('transfer', () => {
       }),
     });
 
-    it('fails if the transfer is not expired', () => {
+    it('fails if the transfer is not expired', async () => {
       const transfer = new TestTransfer({ ...TRANSFER_DATA, expired: false });
 
-      return expect(transfer.withdraw(PROVIDER)).rejects.toThrow(
+      await expect(transfer.withdraw(PROVIDER)).rejects.toThrow(
         'Can only withdraw transfer funds after request expired!',
       );
     });
 
-    it('fails when request identifier has not been set', () => {
+    it('fails when request identifier has not been set', async () => {
       const transfer = new TestTransfer({
         ...TRANSFER_DATA,
         requestInformation: generateRequestInformationData({ identifier: undefined }),
       });
 
-      return expect(transfer.withdraw(PROVIDER)).rejects.toThrow(
+      await expect(transfer.withdraw(PROVIDER)).rejects.toThrow(
         'Attempting to withdraw without request identifier!',
       );
     });
@@ -459,28 +459,28 @@ describe('transfer', () => {
       expect(transfer.checkAndUpdateState).toHaveBeenCalledOnce();
     });
 
-    it('fails when funds are already withdrawn', () => {
+    it('fails when funds are already withdrawn', async () => {
       const transfer = new TestTransfer({ ...TRANSFER_DATA, withdrawn: true });
 
-      return expect(transfer.withdraw(PROVIDER)).rejects.toThrow(
+      await expect(transfer.withdraw(PROVIDER)).rejects.toThrow(
         'Funds have been already withdrawn!',
       );
     });
 
-    it('fails when there are active claims', () => {
+    it('fails when there are active claims', async () => {
       const transfer = new TestTransfer({ ...TRANSFER_DATA, claimCount: 2 });
       transfer.checkAndUpdateState = vi.fn().mockReturnValue({ claimCount: 2 });
 
-      return expect(transfer.withdraw(PROVIDER)).rejects.toThrow(
+      await expect(transfer.withdraw(PROVIDER)).rejects.toThrow(
         'Cannot withdraw when there are active claims!',
       );
     });
 
-    it('fails when no signer is available', () => {
+    it('fails when no signer is available', async () => {
       const transfer = new TestTransfer(TRANSFER_DATA);
       const provider = new MockedEthereumProvider({ signer: undefined });
 
-      return expect(transfer.withdraw(provider)).rejects.toThrow(
+      await expect(transfer.withdraw(provider)).rejects.toThrow(
         'Cannot withdraw without connected wallet!',
       );
     });
@@ -498,7 +498,7 @@ describe('transfer', () => {
       expect(provider.switchChainSafely).toHaveBeenCalledOnce();
     });
 
-    it('fails when the chain switch was not successful', () => {
+    it('fails when the chain switch was not successful', async () => {
       const transfer = new TestTransfer({
         ...TRANSFER_DATA,
         sourceChain: generateChain({ identifier: 1 }),
@@ -506,7 +506,7 @@ describe('transfer', () => {
       const provider = new MockedEthereumProvider({ chainId: 2, signer: SIGNER });
       provider.switchChainSafely = vi.fn().mockResolvedValue(false);
 
-      return expect(transfer.withdraw(provider)).rejects.toThrow(
+      await expect(transfer.withdraw(provider)).rejects.toThrow(
         'Cannot withdraw without switching to the chain where the tokens are!',
       );
     });
@@ -553,7 +553,7 @@ describe('transfer', () => {
         }),
       });
 
-      return expect(transfer.checkAndUpdateState()).rejects.toThrow(
+      await expect(transfer.checkAndUpdateState()).rejects.toThrow(
         'Can not check state without request identfier!',
       );
     });

--- a/frontend/tests/unit/services/transactions/request-manager.spec.ts
+++ b/frontend/tests/unit/services/transactions/request-manager.spec.ts
@@ -176,7 +176,7 @@ describe('request-manager', () => {
           }),
         );
 
-        expect(
+        await expect(
           getAmountBeforeFees(totalAmountWei, RPC_URL, REQUEST_MANAGER_ADDRESS),
         ).rejects.toThrow('Total amount is not high enough to cover the fees.');
       });
@@ -278,7 +278,7 @@ describe('request-manager', () => {
         throw new Error('transaction failed');
       });
 
-      expect(
+      await expect(
         sendRequestTransaction(
           SIGNER,
           amount,
@@ -323,7 +323,7 @@ describe('request-manager', () => {
         .fn()
         .mockReturnValue(new MockedTransactionReceipt({ status: 0 }));
 
-      expect(
+      await expect(
         getRequestIdentifier(RPC_URL, REQUEST_MANAGER_ADDRESS, transactionHash),
       ).rejects.toThrow('Transaction reverted on chain.');
     });
@@ -336,7 +336,7 @@ describe('request-manager', () => {
       const provider = mockGetProvider();
       provider.waitForTransaction = vi.fn().mockReturnValue(undefined);
 
-      expect(
+      await expect(
         getRequestIdentifier(RPC_URL, REQUEST_MANAGER_ADDRESS, transactionHash),
       ).rejects.toThrow('Transaction not found.');
     });
@@ -354,7 +354,7 @@ describe('request-manager', () => {
         .fn()
         .mockReturnValue(new MockedTransactionReceipt({ status: 1, logs: undefined }));
 
-      expect(
+      await expect(
         getRequestIdentifier(RPC_URL, REQUEST_MANAGER_ADDRESS, transactionHash),
       ).rejects.toThrow("Request Failed. Couldn't retrieve Request ID.");
     });
@@ -365,7 +365,7 @@ describe('request-manager', () => {
       const provider = mockGetProvider();
       provider.waitForTransaction = vi.fn().mockReturnValue(null);
 
-      expect(
+      await expect(
         getRequestIdentifier(RPC_URL, REQUEST_MANAGER_ADDRESS, transactionHash),
       ).rejects.toThrow('Transaction not found.');
     });


### PR DESCRIPTION
Closes #1617 

MetaMask Mobile wraps the error code differently. Actually it is a bug: https://github.com/MetaMask/metamask-mobile/issues/3312 . We can still handle the code because it is also wrapped inside the error object. This is necessary because without it, the `wallet_addEthereumChain` rpc was not triggered in case the wallet does not know the chain yet.

Additionally, I fixed some of our tests which didn't await .rejects assertions.