### PR TITLE
ci: e2e optimism requires create-relayers job

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -369,6 +369,7 @@ workflows:
       - e2e-test-optimism:
           requires:
             - compile-contracts
+            - create-relayers
       - e2e-test-arbitrum:
           requires:
             - compile-contracts


### PR DESCRIPTION
Is there a reason why this was missing?