### PR TITLE
Rename chain_id to event_chain_id

### DIFF
--- a/beamer/agent/events.py
+++ b/beamer/agent/events.py
@@ -26,7 +26,7 @@ from beamer.agent.typing import (
 
 @dataclass(frozen=True)
 class Event:
-    chain_id: ChainId
+    event_chain_id: ChainId
 
 
 @dataclass(frozen=True)
@@ -44,10 +44,11 @@ class LatestBlockUpdatedEvent(Event):
     block_data: BlockData
 
     def __repr__(self) -> str:
-        chain_id = self.chain_id
+        chain_id = self.event_chain_id
         number = self.block_data["number"]
         hash_ = self.block_data["hash"].hex()
-        return f"<LatestBlockUpdatedEvent chain_id={chain_id} block_number={number} hash={hash_}>"
+        return f"""<LatestBlockUpdatedEvent event_chain_id={chain_id} block_number={number}
+            hash={hash_}>"""
 
 
 @dataclass(frozen=True)
@@ -206,7 +207,7 @@ def _decode_event(
     data = get_event_data(abi_codec=codec, event_abi=event_abi, log_entry=log_entry)
     if data.event in _EVENT_TYPES:
         kwargs = {_camel_to_snake(name): value for name, value in data.args.items()}
-        kwargs["chain_id"] = chain_id
+        kwargs["event_chain_id"] = chain_id
         kwargs["block_number"] = log_entry["blockNumber"]
         kwargs["tx_hash"] = log_entry["transactionHash"]
         _convert_bytes(kwargs)
@@ -346,7 +347,7 @@ class EventFetcher:
         else:
             result.append(
                 LatestBlockUpdatedEvent(
-                    chain_id=self._chain_id,
+                    event_chain_id=self._chain_id,
                     block_data=block_data,
                 )
             )

--- a/beamer/agent/state_machine.py
+++ b/beamer/agent/state_machine.py
@@ -81,9 +81,9 @@ HandlerResult = tuple[bool, Optional[list[Event]]]
 
 
 def process_event(event: Event, context: Context) -> HandlerResult:
-    if isinstance(event, SourceChainEvent) and event.chain_id != context.source_chain_id:
+    if isinstance(event, SourceChainEvent) and event.event_chain_id != context.source_chain_id:
         return True, None
-    if isinstance(event, TargetChainEvent) and event.chain_id != context.target_chain_id:
+    if isinstance(event, TargetChainEvent) and event.event_chain_id != context.target_chain_id:
         return True, None
 
     if isinstance(event, LatestBlockUpdatedEvent):
@@ -166,7 +166,7 @@ def _timestamp_is_l1_finalized(
 def _handle_latest_block_updated(
     event: LatestBlockUpdatedEvent, context: Context
 ) -> HandlerResult:
-    context.latest_blocks[event.chain_id] = event.block_data
+    context.latest_blocks[event.event_chain_id] = event.block_data
     return True, None
 
 
@@ -187,7 +187,7 @@ def _handle_request_created(event: RequestCreated, context: Context) -> HandlerR
             return True, None
     else:
         is_valid_request = context.token_checker.is_valid_pair(
-            event.chain_id,
+            event.event_chain_id,
             event.source_token_address,
             event.target_chain_id,
             event.target_token_address,
@@ -199,7 +199,7 @@ def _handle_request_created(event: RequestCreated, context: Context) -> HandlerR
 
     request = Request(
         request_id=event.request_id,
-        source_chain_id=event.chain_id,
+        source_chain_id=event.event_chain_id,
         target_chain_id=event.target_chain_id,
         source_token_address=event.source_token_address,
         target_token_address=event.target_token_address,
@@ -319,7 +319,7 @@ def _handle_claim_made(event: ClaimMade, context: Context) -> HandlerResult:
     if _invalidation_ready_for_l1_relay(claim):
         events.append(
             InitiateL1InvalidationEvent(
-                chain_id=request.target_chain_id,  # Resolution happens on the target chain
+                event_chain_id=request.target_chain_id,  # Resolution happens on the target chain
                 claim_id=claim.id,
             )
         )
@@ -337,7 +337,7 @@ def _handle_claim_made(event: ClaimMade, context: Context) -> HandlerResult:
     if _proof_ready_for_l1_relay(request):
         events.append(
             InitiateL1ResolutionEvent(
-                chain_id=request.target_chain_id,  # Resolution happens on the target chain
+                event_chain_id=request.target_chain_id,  # Resolution happens on the target chain
                 request_id=request.id,
                 claim_id=claim.id,
             )

--- a/beamer/health/check.py
+++ b/beamer/health/check.py
@@ -219,7 +219,7 @@ def fetch_events() -> ChainEventMap:
 def get_transfer_token_symbol(transfer: Transfer, token_deployments: TokenMap) -> str | None:
     for token_symbol, deployments in token_deployments.items():
         source_token_address = transfer["created"].source_token_address.lower()
-        source_chain_id = transfer["created"].chain_id
+        source_chain_id = transfer["created"].event_chain_id
         if any(
             source_token_address == address.lower() and source_chain_id == int(chain_id)
             for chain_id, address in deployments
@@ -232,7 +232,7 @@ def get_transfer_token_symbol(transfer: Transfer, token_deployments: TokenMap) -
 def get_transfer_value_formatted(
     request: RequestCreated, token_deployments: TokenMap, token_details: TokenDetailsMap
 ) -> str:
-    token_source_chain = request.chain_id
+    token_source_chain = request.event_chain_id
     token_source_address = request.source_token_address
     request_token = [str(token_source_chain), token_source_address]
     token = None
@@ -506,7 +506,7 @@ def create_unclaimed_fill_notification(
         "meta": {
             "request_id": request.request_id.hex(),
             "message_type": NotificationTypes.UNCLAIMED_FILL,
-            "message_link": link_to_explorer(request.chain_id, request.tx_hash.hex()),
+            "message_link": link_to_explorer(request.event_chain_id, request.tx_hash.hex()),
         },
         "body": f"""
 v1: Unclaimed fill!
@@ -528,7 +528,7 @@ def create_expired_request_notification(request: RequestCreated, ctx: Context) -
         "meta": {
             "request_id": request.request_id.hex(),
             "message_type": NotificationTypes.REQUEST_EXPIRED,
-            "message_link": link_to_explorer(request.chain_id, request.tx_hash.hex()),
+            "message_link": link_to_explorer(request.event_chain_id, request.tx_hash.hex()),
         },
         "body": f"""
 Request expired with no fill {request.request_id.hex()}
@@ -553,7 +553,7 @@ def create_challenge_game_notification(
         "meta": {
             "request_id": request.request_id.hex(),
             "message_type": message_type,
-            "message_link": link_to_explorer(request.chain_id, last_claim.tx_hash.hex()),
+            "message_link": link_to_explorer(request.event_chain_id, last_claim.tx_hash.hex()),
         },
         "body": f"""
 v1: {title[message_type]}

--- a/beamer/tests/agent/test_request.py
+++ b/beamer/tests/agent/test_request.py
@@ -45,7 +45,7 @@ def test_challenge_own_claim(config, request_manager, token, direction):
 
     claim = Claim(
         ClaimMade(
-            chain_id=ChainId(ape.chain.chain_id),
+            event_chain_id=ChainId(ape.chain.chain_id),
             tx_hash=HexBytes(b""),
             claim_id=ClaimId(1),
             request_id=request.id,
@@ -212,7 +212,7 @@ def test_agent_ignores_invalid_fill(_, request_manager, token, agent: Agent, dir
     event_processor.add_events(
         [
             RequestFilled(
-                chain_id=chain_id,
+                event_chain_id=chain_id,
                 tx_hash=HexBytes(b""),
                 request_id=request_id,
                 fill_id=FillId(b"1"),
@@ -231,7 +231,7 @@ def test_agent_ignores_invalid_fill(_, request_manager, token, agent: Agent, dir
     event_processor.add_events(
         [
             RequestFilled(
-                chain_id=chain_id,
+                event_chain_id=chain_id,
                 tx_hash=HexBytes(b""),
                 request_id=request_id,
                 fill_id=FillId(b"1"),
@@ -250,7 +250,7 @@ def test_agent_ignores_invalid_fill(_, request_manager, token, agent: Agent, dir
     event_processor.add_events(
         [
             RequestFilled(
-                chain_id=chain_id,
+                event_chain_id=chain_id,
                 tx_hash=HexBytes(b""),
                 request_id=request_id,
                 fill_id=FillId(b"1"),
@@ -269,7 +269,7 @@ def test_agent_ignores_invalid_fill(_, request_manager, token, agent: Agent, dir
     event_processor.add_events(
         [
             RequestFilled(
-                chain_id=chain_id,
+                event_chain_id=chain_id,
                 tx_hash=HexBytes(b""),
                 request_id=request_id,
                 fill_id=FillId(b"1"),

--- a/beamer/tests/agent/unit/test_handlers.py
+++ b/beamer/tests/agent/unit/test_handlers.py
@@ -211,7 +211,7 @@ def test_handle_request_resolved():
     request.try_to_claim()
 
     event = RequestResolved(
-        chain_id=SOURCE_CHAIN_ID,
+        event_chain_id=SOURCE_CHAIN_ID,
         tx_hash=HexBytes(""),
         request_id=request.id,
         filler=filler,
@@ -253,7 +253,7 @@ def test_handle_generate_l1_resolution_event():
     assert flag
     assert events == [
         InitiateL1ResolutionEvent(
-            chain_id=TARGET_CHAIN_ID,
+            event_chain_id=TARGET_CHAIN_ID,
             request_id=REQUEST_ID,
             claim_id=CLAIM_ID,
         )

--- a/beamer/tests/agent/unit/test_invalidate.py
+++ b/beamer/tests/agent/unit/test_invalidate.py
@@ -51,7 +51,7 @@ def test_handle_fill_invalidated_resolved():
     context.claims.add(claim_2.id, claim_2)
 
     event = FillInvalidatedResolved(
-        chain_id=request.source_chain_id,
+        event_chain_id=request.source_chain_id,
         tx_hash=HexBytes(""),
         request_id=request.id,
         fill_id=request.fill_id,
@@ -84,7 +84,7 @@ def test_handle_fill_invalidated():
 
     tx_hash = make_tx_hash()
     event = FillInvalidated(
-        chain_id=request.target_chain_id,
+        event_chain_id=request.target_chain_id,
         tx_hash=tx_hash,
         request_id=request.id,
         fill_id=request.fill_id,
@@ -230,7 +230,7 @@ def test_handle_generate_l1_invalidation_event(timestamp):
 
     assert events == [
         InitiateL1InvalidationEvent(
-            chain_id=TARGET_CHAIN_ID,
+            event_chain_id=TARGET_CHAIN_ID,
             claim_id=CLAIM_ID,
         )
     ]

--- a/beamer/tests/agent/unit/test_l1.py
+++ b/beamer/tests/agent/unit/test_l1.py
@@ -26,7 +26,7 @@ def test_handle_initiate_l1_resolution(timestamp):
     context.requests.add(request.id, request)
 
     event = InitiateL1ResolutionEvent(
-        chain_id=TARGET_CHAIN_ID,
+        event_chain_id=TARGET_CHAIN_ID,
         request_id=REQUEST_ID,
         claim_id=CLAIM_ID,
     )
@@ -63,7 +63,7 @@ def test_handle_initiate_l1_invalidation(timestamp):
     context.requests.add(request.id, request)
 
     event = InitiateL1InvalidationEvent(
-        chain_id=TARGET_CHAIN_ID,
+        event_chain_id=TARGET_CHAIN_ID,
         claim_id=CLAIM_ID,
     )
 

--- a/beamer/tests/agent/unit/utils.py
+++ b/beamer/tests/agent/unit/utils.py
@@ -111,7 +111,7 @@ def make_claim_challenged(
 
     claim = Claim(
         claim_made=ClaimMade(
-            chain_id=request.source_chain_id,
+            event_chain_id=request.source_chain_id,
             tx_hash=HexBytes(b""),
             claim_id=claim_id,
             request_id=request.id,

--- a/beamer/tests/health/conftest.py
+++ b/beamer/tests/health/conftest.py
@@ -95,7 +95,7 @@ def transfer_request():
         valid_until=Termination(123),
         block_number=BLOCK_NUMBER,
         tx_hash=HexBytes(b"1"),
-        chain_id=SOURCE_CHAIN_ID,
+        event_chain_id=SOURCE_CHAIN_ID,
         lp_fee=TokenAmount(1),
         protocol_fee=TokenAmount(1),
     )
@@ -105,7 +105,7 @@ def transfer_request():
 def transfer_fill(agent_address):
     return RequestFilled(
         request_id=REQUEST_ID,
-        chain_id=TARGET_CHAIN_ID,
+        event_chain_id=TARGET_CHAIN_ID,
         fill_id=FillId(b"1"),
         source_chain_id=SOURCE_CHAIN_ID,
         target_token_address=TARGET_TOKEN_ADDRESS,
@@ -124,7 +124,7 @@ def transfer_claim(agent_address):
         fill_id=FillId(b"1"),
         claimer=agent_address,
         claimer_stake=CLAIMER_STAKE,
-        chain_id=TARGET_CHAIN_ID,
+        event_chain_id=TARGET_CHAIN_ID,
         last_challenger=to_checksum_address(ADDRESS_ZERO),
         challenger_stake_total=Wei(0),
         termination=Termination(100),


### PR DESCRIPTION
As ChainUpdated event in RequestManager has chain_id, this conflicts with Event.chain_id in our agent event representation and chain_id field in ChainUpdatedEvent is rewritten. In order to prevent this, we need to rename chain_id in our agent representation to something else like event_chain_id so it wont get overwritten.