### PR TITLE
frontend: Fix reactivity of transfer limit validation

### DIFF
--- a/frontend/src/composables/useRequestSourceInputValidations.ts
+++ b/frontend/src/composables/useRequestSourceInputValidations.ts
@@ -82,7 +82,17 @@ export const useRequestSourceInputValidations = (
           Object.assign(selectedTokenAmountRules, {
             maxValue: helpers.withMessage(
               'Transfer limit: ' + options.transferLimitTokenAmount.value.formatFullValue(),
-              makeMaxTokenAmountValidator(options.transferLimitTokenAmount.value),
+              (value: TokenAmount) => {
+                if (
+                  !value ||
+                  !options.selectedToken.value ||
+                  !options.transferLimitTokenAmount.value
+                ) {
+                  return true;
+                }
+                // Due to reactivity issues `max` has to be initialized here
+                return makeMaxTokenAmountValidator(options.transferLimitTokenAmount.value)(value);
+              },
             ),
           });
         }

--- a/frontend/tests/unit/composables/useRequestSourceInputValidations.spec.ts
+++ b/frontend/tests/unit/composables/useRequestSourceInputValidations.spec.ts
@@ -148,6 +148,7 @@ describe('useRequestSourceInputValidations', () => {
 
         expect(v$.value.selectedTokenAmount?.$invalid).toBe(false);
       });
+
       it('is invalid when it holds a positive token amount that is higher than the provided transfer limit', () => {
         const token = generateTokenSelectorOption({ decimals: 6 });
         const selectedToken = ref(token);
@@ -168,6 +169,30 @@ describe('useRequestSourceInputValidations', () => {
         );
 
         expect(v$.value.selectedTokenAmount?.$invalid).toBe(true);
+      });
+
+      it('is valid when the provided transfer limit later changes to a lower value than the token amount that is hold', () => {
+        const token = generateTokenSelectorOption({ decimals: 6 });
+        const selectedToken = ref(token);
+        const selectedAmount = ref('0.3');
+        const selectedTokenAmount = computed(() =>
+          TokenAmount.parse(selectedAmount.value, selectedToken.value?.value),
+        );
+        const transferLimitTokenAmount: Ref<TokenAmount | undefined> = ref(undefined);
+        transferLimitTokenAmount.value = TokenAmount.parse('0.2', selectedToken.value.value);
+
+        const v$ = useRequestSourceInputValidations(
+          createConfig({
+            selectedToken,
+            selectedAmount,
+            selectedTokenAmount,
+            transferLimitTokenAmount,
+          }),
+        );
+
+        transferLimitTokenAmount.value = TokenAmount.parse('0.4', selectedToken.value.value);
+
+        expect(v$.value.selectedTokenAmount?.$invalid).toBe(false);
       });
     });
   });


### PR DESCRIPTION
Closes #1641 

Wrong transfer limits could be shown to the user if they switched the token. Somehow it was necessary to wrap the `makeMaxTokenAmountValidator` call in an arrow function. Same issue exists a few lines below in the creation of the balance validation.