### PR TITLE
Docs contract addresses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ workflows:
             scripts/.* backend-updated true
             relayer/.* relayer-updated true
             docs/.* docs-updated true
+            deployments/mainnet/deployment.json docs-updated true
             frontend/.* frontend-updated true
             subgraph/.* subgraph-updated true
             .circleci/.* frontend-updated true             

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,13 @@ relayers:
 	cp relayer/relayer-*-x64 beamer/agent/data/relayers
 
 docs:
+	python scripts/generate-contract-addresses-doc-page.py < deployments/mainnet/deployment.json \
+														   > docs/source/contracts-addresses.rst
 	make -C docs html
 
 clean:
 	make -C docs clean
+	rm -f docs/source/contracts-addresses.rst
 	rm -rf dist
 	rm -rf contracts/.build
 	rm -rf contracts/contracts/.cache

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ Welcome to Beamer's documentation!
    commands.rst
    configuration.rst
    contracts.rst
+   contracts-addresses.rst
    contracts-api-reference.rst
    protocol.rst
    l1_resolution.rst

--- a/scripts/generate-contract-addresses-doc-page.py
+++ b/scripts/generate-contract-addresses-doc-page.py
@@ -1,0 +1,72 @@
+import json
+import sys
+import textwrap
+from typing import Generator, Iterable
+
+_NAMES = {
+    1: "Ethereum",
+    10: "Optimism",
+    288: "Boba",
+    42161: "Arbitrum",
+}
+
+_EXPLORERS = {
+    1: "https://etherscan.io/address/{address}",
+    10: "https://optimistic.etherscan.io/address/{address}",
+    288: "https://bobascan.com/address/{address}",
+    42161: "https://arbiscan.io/address/{address}",
+}
+
+
+def main() -> None:
+    deployment = json.loads(sys.stdin.read())
+    print(
+        textwrap.dedent(
+            """\
+    Beamer contract addresses
+    =========================
+    """
+        )
+    )
+
+    for chain_id, contracts in deployment["chains"].items():
+        name = _NAMES[int(chain_id)]
+        explorer = _EXPLORERS[int(chain_id)]
+        if name == "Ethereum":
+            base_contracts = deployment["base_chain"]
+            contracts.update(base_contracts)
+        _generate_section(name, explorer, contracts)
+
+
+def _generate_section(section_name: str, explorer: str, contracts: dict) -> None:
+    def rows() -> Generator[tuple[str, str], None, None]:
+        yield "Contract", "Address"
+        for name, contract in contracts.items():
+            address = contract["address"]
+            url = explorer.format(address=address)
+            yield name, f"`{address} <{url}>`_"
+
+    section_marker = "-" * len(section_name)
+    print(f"\n{section_name}")
+    print(f"{section_marker}\n")
+    _generate_table(rows())
+
+
+def _generate_table(rows: Iterable[tuple]) -> None:
+    print(
+        textwrap.dedent(
+            """\
+      .. list-table::
+         :header-rows: 1
+    """
+        )
+    )
+
+    for row in rows:
+        columns = iter(row)
+        print(f"""   * - {next(columns)}""")
+        print("".join(f"""     - {col}\n""" for col in columns))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a script (with a terribly long name, suggestions welcome!) to generate a doc page with contract addresses, given a deployment file. The script expects JSON on stdin and outputs rst  to be included in the docs.

The Makefile targets are updated and also CI config is changed so that whenever the mainnet deployment file is changed, the page will be regenerated and uploaded.

Example for the current deployment:
![image](https://user-images.githubusercontent.com/1312091/230405080-870677cb-be8c-4845-a582-3c9aca773ef0.png)
