### PR TITLE
Makefile: improve the dist-exe target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ format: black
 	npx prettier --write $(CONTRACTS)
 
 dist-exe:
+	mkdir -p dist
+	# Since shiv only knows about pyproject.toml and not about poetry.lock,
+	# make sure to fail if poetry.lock is not consistent with pyproject.toml.
+	poetry lock --check
 	shiv -c beamer -o dist/beamer .
 
 container-image: relayers


### PR DESCRIPTION
First, make sure that the dist directory exists (it could be missing as a result of running the clean target, for example).

Second, fail if poetry detects an inconsistency between pyproject.toml and poetry.lock. This is to avoid situations where shiv bundles packages from pyproject.toml, and we test everything with packages from poetry.lock.