### PR TITLE
docker: scripts: add a container image test

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -130,7 +130,7 @@ jobs:
             # Remove other versions so they don't end up in the cache.
             for x in $(ls -1 ${NVM_DIR}/versions/node | grep -v $(nvm version default)); do nvm uninstall $x; done
       - run: npm install yarn --location=global
-      - run: npm install ganache@7.5.0 --location=global
+      - run: npm install ganache@7.7.7 --location=global
       - run: yarn install --frozen-lockfile
       - save_cache:
           key: node18-packages-{{ .Environment.CACHE_VERSION }}

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -319,19 +319,26 @@ jobs:
     environment:
       IMAGE_NAME: ghcr.io/beamer-bridge/beamer
     steps:
-      - attach_workspace:
-          at: /
-      - restore-node-packages
-      - ensure-node-environment
-      - run:
-          name: Log in to github container registry
-          command: echo ${GHCR_PAT} | docker login -u istankovic --password-stdin ghcr.io
+      - initialize-environment
       - run:
           name: Build a beamer image
-          command: cd ~/beamer && make container-image IMAGE_NAME=${IMAGE_NAME}
+          command: make container-image IMAGE_NAME=${IMAGE_NAME}
       - run:
-          name: Push the image to github container registry
-          command: docker push -a ${IMAGE_NAME}
+          name: Compile contracts
+          command: ape compile
+      - run:
+          name: Test the container image
+          command: bash docker/scripts/test-container-image.sh ${IMAGE_NAME}:sha-$(git rev-parse HEAD)
+      - when:
+          condition:
+             equal: [ main, <<pipeline.git.branch>> ]
+          steps:
+            - run:
+                name: Log in to github container registry
+                command: echo ${GHCR_PAT} | docker login -u istankovic --password-stdin ghcr.io
+            - run:
+                name: Push the image to github container registry
+                command: docker push -a ${IMAGE_NAME}
 
 workflows:
   backend:
@@ -374,6 +381,13 @@ workflows:
           requires:
             - compile-contracts
             - create-relayers
+      - build-and-publish-container-image:
+          requires:
+            - test-contracts
+            - test-beamer
+            - e2e-test-ethereum
+            - e2e-test-optimism
+            - e2e-test-arbitrum
 
   docs:
     when: <<pipeline.parameters.docs-updated>>
@@ -402,32 +416,20 @@ workflows:
     when: <<pipeline.parameters.relayer-updated>>
     jobs:
       - checkout
+      - install-python:
+          requires:
+            - checkout
       - install-npm-packages:
           requires:
-              - checkout
+            - checkout
       - create-relayers:
           requires:
             - install-npm-packages
-      - test-relayer
-
-  build-and-publish-container-image:
-    when:
-      or:
-        - <<pipeline.git.tag>>
-        - and:
-          - <<pipeline.parameters.backend-updated>>
-          - equal: [ main, <<pipeline.git.branch>> ]
-        - and:
-          - <<pipeline.parameters.relayer-updated>>
-          - equal: [ main, <<pipeline.git.branch>> ]
-    jobs:
-      - checkout
-      - install-npm-packages:
-          requires:
-              - checkout
-      - create-relayers:
+      - test-relayer:
           requires:
             - install-npm-packages
       - build-and-publish-container-image:
           requires:
+            - install-python
             - create-relayers
+            - test-relayer

--- a/docker/scripts/test-container-image.sh
+++ b/docker/scripts/test-container-image.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+. "$(realpath $(dirname $0))/common.sh"
+
+ROOT="$(get_root_dir)"
+
+CACHE_DIR=$(obtain_cache_dir "$0")
+DEPLOYMENT_DIR="${CACHE_DIR}/deployment"
+DEPLOYMENT_CONFIG_FILE="${ROOT}/scripts/deployment/ethereum-local.json"
+
+# Generate deployer's key.
+KEYFILE=$(mktemp -p ${CACHE_DIR})
+ADDRESS=$(python ${ROOT}/scripts/generate_account.py --password '' ${KEYFILE})
+PRIVKEY=$(python ${ROOT}/scripts/dump-private-key.py ${KEYFILE})
+echo Beamer deployer\'s address and keyfile: ${ADDRESS} ${KEYFILE}
+
+echo -n Starting ganache:
+name=$(npx ganache --chain.vmErrorsOnRPCResponse true  --hardfork istanbul --detach \
+                   --wallet.accounts $PRIVKEY,0x3635C9ADC5DEA00000)
+echo $name
+
+function cleanup {
+    echo Stopping ganache: $name
+    npx ganache instances stop $name
+}
+
+trap cleanup EXIT
+
+echo Deploying Beamer...
+mkdir -p ${CACHE_DIR}/deployment
+deploy_beamer ${KEYFILE} ${DEPLOYMENT_CONFIG_FILE} ${DEPLOYMENT_DIR}
+
+echo Whitelisting deployer...
+python ${ROOT}/scripts/call_contracts.py --keystore-file ${KEYFILE} \
+                                         --password '' \
+                                         --eth-rpc http://localhost:8545 \
+                                         --deployment-dir ${DEPLOYMENT_DIR} \
+                                         whitelist ${ADDRESS}
+
+cat <<EOF > ${CACHE_DIR}/agent.conf
+log-level = "debug"
+deployment-dir = "${DEPLOYMENT_DIR}"
+poll-period = 0.1
+confirmation-blocks = 0
+
+[account]
+path = "${KEYFILE}"
+password = ""
+
+[base-chain]
+rpc-url = "http://localhost:8545"
+
+[chains.foo]
+rpc-url = "http://localhost:8545"
+
+[chains.bar]
+rpc-url = "http://localhost:8545"
+EOF
+
+echo Starting agent...
+container_id=$(docker run --detach --rm --net=host -v ${CACHE_DIR}:${CACHE_DIR} $1 \
+                          agent --config ${CACHE_DIR}/agent.conf)
+
+let n=30
+echo Waiting $n seconds for the sync to finish...
+while [[ $n -gt 0 ]]; do
+    echo $n
+    if docker logs $container_id | grep 'Sync done' > /dev/null; then
+        docker kill --signal INT $container_id > /dev/null
+        echo Test ok.
+        exit 0
+    fi
+    sleep 1
+    ((n--))
+done
+
+echo Test failed.
+docker logs $container_id
+exit 1

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -3,13 +3,15 @@
 Making a new release
 --------------------
 
-* Make sure to populate ``CHANGELOG.md`` and change the version number
-  (see `this commit <https://github.com/beamer-bridge/beamer/commit/440b7ddffc01d16482d78ff9f18a8830670795bc>`_ for example).
-* Commit and push the changes above to Github, merge the PR (if releasing from ``main``;
-  there should be no PR for releases from other branches).
-* Make sure a CI run is triggered, either automatically or manually, and wait for the run to finish.
-* The previous step will have created an agent Docker image, which you can use for final testing before the release.
-  Once everything looks good, tag the commit (e.g. ``git tag v0.1.8``) and push it to Github (e.g. ``git push origin tag v0.1.8``).
-* Make a release on Github based on the pushed tag.
-  Copy the relevant ``CHANGELOG.md`` part to the release notes;
-  see `this page <https://github.com/beamer-bridge/beamer/releases/tag/v0.1.8>`_ for example.
+#. Make sure to populate ``CHANGELOG.md`` and change the version number
+   (see `this commit <https://github.com/beamer-bridge/beamer/commit/440b7ddffc01d16482d78ff9f18a8830670795bc>`_ for example).
+#. Commit the changes above, create and merge the PR
+   (if releasing from ``main``; there should be no PR for releases from other branches).
+#. Tag the resulting commit on ``main`` or on the release branch (e.g. ``git tag v0.1.8``) and
+   push it to Github (e.g. ``git push origin tag v0.1.8``).
+#. Make sure a CI run is triggered, either automatically or manually, and wait for the run to finish.
+#. The previous step will have created an agent Docker image, which you can use for final testing before the release.
+   If you encounter any release-blocking issues, fix them and restart the release process.
+#. Make a release on Github based on the pushed tag.
+   Copy the relevant ``CHANGELOG.md`` part to the release notes;
+   see `this page <https://github.com/beamer-bridge/beamer/releases/tag/v0.1.8>`_ for example.

--- a/scripts/dump-private-key.py
+++ b/scripts/dump-private-key.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import click
+import eth_account
+
+
+@click.command()
+@click.option("--password", type=str, default="", help="The keystore file password")
+@click.argument(
+    "keyfile",
+    type=click.Path(file_okay=True, dir_okay=False, path_type=Path),
+)
+def main(password: str, keyfile: Path) -> None:
+    with keyfile.open() as f:
+        content = f.read()
+    key = eth_account.Account.decrypt(content, password)
+    print(key.hex())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR
- adds a script that tests the beamer container image
- updates CI workflows so that the `build-and-publish-container-image` is run as part of `backend` and `relayer` workflows; pushes to the container registry will only be done if we're on `main` branch

The test consists of starting a local ganache instance, deploying Beamer onto it, running an agent using the specified container image and checking whether the agents was able to sync successfully.