### PR TITLE
feat: check rpc status notifications and halt event processors

### DIFF
--- a/beamer/agent/agent.py
+++ b/beamer/agent/agent.py
@@ -91,6 +91,7 @@ class Agent:
                 confirmation_blocks=self._config.confirmation_blocks[chain_name],
                 on_new_events=[],
                 on_sync_done=[],
+                on_rpc_status_change=[],
             )
             chains[chain_id] = _Chain(
                 w3=w3,

--- a/beamer/health/check.py
+++ b/beamer/health/check.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import DefaultDict, TypedDict, cast
 
+import requests
 import toml
 from eth_typing import BlockNumber
 from eth_utils import to_checksum_address
@@ -212,8 +213,10 @@ def fetch_events() -> ChainEventMap:
             BlockNumber(info["RequestManager"].deployment_block),
             0,
         )
-
-        events[chain_id] = ef.fetch()
+        try:
+            events[chain_id] = ef.fetch()
+        except requests.exceptions.ConnectionError:
+            events[chain_id] = []
 
     return cast(ChainEventMap, events)
 


### PR DESCRIPTION
Closes: #1729 

This PR looks for notifications from EventFetcher and EventMonitor and pushes the state to EventProcessor and if rpc is not working, EventProcessor halting processing claims and requests.