### PR TITLE
Beamer configure command

### DIFF
--- a/beamer/cli.py
+++ b/beamer/cli.py
@@ -1,6 +1,7 @@
 import click
 
 from beamer.agent import commands as agent_commands
+from beamer.configure import commands as configure_commands
 from beamer.health import commands as health_commands
 
 
@@ -10,4 +11,5 @@ def main() -> None:
 
 
 main.add_command(agent_commands.agent)
+main.add_command(configure_commands.configure)
 main.add_command(health_commands.monitor)

--- a/beamer/configure/commands.py
+++ b/beamer/configure/commands.py
@@ -89,7 +89,7 @@ def _execute_command(chain: _Chain, command: Command) -> None:
         input_names = _get_inputs_for_field(request_manager.abi, command.name)[1:]
         write_params = _merge_values(input_names, current_values, param.values)
 
-        if write_params == _merge_values(input_names, current_values, {}):
+        if write_params == current_values:
             print("Values already configured. Not executing!")
             return
 

--- a/beamer/configure/commands.py
+++ b/beamer/configure/commands.py
@@ -1,0 +1,140 @@
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import NamedTuple
+
+import click
+from eth_account.signers.local import LocalAccount
+from web3 import Web3
+from web3.contract import Contract, ContractConstructor
+from web3.contract.contract import ContractFunction
+from web3.types import ABI
+
+from beamer.agent.contracts import DeploymentInfo, load_deployment_info, make_contracts
+from beamer.agent.events import camel_to_snake
+from beamer.agent.typing import ChainId
+from beamer.agent.util import TransactionFailed, account_from_keyfile, make_web3, transact
+from beamer.configure.config import ChainConfig, Command, Config
+
+
+@dataclass
+class _Chain:
+    name: str
+    web3: Web3
+    contracts: dict[str, Contract] = field(default_factory=dict)
+    tokens: list[list[str]] = field(default_factory=list)
+
+    @staticmethod
+    def from_config(
+        chain_id: str,
+        chain_config: ChainConfig,
+        account: LocalAccount,
+        deployment_info: DeploymentInfo,
+    ) -> "_Chain":
+        web3 = make_web3(chain_config.rpc, account)
+        rpc_chain_id = ChainId(web3.eth.chain_id)
+        assert ChainId(int(chain_id)) == rpc_chain_id
+        contracts = make_contracts(web3, deployment_info[rpc_chain_id])
+        return _Chain(chain_config.name, web3, contracts, chain_config.tokens)
+
+    def get_token_address(self, symbol: str) -> str | None:
+        for token, address in self.tokens:
+            if symbol == token:
+                return address
+        return None
+
+
+def _transact(transaction: ContractConstructor | ContractFunction) -> None:
+    try:
+        receipt = transact(transaction)
+        if receipt is not None and receipt.status != 0:
+            print(f"Transaction successfully executed! Hash: {receipt.transactionHash.hex()}")
+        else:
+            print("Transaction failed!")
+    except TransactionFailed:
+        print("Transaction failed!")
+
+
+def _get_inputs_for_field(abi: ABI, name: str) -> list[str]:
+    for contract_field in abi:
+        if contract_field.get("name") == name:
+            return [arg["name"] for arg in contract_field["inputs"]]
+    raise ValueError("Field not in ABI")
+
+
+def _get_values_from_mapping(contract: Contract, command: str, key: str | int) -> NamedTuple:
+    subject = "%ss" % command.removeprefix("update").lower()
+    read_func = getattr(contract.functions, subject)
+    return read_func(key).call()
+
+
+def _merge_values(
+    input_names: list[str], current_values: NamedTuple, new_values: dict[str, str | int]
+) -> tuple[str | int, ...]:
+    values: list[str | int] = list()
+    for name in input_names:
+        values.append(new_values.get(camel_to_snake(name), getattr(current_values, name)))
+    return tuple(values)
+
+
+def _execute_command(chain: _Chain, command: Command) -> None:
+    for param in command.params:
+        key = param.key
+        if command.name == "updateToken":
+            key = chain.get_token_address(str(param.key))
+
+        request_manager = chain.contracts["RequestManager"]
+        # FIXME: new commands do not necessarily need a key -> updateFees
+        assert key is not None
+        current_values = _get_values_from_mapping(request_manager, command.name, key)
+        input_names = _get_inputs_for_field(request_manager.abi, command.name)[1:]
+        write_params = _merge_values(input_names, current_values, param.values)
+
+        if write_params == _merge_values(input_names, current_values, {}):
+            print("Values already configured. Not executing!")
+            return
+
+        write_func = getattr(chain.contracts["RequestManager"].functions, command.name)
+        _transact(write_func(key, *write_params))
+
+
+def _execute_on_chain(chain: _Chain, commands: list[Command]) -> None:
+    for command in commands:
+        print(f"Execute {command.name}...")
+        _execute_command(chain, command)
+
+
+def _make_chains(
+    chain_configs: dict[str, ChainConfig], account: LocalAccount, deployment_dir: str
+) -> dict[ChainId, _Chain]:
+    deployment_info = load_deployment_info(Path(deployment_dir))
+    return {
+        ChainId(int(chain_id)): _Chain.from_config(chain_id, chain, account, deployment_info)
+        for chain_id, chain in chain_configs.items()
+    }
+
+
+@click.command("configure")
+@click.option(
+    "--keystore-file",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
+    required=True,
+    metavar="FILE",
+    help="The file that stores the key for the account to be used.",
+)
+@click.option(
+    "--password", type=str, required=True, help="The password needed to unlock the account."
+)
+@click.option(
+    "--config-file",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
+    required=True,
+    metavar="FILE",
+    help="The file containing configuration information.",
+)
+def configure(keystore_file: Path, password: str, config_file: Path) -> None:
+    account = account_from_keyfile(keystore_file, password)
+    config = Config.from_file(config_file)
+    chains = _make_chains(config.chains, account, config.deployment_dir)
+    for chain in chains.values():
+        print(f"Chain: {chain.name}...")
+        _execute_on_chain(chain, config.commands)

--- a/beamer/configure/config.py
+++ b/beamer/configure/config.py
@@ -1,0 +1,39 @@
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from apischema import deserialize, schema
+
+from beamer.agent.typing import URL
+
+
+@dataclass
+class ChainConfig:
+    name: str
+    rpc: URL
+    tokens: list[list[str]] = field(default_factory=list)
+
+
+@dataclass
+class Param:
+    key: str | int | None = field(default=None)
+    values: dict[str, str | int] = field(default_factory=dict)
+
+
+@dataclass
+class Command:
+    name: str
+    params: list[Param]
+
+
+@dataclass
+class Config:
+    deployment_dir: str
+    chains: dict[str, ChainConfig] = field(metadata=schema(min_items=1))
+    commands: list[Command] = field(metadata=schema(min_items=1))
+
+    @staticmethod
+    def from_file(config_file: Path) -> "Config":
+        with open(config_file) as f:
+            config = json.load(f)
+        return deserialize(Config, config)

--- a/beamer/configure/mainnet.json
+++ b/beamer/configure/mainnet.json
@@ -1,0 +1,97 @@
+{
+    "deployment_dir": "deployments/mainnet",
+    "chains": {
+        "1": {
+            "name": "Ethereum",
+            "rpc": "https://eth-mainnet.g.alchemy.com/v2/846ZyXYGItwqGPXIGYxzxjmZAhUlRbf6",
+            "tokens": [
+                [
+                    "USDC",
+                    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+                ],
+                [
+                    "DAI",
+                    "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+                ]
+            ]
+        },
+        "10": {
+            "name": "Optimism",
+            "rpc": "https://opt-mainnet.g.alchemy.com/v2/vwHU74Q04-hqpB-8gHIAQcQ1rsBipjPX",
+            "tokens": [
+                [
+                    "USDC",
+                    "0x7F5c764cBc14f9669B88837ca1490cCa17c31607"
+                ],
+                [
+                    "DAI",
+                    "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
+                ]
+            ]
+        },
+        "42161": {
+            "name": "Arbitrum",
+            "rpc": "https://arb-mainnet.g.alchemy.com/v2/u66kdJE3hM6rh0sYAcV6PqTee9YbIP-F",
+            "tokens": [
+                [
+                    "USDC",
+                    "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8"
+                ],
+                [
+                    "DAI",
+                    "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
+                ]
+            ]
+        }
+    },
+    "commands": [
+        {
+            "name": "updateChain",
+            "params": [
+                {
+                    "key": 1,
+                    "values": {
+                        "finality_period": "",
+                        "transfer_cost": "",
+                        "target_weight_ppm": ""
+                    }
+                },
+                {
+                    "key": 10,
+                    "values": {
+                        "finality_period": "",
+                        "transfer_cost": "",
+                        "target_weight_ppm": ""
+                    }
+                },
+                {
+                    "key": 42161,
+                    "values": {
+                        "finality_period": "",
+                        "transfer_cost": "",
+                        "target_weight_ppm": ""
+                    }
+                }
+            ]
+        },
+        {
+            "name": "updateToken",
+            "params": [
+                {
+                    "key": "USDC",
+                    "values": {
+                        "transfer_limit": 50000000000,
+                        "eth_in_token": ""
+                    }
+                },
+                {
+                    "key": "DAI",
+                    "values": {
+                        "transfer_limit": 50000000000000000000000,
+                        "eth_in_token": ""
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/beamer/events.py
+++ b/beamer/events.py
@@ -142,7 +142,7 @@ class FillInvalidated(TxEvent, TargetChainEvent):
     fill_id: FillId
 
 
-def _camel_to_snake(s: str) -> str:
+def camel_to_snake(s: str) -> str:
     snake = "".join(
         "%c_" % current if current.islower() and next.isupper() else current.lower()
         for current, next in pairwise(s)
@@ -198,7 +198,7 @@ def _decode_event(
     event_abi = event_abis[topic]
     data = get_event_data(abi_codec=codec, event_abi=event_abi, log_entry=log_entry)
     if data.event in _EVENT_TYPES:
-        kwargs = {_camel_to_snake(name): value for name, value in data.args.items()}
+        kwargs = {camel_to_snake(name): value for name, value in data.args.items()}
         kwargs["event_chain_id"] = chain_id
         kwargs["block_number"] = log_entry["blockNumber"]
         kwargs["tx_hash"] = log_entry["transactionHash"]


### PR DESCRIPTION
implements: #1706

I tried a generic approach. The general problem is that it is hard to map input to output of the contract. Namely, when we have an input function (i.e. `updateChain`) where and how can I read the output (what are the current values)? Generically this is difficult to achieve.

I started now with the first pattern we have, and the script tries to find a the corresponding mapping from input to storage (setter and getter). This can't really be read from the ABI.

Currently the script does: 

updateChain maps to the getter -> chains
updateToken maps to the getter -> tokens
... 

I removed modifying the allowlist which is a different pattern (No values to be set but bool to be read)


From here we could move forward and decide how to evolve this script.


Additionally: 
The script fills missing params with currently stored values
The script checks whether the storage would be changed by executing. If not, don't send transaction.


Future Improvements: 
* There is a lot of room to improve the apischema for type validation
* check that changes were effective
* add more commands
* Better feedback if names cannot be found in the ABI
* We could build a exclusive mapping for getters and setters (less generics)
* ...
