### PR TITLE
frontend: replace broken ethereum rpc

### DIFF
--- a/frontend/config/chains/1.json
+++ b/frontend/config/chains/1.json
@@ -1,7 +1,7 @@
 {
   "identifier": 1,
   "explorerUrl": "https://etherscan.io/",
-  "rpcUrl": "https://eth.llamarpc.com",
+  "rpcUrl": "https://rpc.flashbots.net",
   "name": "Ethereum Mainnet",
   "imageUrl": "/images/ethereum.svg",
   "tokenSymbols": ["USDC", "DAI"],


### PR DESCRIPTION
When connected via walletconnect to our production app most of the rpc requests fail with the following error:
```
Failed to deserialize the JSON body into the target type: skipCache: unknown field `skipCache`, expected one of `jsonrpc`, `id`, `method`, `params` at line 1 column 74
```

The issue comes from the public rpc url we are using in our app: `https://eth.llamarpc.com`

<img width="374" alt="Screenshot 2023-05-02 at 12 35 43" src="https://user-images.githubusercontent.com/18466333/235644700-f0ac9130-9778-4598-aa55-8aff848a9aba.png">


This PR Fixes this by replacing the public rpc url our app uses to do simple rpc calls. 