### PR TITLE
deployments: tag dev npm package with the dev tag

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -346,7 +346,7 @@ jobs:
                 working_directory: ~/beamer    
             - run:
                 name: Publish to npm
-                command: yarn publish dist/beamer-bridge-deployments.tgz
+                command: yarn publish dist/beamer-bridge-deployments.tgz --tag dev
                 working_directory: ~/beamer/deployments
 
   test-relayer:

--- a/deployments/scripts/create-package.sh
+++ b/deployments/scripts/create-package.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 rm -rf dist
 mkdir -p dist/abis/{goerli,mainnet}


### PR DESCRIPTION
In addition to tagging the dev release as dev, this PR also fixes a bug that would prevent the building of the npm package