### PR TITLE
deployments: Add github hash to dev npm releases

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -338,7 +338,7 @@ jobs:
           steps:
             - run:
                 name: Update to prerelease version
-                command: yarn version --prerelease --no-git-tag-version --preid $(date +%s)  
+                command: yarn version --prerelease --no-git-tag-version --preid $(git rev-parse --short HEAD)-$(date +%s)
                 working_directory: ~/beamer/deployments
             - run:
                 name: Build

--- a/deployments/artifacts/goerli/base.deployment.json
+++ b/deployments/artifacts/goerli/base.deployment.json
@@ -6,7 +6,7 @@
             "beamer_commit": "0d09825c844d20ddc6d2709c5c832ea987b6fb9a",
             "tx_hash": "0xd91736fd22316f7383e60654eda6e195c90d42141a19a4dbfdb1a18cce72efe4",
             "address": "0x880292d23338F81B54f9C74e11A720A2d2b4813c",
-            "deployment_block": 8750450,
+            "deployment_block": 8750451,
             "deployment_args": []
         }
     }


### PR DESCRIPTION
Without the github hash it is hard to figure out which commit triggered a dev release.