### PR TITLE
Frontend/fix transfer time

### DIFF
--- a/frontend/src/components/ShareTweet.vue
+++ b/frontend/src/components/ShareTweet.vue
@@ -20,7 +20,7 @@ const isShareable = computed(() => {
     !!transfer.value.sourceAmount.token &&
     !!transfer.value.sourceChain &&
     !!transfer.value.targetChain &&
-    !!transfer.value.transferTime
+    !!transfer.value.transferTimeSeconds
   );
 });
 
@@ -28,7 +28,7 @@ const tweetText = computed(() => {
   const sourceToken = transfer.value?.sourceAmount.token;
   const sourceChain = transfer.value?.sourceChain;
   const targetChain = transfer.value?.targetChain;
-  const transferTime = transfer.value?.transferTime;
+  const transferTime = transfer.value?.transferTimeSeconds;
 
   return `I just used @beamerbridge to seamlessly and securely transfer #${sourceToken?.symbol} from ${sourceChain?.name} to ${targetChain?.name} in ${transferTime} seconds! 🔥
 

--- a/frontend/src/components/notifications/TransferComplete.vue
+++ b/frontend/src/components/notifications/TransferComplete.vue
@@ -1,21 +1,26 @@
 <template>
   <div>
     <span data-test="message">
-      <span v-if="transfer?.transferTime !== undefined"
-        >Transfer completed in {{ transfer?.transferTime }}s.</span
-      >
+      <div v-if="shareVisible">
+        <div>Transfer completed in {{ transfer?.transferTimeSeconds }}s.</div>
+        <ShareTweet :transfer="transfer"></ShareTweet>
+      </div>
       <span v-else> Transfer completed. </span>
     </span>
-    <br />
-    <ShareTweet :transfer="transfer"></ShareTweet>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
+
 import { Transfer } from '@/actions/transfers';
 import ShareTweet from '@/components/ShareTweet.vue';
 
-defineProps({
+const props = defineProps({
   transfer: Transfer,
 });
+
+const shareVisible = computed(
+  () => props.transfer?.transferTimeSeconds && props.transfer.transferTimeSeconds < 120,
+);
 </script>

--- a/frontend/src/services/transactions/request-manager.ts
+++ b/frontend/src/services/transactions/request-manager.ts
@@ -9,7 +9,6 @@ import { UInt256 } from '@/types/uint-256';
 
 import type { IEthereumProvider } from '../web3-provider';
 import {
-  getBlockTimestamp,
   getConfirmationTimeBlocksForChain,
   getJsonRpcProvider,
   getLatestBlock,
@@ -156,10 +155,7 @@ export async function getRequestInformation(
   rpcUrl: string,
   requestManagerAddress: EthereumAddress,
   transactionHash: string,
-): Promise<{
-  requestId: string;
-  timestamp: number;
-}> {
+): Promise<string> {
   const provider = getJsonRpcProvider(rpcUrl);
   const contract = getReadOnlyContract<RequestManager>(
     requestManagerAddress,
@@ -187,8 +183,7 @@ export async function getRequestInformation(
       continue;
     }
     if (event && event.args.requestId) {
-      const timestamp = await getBlockTimestamp(rpcUrl, receipt.blockHash);
-      return { requestId: event.args.requestId, timestamp };
+      return event.args.requestId;
     }
   }
   throw new Error("Request Failed. Couldn't retrieve Request ID.");

--- a/frontend/tests/unit/actions/transfers/transfer.spec.ts
+++ b/frontend/tests/unit/actions/transfers/transfer.spec.ts
@@ -83,6 +83,8 @@ function define(object: unknown, property: string, value: unknown): void {
 
 describe('transfer', () => {
   beforeEach(() => {
+    global.Date.now = vi.fn();
+
     Object.defineProperties(tokenUtils, {
       ensureTokenAllowance: { value: vi.fn().mockResolvedValue(undefined) },
     });
@@ -332,12 +334,9 @@ describe('transfer', () => {
       const transfer = new TestTransfer(data);
       const identifier = '0x123';
       const timestamp = 100;
+      global.Date.now = vi.fn().mockReturnValue(timestamp);
 
-      define(
-        requestManager,
-        'getRequestInformation',
-        vi.fn().mockResolvedValue({ requestId: identifier, timestamp }),
-      );
+      define(requestManager, 'getRequestInformation', vi.fn().mockResolvedValue(identifier));
 
       await transfer.waitForRequestEvent();
 
@@ -465,11 +464,8 @@ describe('transfer', () => {
       const transfer = new TestTransfer(data);
       const fulfillmentTimestamp = 100;
 
-      define(
-        fillManager,
-        'waitForFulfillment',
-        createTestCancelable({ result: fulfillmentTimestamp }),
-      );
+      global.Date.now = vi.fn().mockReturnValue(fulfillmentTimestamp);
+      define(fillManager, 'waitForFulfillment', createTestCancelable({ result: true }));
 
       await transfer.waitForFulfillment();
 

--- a/frontend/tests/unit/components/notifications/TransferComplete.spec.ts
+++ b/frontend/tests/unit/components/notifications/TransferComplete.spec.ts
@@ -21,7 +21,7 @@ describe('TransferComplete.vue', () => {
       },
     });
     const message = wrapper.find('[data-test="message"]');
-    expect(message.text()).toBe(`Transfer completed in ${transfer.transferTime}s.`);
+    expect(message.text()).toBe(`Transfer completed in ${transfer.transferTimeSeconds}s.`);
   });
 
   it('shows a general completion message when transfer time is not defined', () => {

--- a/frontend/tests/unit/services/transactions/fill-manager.spec.ts
+++ b/frontend/tests/unit/services/transactions/fill-manager.spec.ts
@@ -114,10 +114,6 @@ describe('fill-manager', () => {
       Object.defineProperty(eventFiltersService, 'fetchFirstMatchingEvent', {
         value: vi.fn().mockResolvedValue(event),
       });
-      const timestamp = 100;
-      Object.defineProperty(transactionUtils, 'getBlockTimestamp', {
-        value: vi.fn().mockResolvedValue(timestamp),
-      });
 
       const { promise } = waitForFulfillment(
         rpcUrl,
@@ -126,7 +122,7 @@ describe('fill-manager', () => {
         fromBlockNumber,
       );
 
-      await expect(promise).resolves.toBe(timestamp);
+      await expect(promise).resolves.toBeUndefined();
       expect(contract.removeAllListeners).toHaveBeenCalled();
     });
 

--- a/frontend/tests/unit/services/transactions/request-manager.spec.ts
+++ b/frontend/tests/unit/services/transactions/request-manager.spec.ts
@@ -208,7 +208,6 @@ describe('request-manager', () => {
   describe('getRequestInformation()', async () => {
     it('queries and returns the request information for a given transaction hash', async () => {
       const transactionHash = getRandomString();
-      const transactionMinedTimestamp = 100;
 
       const contract = mockGetRequestManagerContract();
       contract.interface.parseLog = vi.fn().mockReturnValue({ args: { requestId: '1' } });
@@ -222,20 +221,16 @@ describe('request-manager', () => {
         getConfirmationTimeBlocksForChain: {
           value: vi.fn().mockReturnValue(1),
         },
-        getBlockTimestamp: {
-          value: vi.fn().mockReturnValue(transactionMinedTimestamp),
-        },
       });
 
-      const requestInformation = await getRequestInformation(
+      const identifier = await getRequestInformation(
         RPC_URL,
         REQUEST_MANAGER_ADDRESS,
         transactionHash,
       );
 
       expect(provider.waitForTransaction).toHaveBeenCalledWith(transactionHash, expect.anything());
-      expect(requestInformation.requestId).toBe('1');
-      expect(requestInformation.timestamp).toBe(transactionMinedTimestamp);
+      expect(identifier).toBe('1');
     });
 
     it('throws an error if the transaction has reverted', async () => {


### PR DESCRIPTION
Changed the time strategy: from using `block.timestamp` to using local clock (with `Date.now()`).
You can read more on why this was necessary here: https://github.com/beamer-bridge/beamer/issues/1796

Closes #1684 & #1796