### PR TITLE
fix: solve deployment related issues

### DIFF
--- a/beamer/deploy/config.py
+++ b/beamer/deploy/config.py
@@ -49,8 +49,8 @@ class _Token:
 class Chain:
     name: str
     chain_id: ChainId = field(metadata=schema(min=1))
-    l1_messenger: str | tuple[str, ...]
-    l2_messenger: str | tuple[str, ...]
+    l1_messenger: str | tuple[str | int, ...]
+    l2_messenger: str | tuple[str | int, ...]
     finality_period: int = field(metadata=schema(min=1))
     transfer_cost: int = field(metadata=schema(min=0))
     target_weight_ppm: int = field(metadata=schema(min=0))

--- a/beamer/deploy/util.py
+++ b/beamer/deploy/util.py
@@ -91,7 +91,9 @@ def _resolve_constructor_args(
     if isinstance(constructor_spec, str):
         # This is just the contract's name.
         return (constructor_spec,)
-    return tuple(contract_args[arg].address if "$" in arg else arg for arg in constructor_spec)
+    return tuple(
+        contract_args[arg].address if "$" in str(arg) else arg for arg in constructor_spec
+    )
 
 
 def deploy_beamer(


### PR DESCRIPTION
This PR is solving following issues:

1. To support Polygon ZkEVM, messengers can accept integer in constructor. Config changed.
2. Old resolver args function cant handle int as argument because it looks for "$" in arg.