### PR TITLE
deployments: release v1 of npm package

### DIFF
--- a/deployments-npm-package/package.json
+++ b/deployments-npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beamer-bridge/deployments",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "description": "The beamer-bridge contract deployments & ABIs",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
It’s a little strange to go from 2 to 1, but version 2 was actually never released to npm. So it should be fine.

Keep your fingers cross that circleCI will work once merged in main :D