### PR TITLE
Fix flaky e2e test due to unfinalized message

### DIFF
--- a/docker/arbitrum/arbitrum.sh
+++ b/docker/arbitrum/arbitrum.sh
@@ -84,7 +84,6 @@ create_deployment_config_file() {
 e2e_test() {
     l2_rpc=http://0.0.0.0:8547
     password=""
-    relayer=${ROOT}/relayer/relayer-node18-linux-x64
     l1_messenger=$(cat ${DEPLOYMENT_DIR}/deployment.json | jq -r '.base_chain.ArbitrumL1Messenger.address')
 
     network_config="${CACHE_DIR}/localnetwork.json"
@@ -95,15 +94,8 @@ e2e_test() {
     e2e_test_fill ${DEPLOYMENT_DIR} ${KEYFILE} "${password}" $l2_rpc
 
     export ARBITRUM_L1_MESSENGER=$l1_messenger
-    echo Starting relayer...
-    ${relayer} --l1-rpc-url http://0.0.0.0:8545 \
-               --l2-relay-to-rpc-url $l2_rpc \
-               --l2-relay-from-rpc-url $l2_rpc \
-               --network-to $network_config \
-               --network-from $network_config \
-               --wallet-private-key $PRIVKEY \
-               --l2-transaction-hash $e2e_test_l2_txhash
 
+    e2e_test_relayer http://0.0.0.0:8545 $l2_rpc $network_config $PRIVKEY $e2e_test_l2_txhash
     e2e_test_verify ${DEPLOYMENT_DIR} $l2_rpc $ADDRESS $e2e_test_request_id
 }
 

--- a/docker/ethereum/ethereum.sh
+++ b/docker/ethereum/ethereum.sh
@@ -33,19 +33,13 @@ up() {
 e2e_test() {
     l2_rpc=http://0.0.0.0:8545
     password=""
-    relayer=${ROOT}/relayer/relayer-node18-linux-x64
     l2_messenger=$(cat ${DEPLOYMENT_DIR}/deployment.json | jq -r '.chains."1337".EthereumL2Messenger.address')
 
     e2e_test_fill ${DEPLOYMENT_DIR} ${KEYFILE} "${password}" $l2_rpc
 
     export ETHEREUM_L2_MESSENGER=$l2_messenger
-    echo Starting relayer...
-    ${relayer} --l1-rpc-url http://0.0.0.0:8545 \
-               --l2-relay-to-rpc-url $l2_rpc \
-               --l2-relay-from-rpc-url $l2_rpc \
-               --wallet-private-key $PRIVKEY \
-               --l2-transaction-hash $e2e_test_l2_txhash
 
+    e2e_test_relayer $l2_rpc $l2_rpc "" $PRIVKEY $e2e_test_l2_txhash
     e2e_test_verify ${DEPLOYMENT_DIR} $l2_rpc $ADDRESS $e2e_test_request_id
 }
 

--- a/docker/optimism/optimism.sh
+++ b/docker/optimism/optimism.sh
@@ -48,19 +48,11 @@ create_deployment_config_file() {
 e2e_test() {
     l2_rpc=http://localhost:8545
     password=""
-    relayer=${ROOT}/relayer/relayer-node18-linux-x64
     contract_addresses="${CACHE_DIR}/addresses.json"
     echo Copying contract addresses to $contract_addresses
     docker exec ops-deployer-1 cat genesis/addresses.json > $contract_addresses
     e2e_test_fill ${DEPLOYMENT_DIR} ${KEYFILE} "${password}" $l2_rpc
-    echo Starting relayer
-    ${relayer} --l1-rpc-url http://localhost:9545 \
-               --l2-relay-to-rpc-url $l2_rpc \
-               --l2-relay-from-rpc-url $l2_rpc \
-               --network-to $contract_addresses \
-               --network-from $contract_addresses \
-               --wallet-private-key $PRIVKEY \
-               --l2-transaction-hash $e2e_test_l2_txhash
+    e2e_test_relayer http://localhost:9545 $l2_rpc $contract_addresses $PRIVKEY $e2e_test_l2_txhash
     e2e_test_verify ${DEPLOYMENT_DIR} $l2_rpc $ADDRESS $e2e_test_request_id
 }
 

--- a/docker/scripts/common.sh
+++ b/docker/scripts/common.sh
@@ -63,6 +63,26 @@ e2e_test_fill() {
     echo Fill tx hash: $e2e_test_l2_txhash
 }
 
+e2e_test_relayer() {
+    local root=$(get_root_dir)
+    local l1_rpc=$1
+    local l2_rpc=$2
+    local network_config=$3
+    local privkey=$4
+    local txhash=$5
+    local relayer=${root}/relayer/relayer-node18-linux-x64
+    
+    echo Starting relayer...
+    timeout 5m bash -c "until ${relayer} --l1-rpc-url '$l1_rpc' \
+                                         --l2-relay-to-rpc-url '$l2_rpc' \
+                                         --l2-relay-from-rpc-url '$l2_rpc' \
+                                         --network-to '$network_config' \
+                                         --network-from '$network_config' \
+                                         --wallet-private-key '$privkey' \
+                                         --l2-transaction-hash '$txhash'; \
+                        do sleep 1s; done"
+}
+
 e2e_test_verify() {
     local root="$(get_root_dir)"
     local deployment_dir=$1


### PR DESCRIPTION
Closes #1805

There might be the case in the e2e tests that a message was not finalized yet and the relayer is already started. To align with the agent, the e2e tests should restart the relayer. For the implementation, I separated the execution of the relayer in a new python script.