### PR TITLE
WIP: Improve events fetching by using websockets

### DIFF
--- a/beamer/events.py
+++ b/beamer/events.py
@@ -334,13 +334,14 @@ class EventFetcher:
                 event_abis=self._event_abis,
             )
 
-    def fetch(self) -> list[Event]:
-        try:
-            block_data = self._web3.eth.get_block("latest")
-        except requests.exceptions.ConnectionError:
-            raise
-        except RequestException:
-            return []
+    def fetch(self, block_data=None) -> list[Event]:
+        if not block_data:
+            try:
+                block_data = self._web3.eth.get_block("latest")
+            except requests.exceptions.ConnectionError:
+                raise
+            except RequestException:
+                return []
 
         block_number = BlockNumber(block_data["number"] - self._confirmation_blocks)
 


### PR DESCRIPTION
This PR is POC of an improve in `EventFetcher` that can significantly reduce Beamer transaction latency and Alchemy billing.

### What's new
* After agent is synced, no more `eth_getBlockByNumber` rpc calles are expected to be called by agent, thanks to the `block_cache` dictionary that is built based on blocks received by websocket
* Instead of polling for new blocks and afterwards fetching Beamer contracts events, we fetch events after a new Beamer contract event showed up on websocket.

### Implementation
* After EventMonitor did the sync, subscribe for new blocks and new events triggered by Beamer contracts in `EventMonitor` thread
* Just after subscription was established, call `self._web3.eth.get_block("latest")` to catch the events that could had been created during creating subscription
* Collect blocks received in subscription and save them in [block_cache](https://github.com/beamer-bridge/beamer/pull/1872/files#diff-5e24f82cac7fc5916c1b86818b6848ce1e2a313b46ff5e225f55c4640eda4dd0R123) which further is used whenever `web3.eth.get_block()` is called.
* Once there is a new event received in subscription, execute the current logic that fetches events within block range.
 
### Why events are not collected from websocket

Current event fetching logic relies on fetching events within given block range. That is hard to achieve while listening on websocket, because we don't know the order of coming events and don't know whenever the event is the last event of a block. 

TODO:

- [ ] Catch IO errors during ws communication
- [ ] Test coverage (in the test run a websocket server in a thread and make agent to communicate to it).

