### PR TITLE
frontend: use node 16.x

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,7 +79,7 @@
     "vitest": "^0.31.0"
   },
   "engines": {
-    "node": ">=16"
+    "node": "16.x"
   },
   "imports": {
     "#contract-factories/*.ts": {


### PR DESCRIPTION
DigitalOcean doesn't support Node.js v18 at this moment and this is a quick workaround to fix the deployment process.