### PR TITLE
Add a new command, 'config read'

### DIFF
--- a/beamer/cli.py
+++ b/beamer/cli.py
@@ -1,6 +1,7 @@
 import click
 
 from beamer.agent import commands as agent_commands
+from beamer.config import commands as config_commands
 from beamer.deploy import commands as deploy_commands
 from beamer.health import commands as health_commands
 
@@ -14,3 +15,4 @@ main.add_command(agent_commands.agent)
 main.add_command(health_commands.monitor)
 main.add_command(deploy_commands.deploy)
 main.add_command(deploy_commands.deploy_base)
+main.add_command(config_commands.config)

--- a/beamer/config/commands.py
+++ b/beamer/config/commands.py
@@ -1,0 +1,131 @@
+from pathlib import Path
+
+import click
+import structlog
+from web3 import Web3
+
+import beamer.contracts
+import beamer.deploy.config
+import beamer.util
+from beamer.config.state import ChainConfig, Configuration, TokenConfig
+from beamer.deploy.artifacts import Deployment
+from beamer.events import (
+    ChainUpdated,
+    Event,
+    EventFetcher,
+    FeesUpdated,
+    LpAdded,
+    LpRemoved,
+    TokenUpdated,
+)
+from beamer.util import get_ERC20_abi, make_web3
+
+log = structlog.get_logger(__name__)
+
+
+def _replay_event(w3: Web3, deployment: Deployment, config: Configuration, event: Event) -> None:
+    assert deployment.chain is not None
+    match event:
+        case ChainUpdated():
+            config.request_manager.chains[event.chain_id] = ChainConfig(
+                finality_period=event.finality_period,
+                target_weight_ppm=event.target_weight_ppm,
+                transfer_cost=event.transfer_cost,
+            )
+
+        case FeesUpdated():
+            config.request_manager.lp_fee_ppm = event.lp_fee_ppm
+            config.request_manager.min_fee_ppm = event.min_fee_ppm
+            config.request_manager.protocol_fee_ppm = event.protocol_fee_ppm
+
+        case TokenUpdated():
+            token = w3.eth.contract(address=event.token_address, abi=get_ERC20_abi())
+            symbol = token.functions.symbol().call()
+            config.request_manager.tokens[symbol] = TokenConfig(
+                transfer_limit=event.transfer_limit, eth_in_token=event.eth_in_token
+            )
+            address = config.token_addresses.get(symbol)
+            if address is None:
+                config.token_addresses[symbol] = event.token_address
+            else:
+                assert address == event.token_address
+
+        case LpAdded():
+            if event.event_address == deployment.chain.contracts["RequestManager"].address:
+                config.request_manager.whitelist.add(event.lp)
+            elif event.event_address == deployment.chain.contracts["FillManager"].address:
+                config.fill_manager.whitelist.add(event.lp)
+            else:
+                raise ValueError(f"event from an unexpected address: {event}")
+
+        case LpRemoved():
+            if event.event_address == deployment.chain.contracts["RequestManager"].address:
+                config.request_manager.whitelist.remove(event.lp)
+            elif event.event_address == deployment.chain.contracts["FillManager"].address:
+                config.fill_manager.whitelist.remove(event.lp)
+            else:
+                raise ValueError(f"event from an unexpected address: {event}")
+
+
+@click.group()
+def config() -> None:
+    pass
+
+
+@config.command("read")
+@click.option(
+    "--rpc-file",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Path to the RPC config file.",
+)
+@click.option(
+    "--abi-dir",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+    required=True,
+    help="Path to the directory with contract ABIs.",
+)
+@click.option(
+    "--artifact",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Path to the deployment artifact.",
+)
+@click.argument("state_path", type=click.Path(file_okay=True, dir_okay=False, path_type=Path))
+def read(
+    rpc_file: Path, abi_dir: Path, artifact: Path, state_path: Path
+) -> None:  # pylint: disable=unused-argument
+    """Read latest contract configuration state from the chain and store it into STATE_PATH."""
+    beamer.util.setup_logging(log_level="DEBUG", log_json=False)
+
+    rpc_info = beamer.deploy.config.load_rpc_info(rpc_file)
+    deployment = Deployment.from_file(artifact)
+
+    assert deployment.chain is not None
+    chain_id = deployment.chain.chain_id
+    url = rpc_info[chain_id]
+    w3 = make_web3(url)
+    assert w3.eth.chain_id == chain_id
+    log.info("Connected to RPC", url=url)
+
+    request_manager = deployment.obtain_contract(w3, "chain", "RequestManager")
+    fill_manager = deployment.obtain_contract(w3, "chain", "FillManager")
+    start_block = min(
+        deployment.chain.contracts["RequestManager"].deployment_block,
+        deployment.chain.contracts["FillManager"].deployment_block,
+    )
+    fetcher = EventFetcher(
+        w3, (request_manager, fill_manager), start_block=start_block, confirmation_blocks=0
+    )
+
+    if state_path.exists():
+        config = Configuration.from_file(state_path)
+    else:
+        config = Configuration.initial(chain_id, start_block)
+
+    events = fetcher.fetch()
+    for event in events:
+        _replay_event(w3, deployment, config, event)
+
+    config.block = fetcher.synced_block
+    config.to_file(state_path)

--- a/beamer/config/state.py
+++ b/beamer/config/state.py
@@ -1,0 +1,135 @@
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Generator
+
+import apischema
+from apischema import schema, validator
+from apischema.metadata import alias
+from apischema.objects import get_alias
+from eth_typing import ChecksumAddress
+from eth_utils import is_checksum_address
+
+from beamer.typing import BlockNumber, ChainId
+
+
+class ValidationError(Exception):
+    def __str__(self) -> str:
+        if self.__cause__ is None:
+            return super().__str__()
+        assert isinstance(self.__cause__, apischema.ValidationError)
+        return "\n".join(map(str, self.__cause__.errors))  # pylint: disable=no-member
+
+
+@dataclass(frozen=True)
+class TokenConfig:
+    transfer_limit: int = field(metadata=schema(min=0))
+    eth_in_token: int = field(metadata=schema(min=0))
+
+
+@dataclass(frozen=True)
+class ChainConfig:
+    finality_period: int = field(metadata=schema(min=1))
+    target_weight_ppm: int = field(metadata=schema(min=0, max=999_999))
+    transfer_cost: int = field(metadata=schema(min=0))
+
+
+@dataclass
+class FillManagerConfig:
+    whitelist: set[ChecksumAddress]
+
+
+@dataclass
+class RequestManagerConfig:
+    min_fee_ppm: int = field(metadata=schema(min=0))
+    lp_fee_ppm: int = field(metadata=schema(min=0, max=999_999))
+    protocol_fee_ppm: int = field(metadata=schema(min=0, max=999_999))
+    chains: dict[ChainId, ChainConfig]
+    tokens: dict[str, TokenConfig]
+    whitelist: set[ChecksumAddress]
+
+
+@dataclass
+class Configuration:
+    block: int = field(metadata=schema(min=1))
+    chain_id: ChainId = field(metadata=schema(min=1))
+    token_addresses: dict[str, ChecksumAddress]
+    request_manager: RequestManagerConfig = field(metadata=alias("RequestManager"))
+    fill_manager: FillManagerConfig = field(metadata=alias("FillManager"))
+
+    def compute_checksum(self) -> str:
+        data = apischema.serialize(self)
+        # We add a newline at the end so that one can easily compute the checksum
+        # using common tools e.g.
+        #
+        #   grep -v checksum state-file | sha256sum
+        #   jq --indent 4 'del(.checksum)' state-file | sha256sum
+        serialized = json.dumps(data, indent=4) + "\n"
+        return hashlib.sha256(serialized.encode("utf-8")).digest().hex()
+
+    @validator
+    def _check_token_addresses(self) -> Generator:
+        for name, address in self.token_addresses.items():
+            if not is_checksum_address(address):
+                loc = get_alias(self).token_addresses, name
+                yield loc, f"expected a checksum address: {address}"
+
+    @validator
+    def _check_tokens(self) -> Generator:
+        # Make sure each token symbol has its entry in token_addresses.
+        for name in self.request_manager.tokens:
+            if name not in self.token_addresses:
+                loc = get_alias(self).token_addresses
+                yield loc, f"missing address for token {name}"
+
+    @staticmethod
+    def initial(chain_id: ChainId, block: BlockNumber) -> "Configuration":
+        fm_config = FillManagerConfig(whitelist=set())
+        rm_config = RequestManagerConfig(
+            min_fee_ppm=0, lp_fee_ppm=0, protocol_fee_ppm=0, chains={}, tokens={}, whitelist=set()
+        )
+        return Configuration(
+            block=block,
+            chain_id=chain_id,
+            token_addresses={},
+            request_manager=rm_config,
+            fill_manager=fm_config,
+        )
+
+    @staticmethod
+    def from_file(path: Path) -> "Configuration":
+        with open(path, "rt") as f:
+            data = json.load(f)
+
+        if "RequestManager" in data:
+            # convert chain ID strings to integers, since the schema expects
+            # integers
+            chains = data["RequestManager"].get("chains")
+            if chains is not None:
+                new_chains = {}
+                for chain_id, value in chains.items():
+                    try:
+                        chain_id = ChainId(int(chain_id))
+                    except ValueError as exc:
+                        raise ValidationError(f"invalid chain ID: {chain_id}") from exc
+                    new_chains[chain_id] = value
+                data["RequestManager"]["chains"] = new_chains
+
+        checksum = data.pop("checksum")
+        try:
+            config = apischema.deserialize(Configuration, data)
+        except apischema.ValidationError as exc:
+            raise ValidationError from exc
+
+        computed_checksum = config.compute_checksum()
+        if checksum != computed_checksum:
+            raise ValidationError(f"checksum mismatch: {checksum} (expected {computed_checksum})")
+        return config
+
+    def to_file(self, artifact: Path) -> None:
+        # Make sure the checksum is added first so it is the first field to appear.
+        # We do that so it is easy to remove it from the JSON output, e.g. by using grep.
+        data = dict(checksum=self.compute_checksum(), **apischema.serialize(self))
+        with open(artifact, "wt") as f:
+            json.dump(data, f, indent=4)

--- a/beamer/deploy/commands.py
+++ b/beamer/deploy/commands.py
@@ -67,13 +67,26 @@ class _ChainIdParam(click.ParamType):
     metavar="DIR",
     help="The directory to store contract deployment artifacts in.",
 )
+@click.option(
+    "--commit-check",
+    type=bool,
+    default=True,
+    show_default=True,
+    help="Whether to check for commit on the remote.",
+)
 @click.argument("chain_id", type=_ChainIdParam())
 def deploy_base(
-    rpc_file: Path, keystore_file: Path, password: str, artifacts_dir: Path, chain_id: ChainId
+    rpc_file: Path,
+    keystore_file: Path,
+    password: str,
+    artifacts_dir: Path,
+    chain_id: ChainId,
+    commit_check: bool,
 ) -> None:
     """Deploy resolver on the base chain."""
     beamer.util.setup_logging(log_level="DEBUG", log_json=False)
-    _ensure_commit_is_on_remote()
+    if commit_check:
+        _ensure_commit_is_on_remote()
 
     artifacts_dir.mkdir(parents=True, exist_ok=True)
 
@@ -132,17 +145,26 @@ def deploy_base(
     required=True,
     type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
 )
+@click.option(
+    "--commit-check",
+    type=bool,
+    default=True,
+    show_default=True,
+    help="Whether to check for commit on the remote.",
+)
 def deploy(
     rpc_file: Path,
     keystore_file: Path,
     password: str,
     artifacts_dir: Path,
     deploy_mintable_token: bool,
+    commit_check: bool,
     **chains: dict,
 ) -> None:
     """Deploy L2 Beamer contracts on the specified chains and set up the trusted call chain."""
     beamer.util.setup_logging(log_level="DEBUG", log_json=False)
-    _ensure_commit_is_on_remote()
+    if commit_check:
+        _ensure_commit_is_on_remote()
 
     rpc_info = beamer.deploy.config.load_rpc_info(rpc_file)
     log.info("Loaded RPC file")

--- a/beamer/tests/agent/test_request.py
+++ b/beamer/tests/agent/test_request.py
@@ -46,6 +46,7 @@ def test_challenge_own_claim(config, request_manager, token, direction):
     claim = Claim(
         ClaimMade(
             event_chain_id=ChainId(ape.chain.chain_id),
+            event_address=to_checksum_address(ADDRESS_ZERO),
             tx_hash=HexBytes(b""),
             claim_id=ClaimId(1),
             request_id=request.id,
@@ -213,6 +214,7 @@ def test_agent_ignores_invalid_fill(_, request_manager, token, agent: Agent, dir
         [
             RequestFilled(
                 event_chain_id=chain_id,
+                event_address=to_checksum_address(ADDRESS_ZERO),
                 tx_hash=HexBytes(b""),
                 request_id=request_id,
                 fill_id=FillId(b"1"),
@@ -232,6 +234,7 @@ def test_agent_ignores_invalid_fill(_, request_manager, token, agent: Agent, dir
         [
             RequestFilled(
                 event_chain_id=chain_id,
+                event_address=to_checksum_address(ADDRESS_ZERO),
                 tx_hash=HexBytes(b""),
                 request_id=request_id,
                 fill_id=FillId(b"1"),
@@ -251,6 +254,7 @@ def test_agent_ignores_invalid_fill(_, request_manager, token, agent: Agent, dir
         [
             RequestFilled(
                 event_chain_id=chain_id,
+                event_address=to_checksum_address(ADDRESS_ZERO),
                 tx_hash=HexBytes(b""),
                 request_id=request_id,
                 fill_id=FillId(b"1"),
@@ -270,6 +274,7 @@ def test_agent_ignores_invalid_fill(_, request_manager, token, agent: Agent, dir
         [
             RequestFilled(
                 event_chain_id=chain_id,
+                event_address=to_checksum_address(ADDRESS_ZERO),
                 tx_hash=HexBytes(b""),
                 request_id=request_id,
                 fill_id=FillId(b"1"),

--- a/beamer/tests/agent/unit/test_handlers.py
+++ b/beamer/tests/agent/unit/test_handlers.py
@@ -3,7 +3,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from eth_typing import BlockNumber, HexStr
+from eth_utils import to_checksum_address
 from hexbytes import HexBytes
+from web3.constants import ADDRESS_ZERO
 from web3.datastructures import AttributeDict
 from web3.types import ChecksumAddress, TxReceipt, Wei
 
@@ -207,6 +209,7 @@ def test_handle_request_resolved():
 
     event = RequestResolved(
         event_chain_id=SOURCE_CHAIN_ID,
+        event_address=to_checksum_address(ADDRESS_ZERO),
         tx_hash=HexBytes(""),
         request_id=request.id,
         filler=filler,

--- a/beamer/tests/agent/unit/test_invalidate.py
+++ b/beamer/tests/agent/unit/test_invalidate.py
@@ -2,7 +2,9 @@ import time
 from unittest.mock import patch
 
 import pytest
+from eth_utils import to_checksum_address
 from hexbytes import HexBytes
+from web3.constants import ADDRESS_ZERO
 
 from beamer.agent.chain import process_claims
 from beamer.agent.state_machine import process_event
@@ -46,6 +48,7 @@ def test_handle_fill_invalidated_resolved():
 
     event = FillInvalidatedResolved(
         event_chain_id=request.source_chain_id,
+        event_address=to_checksum_address(ADDRESS_ZERO),
         tx_hash=HexBytes(""),
         request_id=request.id,
         fill_id=request.fill_id,
@@ -79,6 +82,7 @@ def test_handle_fill_invalidated():
     tx_hash = make_tx_hash()
     event = FillInvalidated(
         event_chain_id=request.target_chain_id,
+        event_address=to_checksum_address(ADDRESS_ZERO),
         tx_hash=tx_hash,
         request_id=request.id,
         fill_id=request.fill_id,

--- a/beamer/tests/agent/unit/utils.py
+++ b/beamer/tests/agent/unit/utils.py
@@ -104,6 +104,7 @@ def make_claim_challenged(
     claim = Claim(
         claim_made=ClaimMade(
             event_chain_id=request.source_chain_id,
+            event_address=to_checksum_address(ADDRESS_ZERO),
             tx_hash=HexBytes(b""),
             claim_id=claim_id,
             request_id=request.id,

--- a/beamer/tests/config/test_read.py
+++ b/beamer/tests/config/test_read.py
@@ -1,0 +1,148 @@
+import json
+import pathlib
+
+from typing import Any
+
+import ape
+import pytest
+from apischema.validation.mock import NonTrivialDependency
+
+import beamer.config.commands
+import beamer.deploy.commands
+from beamer.config.state import Configuration
+from beamer.deploy.artifacts import Deployment
+from beamer.tests.config.util import deploy, run
+
+
+def _read_config_state(rpc_file, artifact, state_path):
+    root = pathlib.Path(__file__).parents[3]
+    run(
+        beamer.config.commands.read,
+        (
+            "--rpc-file",
+            rpc_file,
+            "--abi-dir",
+            f"{root}/contracts/.build/",
+            "--artifact",
+            artifact,
+            str(state_path),
+        ),
+    )
+    return Configuration.from_file(state_path)
+
+
+def test_config_read_request_manager(tmp_path, token, deployer):
+    rpc_file, artifact = deploy(deployer, tmp_path)
+    deployment = Deployment.from_file(artifact)
+    assert deployment.chain is not None
+
+    state_path = tmp_path / "config.state"
+    config = _read_config_state(rpc_file, artifact, state_path)
+    assert config.request_manager.min_fee_ppm == 0
+    assert config.request_manager.lp_fee_ppm == 0
+    assert config.request_manager.protocol_fee_ppm == 0
+    assert not config.request_manager.chains
+    assert not config.request_manager.tokens
+    assert not config.request_manager.whitelist
+    address = deployment.chain.contracts["RequestManager"].address
+    request_manager: Any = ape.project.RequestManager.at(address)  # type: ignore
+
+    # check fee update
+    request_manager.updateFees(1, 2, 3)
+
+    config = _read_config_state(rpc_file, artifact, state_path)
+    assert config.request_manager.min_fee_ppm == 1
+    assert config.request_manager.lp_fee_ppm == 2
+    assert config.request_manager.protocol_fee_ppm == 3
+
+    old_block = config.block
+
+    # check token update
+    request_manager.updateToken(token.address, 4, 5)
+
+    config = _read_config_state(rpc_file, artifact, state_path)
+    assert config.block > old_block
+    assert len(config.request_manager.tokens) == 1
+    symbol = token.symbol()
+    token_config = config.request_manager.tokens[symbol]
+    assert token_config.transfer_limit == 4
+    assert token_config.eth_in_token == 5
+    assert config.token_addresses == {symbol: token.address}
+
+    # check chain update
+    request_manager.updateChain(123, 6, 7, 8)
+
+    config = _read_config_state(rpc_file, artifact, state_path)
+    assert len(config.request_manager.chains) == 1
+    chain_config = config.request_manager.chains[123]
+    assert chain_config.finality_period == 6
+    assert chain_config.transfer_cost == 7
+    assert chain_config.target_weight_ppm == 8
+
+    # check LP addition
+    lp = ape.accounts.test_accounts[0].address
+    request_manager.addAllowedLp(lp)
+
+    config = _read_config_state(rpc_file, artifact, state_path)
+    assert config.request_manager.whitelist == {lp}
+
+    # check LP removal
+    request_manager.removeAllowedLp(lp)
+
+    config = _read_config_state(rpc_file, artifact, state_path)
+    assert not config.request_manager.whitelist
+
+
+def test_config_read_fill_manager(tmp_path, deployer):
+    rpc_file, artifact = deploy(deployer, tmp_path)
+    deployment = Deployment.from_file(artifact)
+    assert deployment.chain is not None
+
+    state_path = tmp_path / "config.state"
+    config = _read_config_state(rpc_file, artifact, state_path)
+    assert not config.fill_manager.whitelist
+    address = deployment.chain.contracts["FillManager"].address
+    fill_manager: Any = ape.project.FillManager.at(address)  # type: ignore
+
+    # check LP addition
+    lp = ape.accounts.test_accounts[0].address
+    fill_manager.addAllowedLp(lp, sender=deployer.address)
+
+    config = _read_config_state(rpc_file, artifact, state_path)
+    assert config.fill_manager.whitelist == {lp}
+
+    # check LP removal
+    fill_manager.removeAllowedLp(lp, sender=deployer.address)
+
+    config = _read_config_state(rpc_file, artifact, state_path)
+    assert not config.fill_manager.whitelist
+
+
+def test_config_read_checksum_mismatch(tmp_path, deployer):
+    rpc_file, artifact = deploy(deployer, tmp_path)
+    deployment = Deployment.from_file(artifact)
+    assert deployment.chain is not None
+
+    address = deployment.chain.contracts["RequestManager"].address
+    request_manager: Any = ape.project.RequestManager.at(address)  # type: ignore
+
+    request_manager.updateFees(1, 2, 3)
+
+    state_path = tmp_path / "config.state"
+    config = _read_config_state(rpc_file, artifact, state_path)
+    path = tmp_path / "temp.state"
+    config.to_file(path)
+
+    # modify the data so the checksum does not match anymore
+    data = json.loads(path.read_text())
+    data["RequestManager"]["min_lp_fee"] = 9
+    path.write_text(json.dumps(data))
+
+    # TODO: due to a presumed bug in apischema, we cannot do
+    #
+    #  match = r"checksum mismatch: [0-9a-f]+ \(expected [0-9a-f]+\)"
+    #  with pytest.raises(ValidationError, match=match):
+    #
+    # because apischema will raise NonTrivialDependency.
+    with pytest.raises(NonTrivialDependency):
+        Configuration.from_file(path)

--- a/beamer/tests/config/util.py
+++ b/beamer/tests/config/util.py
@@ -1,0 +1,67 @@
+import json
+import pathlib
+
+import eth_account
+from click.testing import CliRunner
+
+import beamer.deploy.commands
+
+
+def run(*args):
+    runner = CliRunner()
+    result = runner.invoke(*args)
+    assert result.exit_code == 0
+
+
+def _write_keystore_file(path, private_key, password):
+    obj = eth_account.Account.encrypt(private_key, password)
+    path.write_text(json.dumps(obj))
+
+
+def deploy(deployer, destdir):
+    password = "test"
+    keystore_file = destdir / f"{deployer.address}.json"
+    _write_keystore_file(keystore_file, deployer.private_key, password)
+    artifacts_dir = destdir / "artifacts"
+    artifacts_dir.mkdir()
+
+    rpc_file = destdir / "rpc.json"
+    rpc_file.write_text(json.dumps({"1337": "http://localhost:8545"}))
+
+    run(
+        beamer.deploy.commands.deploy_base,
+        (
+            "--rpc-file",
+            rpc_file,
+            "--keystore-file",
+            keystore_file,
+            "--password",
+            password,
+            "--artifacts-dir",
+            artifacts_dir,
+            "--commit-check",
+            "no",
+            "1337",
+        ),
+    )
+
+    root = pathlib.Path(__file__).parents[3]
+    run(
+        beamer.deploy.commands.deploy,
+        (
+            "--rpc-file",
+            rpc_file,
+            "--keystore-file",
+            keystore_file,
+            "--password",
+            password,
+            "--artifacts-dir",
+            artifacts_dir,
+            "--commit-check",
+            "no",
+            f"{root}/deployments/config/local/1337-ethereum.json",
+        ),
+    )
+
+    artifact = f"{artifacts_dir}/1337-Ethereum on ganache L1.deployment.json"
+    return rpc_file, artifact

--- a/beamer/tests/health/conftest.py
+++ b/beamer/tests/health/conftest.py
@@ -98,6 +98,7 @@ def transfer_request():
         block_number=BLOCK_NUMBER,
         tx_hash=HexBytes(b"1"),
         event_chain_id=SOURCE_CHAIN_ID,
+        event_address=to_checksum_address(ADDRESS_ZERO),
         lp_fee=TokenAmount(1),
         protocol_fee=TokenAmount(1),
     )
@@ -108,6 +109,7 @@ def transfer_fill(agent_address):
     return RequestFilled(
         request_id=REQUEST_ID,
         event_chain_id=TARGET_CHAIN_ID,
+        event_address=to_checksum_address(ADDRESS_ZERO),
         fill_id=FillId(b"1"),
         source_chain_id=SOURCE_CHAIN_ID,
         target_token_address=TARGET_TOKEN_ADDRESS,
@@ -127,6 +129,7 @@ def transfer_claim(agent_address):
         claimer=agent_address,
         claimer_stake=CLAIMER_STAKE,
         event_chain_id=TARGET_CHAIN_ID,
+        event_address=to_checksum_address(ADDRESS_ZERO),
         last_challenger=to_checksum_address(ADDRESS_ZERO),
         challenger_stake_total=Wei(0),
         termination=Termination(100),

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -4,6 +4,7 @@ Command reference
 The Beamer software currently supports two commands: 
 
 * :ref:`command-agent` allows to run a Beamer agent.
+* :ref:`command-config-read` reads contract configuration from the chain.
 * :ref:`command-health-check` analyzes the Beamer protocol and agent activity.
 
 .. _command-agent:
@@ -65,6 +66,34 @@ The ``agent`` command will run a Beamer agent and provide liquidity for the brid
      - Time in seconds which is waited before new events are fetched from the chains after 
        the last fetch. If a value for a specific chain is provided in the config file, it 
        takes precedence for this chain. Default: ``5.0``.
+
+
+.. _command-config-read:
+
+``beamer config read``
+^^^^^^^^^^^^^^^^^^^^^^
+
+``beamer config read --rpc-file RPC-FILE --abi-dir DIR --artifact CHAIN-NAME.deployment.json STATE_PATH``
+
+The command reads the latest contract configuration state from the chain and
+store it into ``STATE_PATH``. If ``STATE_PATH`` already exists, it is used as
+the starting point to fetch contract events from. Otherwise, contracts events
+are fetched from the deployment block.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Command-line option
+     - Description
+
+   * - ``--abi-dir DIR``
+     - The directory containing contract ABI files.
+
+   * - ``--artifact CHAIN-NAME.deployment.json``
+     - Path to the deployment artifact.
+
+   * - ``--rpc-file``
+     - Path to the JSON file containing RPC information.
 
 
 .. _command-health-check:


### PR DESCRIPTION
This PR does a few preparatory steps first (add a way to skip commit checks when deploying, add address field to events) and then adds the implementation of the new `config read` command. Finally, several tests are made that exercise 
- reading state from contract deployment
- reading state starting from an already existing state
- reading state that has a mismatched checksum

There is one `TODO` item in the test code, namely, in the test for checksum mismatch. We can't test this properly now due to a presumed `apischema` bug. That will be investigated independently of this PR and once a fix is found, we will update the code marked by `TODO`.

Closes: #1831 