### PR TITLE
npm: use generate script for goerli artifacts

### DIFF
--- a/deployments-npm-package/scripts/create-package.sh
+++ b/deployments-npm-package/scripts/create-package.sh
@@ -7,6 +7,6 @@ mkdir -p dist/artifacts
 cp -r ../deployments/artifacts/. dist/artifacts
 
 python ../scripts/generate-abi.py --only-abi ../deployments/artifacts/mainnet dist/abis/mainnet
-cp ../deployments/goerli/*.* dist/abis/goerli
+python ../scripts/generate-abi.py --only-abi ../deployments/artifacts/goerli dist/abis/goerli
 
 git rev-parse HEAD > git-commit-version.txt


### PR DESCRIPTION
Since we fixed the incorrect commit hash issue with the goerli artifacts (by redeploying on goerli) we can now re-enable the abi generation in the npm package.