### PR TITLE
.circleci: update container image workflow deps

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -589,9 +589,11 @@ workflows:
             - create-relayers
       - build-and-publish-container-image:
           requires:
-            - install-python
-            - create-relayers
             - test-relayer
+            - e2e-test-ethereum
+            - e2e-test-optimism
+            - e2e-test-arbitrum
+            - e2e-test-polygon-zkevm
 
   frontend-deployment:
     unless: 


### PR DESCRIPTION
Fixes the incorrect dependency definitions of the `build-and-publish-container-image` job inside the `relayer` workflow. 

The current definition of the `relayer` workflow results in the following flow: https://app.circleci.com/pipelines/github/beamer-bridge/beamer/3132/workflows/2b23d0ef-783f-422e-9447-b0439830029c

It should instead be looking like: https://app.circleci.com/pipelines/github/beamer-bridge/beamer/3127/workflows/c7c203e2-d67d-454d-8db8-b116bd0b4558