### PR TITLE
Relayer: Recover l1 transaction hash in Arbitrum relayer service

### DIFF
--- a/docker/arbitrum/arbitrum.sh
+++ b/docker/arbitrum/arbitrum.sh
@@ -111,6 +111,7 @@ e2e_test() {
     l2_rpc=http://0.0.0.0:8547
     password=""
     l1_messenger=$(jq -r '.base.ArbitrumL1Messenger.address' ${ARTIFACTS_DIR}/412346-arbitrum.deployment.json)
+    resolver=$(jq -r '.base.Resolver.address' ${ARTIFACTS_DIR}/base.deployment.json)
 
     network_config="${CACHE_DIR}/localnetwork.json"
     echo Copying network config to $network_config
@@ -120,6 +121,7 @@ e2e_test() {
     e2e_test_fill $ARTIFACTS_DIR $l2_rpc $KEYFILE "${password}"
 
     export ARBITRUM_L1_MESSENGER=$l1_messenger
+    export RESOLVER=$resolver
 
     e2e_test_relayer http://0.0.0.0:8545 $l2_rpc $network_config $PRIVKEY $e2e_test_l2_txhash
     e2e_test_verify $ARTIFACTS_DIR $l2_rpc $ADDRESS $e2e_test_request_id

--- a/docker/ethereum/ethereum.sh
+++ b/docker/ethereum/ethereum.sh
@@ -32,8 +32,11 @@ e2e_test() {
     l2_rpc=http://0.0.0.0:8545
     password=""
     l2_messenger=$(jq -r '.chain.EthereumL2Messenger.address' ${ARTIFACTS_DIR}/1337-ethereum.deployment.json)
+    resolver=$(jq -r '.base.Resolver.address' ${ARTIFACTS_DIR}/base.deployment.json)
     e2e_test_fill $ARTIFACTS_DIR $l2_rpc $KEYFILE "${password}" 
+
     export ETHEREUM_L2_MESSENGER=$l2_messenger
+    export RESOLVER=$resolver
 
     e2e_test_relayer $l2_rpc $l2_rpc "" $PRIVKEY $e2e_test_l2_txhash
     e2e_test_verify $ARTIFACTS_DIR $l2_rpc $ADDRESS $e2e_test_request_id

--- a/relayer/package.json
+++ b/relayer/package.json
@@ -14,8 +14,11 @@
   "scripts": {
     "build": "tsc",
     "start": "node -r ./node_modules/ts-node/register ./src/cli.ts",
-    "lint": "eslint --ext .js,.ts --ignore-path .gitignore --max-warnings 0 .",
-    "lint:fix": "eslint --ext .js,.ts --ignore-path .gitignore --fix .",
+    "check-types": "tsc --noEmit",
+    "eslint": "eslint --ext .js,.ts --ignore-path .gitignore --max-warnings 0 .",
+    "eslint:fix": "eslint --ext .js,.ts --ignore-path .gitignore --fix .",
+    "lint": "yarn check-types && yarn eslint",
+    "lint:fix": "yarn check-types; yarn eslint:fix",
     "test:unit": "jest unit",
     "test:coverage": "jest --collect-coverage",
     "generate-types": "typechain --target=ethers-v5 ./src/assets/abi/**.json --out-dir=./types-gen/contracts/",

--- a/relayer/src/cli/programs/prove-op-message.ts
+++ b/relayer/src/cli/programs/prove-op-message.ts
@@ -16,7 +16,7 @@ export class OPMessageProverProgram {
   ) {}
 
   static validateArgs(args: ProgramOptions): Array<string> {
-    const validationErrors = [];
+    const validationErrors: string[] = [];
 
     if (!args.l2TransactionHash.startsWith("0x") || args.l2TransactionHash.trim().length != 66) {
       validationErrors.push(

--- a/relayer/src/cli/programs/relay.ts
+++ b/relayer/src/cli/programs/relay.ts
@@ -64,18 +64,20 @@ export class RelayerProgram {
     );
     let l1TransactionHash: string;
 
-    if (relayStepCompleted === false) {
+    if (relayStepCompleted) {
+      l1TransactionHash = await this.l2RelayerFrom.relayTxToL1Step.recoverL1TransactionHash(
+        this.l2TransactionHash,
+      );
+    } else {
       if (this.l2RelayerTo.prepareStep) {
         const prepareStepCompleted = await this.l2RelayerTo.prepareStep.isCompleted();
 
-        if (prepareStepCompleted === false) {
+        if (!prepareStepCompleted) {
           await this.l2RelayerTo.prepareStep.execute();
         }
       }
 
       l1TransactionHash = await this.l2RelayerFrom.relayTxToL1Step.execute(this.l2TransactionHash);
-    } else {
-      l1TransactionHash = relayStepCompleted;
     }
 
     if (this.l2RelayerTo.finalizeStep) {
@@ -83,7 +85,7 @@ export class RelayerProgram {
         l1TransactionHash,
       );
 
-      if (finalizeStepCompleted === false) {
+      if (!finalizeStepCompleted) {
         await this.l2RelayerTo.finalizeStep.execute(l1TransactionHash);
       }
     }

--- a/relayer/src/cli/programs/relay.ts
+++ b/relayer/src/cli/programs/relay.ts
@@ -20,7 +20,7 @@ export class RelayerProgram {
   ) {}
 
   static validateArgs(args: ProgramOptions): Array<string> {
-    const validationErrors = [];
+    const validationErrors: string[] = [];
 
     if (!args.l2TransactionHash.startsWith("0x") || args.l2TransactionHash.trim().length != 66) {
       validationErrors.push(

--- a/relayer/src/services/relayer/arbitrum.ts
+++ b/relayer/src/services/relayer/arbitrum.ts
@@ -1,4 +1,9 @@
-import type { L1Network, L2Network } from "@arbitrum/sdk";
+import type {
+  L1Network,
+  L1ToL2MessageWriter,
+  L2Network,
+  L2ToL1MessageWriter,
+} from "@arbitrum/sdk";
 import {
   addCustomNetwork,
   L1ToL2MessageGasEstimator,
@@ -11,9 +16,10 @@ import type { Signer } from "@ethersproject/abstract-signer";
 import { BigNumber } from "ethers";
 import { readFileSync } from "fs";
 
+import type { ArbitrumL1Messenger } from "../../../types-gen/contracts";
 import { ArbitrumL1Messenger__factory } from "../../../types-gen/contracts";
 import type { TransactionHash } from "../types";
-import { BaseRelayerService } from "../types";
+import { BaseRelayerService, FinalizeStep, PrepareStep, RelayStep } from "../types";
 
 const L1_CONTRACTS: Record<number, { ARBITRUM_L1_MESSENGER: string }> = {
   42161: {
@@ -30,61 +36,87 @@ const L1_CONTRACTS: Record<number, { ARBITRUM_L1_MESSENGER: string }> = {
 export class ArbitrumRelayerService extends BaseRelayerService {
   static readonly MAX_MESSAGE_LENGTH_BYTES = 5_000;
 
-  async prepare(): Promise<boolean> {
-    console.log("Preparing Arbitrum Messenger for forwarding the L1 message...");
+  prepareStep = new PrepareStep(
+    async () => await this.prepare(),
+    async () => await this.isPrepareCompleted(),
+  );
+  relayTxToL1Step = new RelayStep(
+    async (l2TransactionHash) => await this.relayTxToL1(l2TransactionHash),
+    async (l2TransactionHash) => await this.isRelayCompleted(l2TransactionHash),
+  );
+  finalizeStep = new FinalizeStep(
+    async (l1TransactionHash) => await this.finalize(l1TransactionHash),
+    async (l1TransactionHash) => await this.isFinalizeCompleted(l1TransactionHash),
+  );
 
-    const arbitrumMessengerAddress = L1_CONTRACTS[await this.getL2ChainId()].ARBITRUM_L1_MESSENGER;
+  private arbitrumL1Messenger: ArbitrumL1Messenger;
 
-    const arbitrumL1Messenger = ArbitrumL1Messenger__factory.connect(
+  constructor(...args: ConstructorParameters<typeof BaseRelayerService>) {
+    super(...args);
+
+    const arbitrumMessengerAddress = L1_CONTRACTS[this.l2ChainId].ARBITRUM_L1_MESSENGER;
+    this.arbitrumL1Messenger = ArbitrumL1Messenger__factory.connect(
       arbitrumMessengerAddress,
       this.l1Wallet,
     );
+  }
 
-    const currentDeposit: BigNumber = await arbitrumL1Messenger.deposits(this.l1Wallet.address);
+  private async getDeltaSubmissionFee(): Promise<BigNumber> {
     const l1ToL2MessageGasEstimate = new L1ToL2MessageGasEstimator(this.l2RpcProvider);
-
     const submissionFee = await l1ToL2MessageGasEstimate.estimateSubmissionFee(
       this.l1RpcProvider,
       BigNumber.from(0),
       BigNumber.from(ArbitrumRelayerService.MAX_MESSAGE_LENGTH_BYTES),
     );
-
     const deltaSubmissionFee = submissionFee.mul(110).div(100); // We add 10% on top to ensure that the creation of a retryable ticket doesn't fail
 
-    if (currentDeposit.lte(deltaSubmissionFee)) {
-      // ArbitrumL1Messenger refunds the rest of the deposit automatically
-      // after relaying a message by calling `ArbitrumL1Messenger.sendMessage`.
-      const estimatedGasLimit = await arbitrumL1Messenger.estimateGas.deposit({
-        value: deltaSubmissionFee,
-      });
-
-      const transaction = await arbitrumL1Messenger.deposit({
-        gasLimit: estimatedGasLimit,
-        value: deltaSubmissionFee,
-      });
-
-      await transaction.wait();
-
-      const receipt = await arbitrumL1Messenger.provider.waitForTransaction(transaction.hash, 1);
-
-      if (receipt && receipt.status) {
-        console.log(
-          `Successfully deposited funds on ArbitrumL1Messenger: ${receipt.transactionHash}`,
-        );
-        return true;
-      } else {
-        throw new Error("Arbitrum L1 deposit transaction reverted on chain.");
-      }
-    } else {
-      console.log("ArbitrumL1Messenger has enough funds to proceed!");
-    }
-
-    return true;
+    return deltaSubmissionFee;
   }
 
-  async relayTxToL1(l2TransactionHash: TransactionHash): Promise<string | undefined> {
-    console.log("Arbitrum outbox execution");
+  private async isPrepareCompleted(): Promise<void | false> {
+    const deltaSubmissionFee = await this.getDeltaSubmissionFee();
 
+    const currentDeposit: BigNumber = await this.arbitrumL1Messenger.deposits(
+      this.l1Wallet.address,
+    );
+
+    if (currentDeposit.lte(deltaSubmissionFee)) {
+      return false;
+    }
+    console.log("ArbitrumL1Messenger has enough funds to proceed!");
+  }
+
+  private async prepare(): Promise<void> {
+    const deltaSubmissionFee = await this.getDeltaSubmissionFee();
+
+    console.log("Preparing Arbitrum Messenger for forwarding the L1 message...");
+
+    // ArbitrumL1Messenger refunds the rest of the deposit automatically
+    // after relaying a message by calling `ArbitrumL1Messenger.sendMessage`.
+    const estimatedGasLimit = await this.arbitrumL1Messenger.estimateGas.deposit({
+      value: deltaSubmissionFee,
+    });
+
+    const transaction = await this.arbitrumL1Messenger.deposit({
+      gasLimit: estimatedGasLimit,
+      value: deltaSubmissionFee,
+    });
+
+    const receipt = await transaction.wait(1);
+
+    if (receipt && receipt.status) {
+      console.log(
+        `Successfully deposited funds on ArbitrumL1Messenger: ${receipt.transactionHash}`,
+      );
+      return;
+    } else {
+      throw new Error("Arbitrum L1 deposit transaction reverted on chain.");
+    }
+  }
+
+  private async getL2ToL1Message(
+    l2TransactionHash: TransactionHash,
+  ): Promise<L2ToL1MessageWriter> {
     /**
      * First, let's find the Arbitrum txn from the txn hash provided
      */
@@ -95,34 +127,51 @@ export class ArbitrumRelayerService extends BaseRelayerService {
     const l2Receipt = new L2TransactionReceipt(receipt);
 
     /**
-     * Note that in principle, a single transaction could trigger any number of outgoing messages; the common case will be there's only one.
-     * For the sake of this script, we assume there's only one / just grab the first one.
+     * Note that in principle, a single transaction could trigger any number of outgoing messages;
+     * The common case for beamer however, will be only 1 message per transaction.
      */
     const messages = await l2Receipt.getL2ToL1Messages<Signer>(this.l1Wallet);
     const l2ToL1Msg = messages[0];
+    return l2ToL1Msg;
+  }
+
+  private async isRelayCompleted(
+    l2TransactionHash: TransactionHash,
+  ): Promise<TransactionHash | false> {
+    const l2ToL1Message = await this.getL2ToL1Message(l2TransactionHash);
 
     /**
      * Check if already executed
      */
-    if ((await l2ToL1Msg.status(this.l2RpcProvider)) == L2ToL1MessageStatus.EXECUTED) {
+    if ((await l2ToL1Message.status(this.l2RpcProvider)) == L2ToL1MessageStatus.EXECUTED) {
       console.log("Message already executed! Nothing else to do here.");
-      return;
+      // TODO IMPORTANT: return l1 transaction hash
+      // I think it is not possible to get it via the SDK.
+      // Maybe we have to use the contracts directly to get it.
+      return "";
     }
+    return false;
+  }
+
+  private async relayTxToL1(l2TransactionHash: TransactionHash): Promise<string> {
+    console.log("Arbitrum outbox execution");
+    const l2ToL1Message = await this.getL2ToL1Message(l2TransactionHash);
 
     /**
-     * before we try to execute out message, we need to make sure the l2 block it's included in is confirmed! (It can only be confirmed after the dispute period; Arbitrum is an optimistic rollup after-all)
+     * before we try to execute out message, we need to make sure the l2 block it's included in is confirmed!
+     * (It can only be confirmed after the dispute period; Arbitrum is an optimistic rollup after-all)
      * waitUntilReadyToExecute() waits until the item outbox entry exists
      */
     const timeToWaitMs = 1000 * 60;
     console.log("Waiting for outbox entry to show up...");
-    await l2ToL1Msg.waitUntilReadyToExecute(this.l2RpcProvider, timeToWaitMs);
+    await l2ToL1Message.waitUntilReadyToExecute(this.l2RpcProvider, timeToWaitMs);
 
     /**
      * Now that its confirmed and not executed, we can execute our message in its outbox entry.
      */
     console.log("Outbox entry found! Executing it...");
 
-    const l1Transaction = await l2ToL1Msg.execute(this.l2RpcProvider);
+    const l1Transaction = await l2ToL1Message.execute(this.l2RpcProvider);
     const l1Receipt = await l1Transaction.wait();
 
     console.log("Done! Your transaction is executed ", l1Receipt.transactionHash);
@@ -130,8 +179,9 @@ export class ArbitrumRelayerService extends BaseRelayerService {
     return l1Receipt.transactionHash;
   }
 
-  async finalize(l1TransactionHash: string): Promise<void> {
-    console.log("Finalizing message travelling to Arbitrum.");
+  private async getL1ToL2Message(
+    l1TransactionHash: TransactionHash,
+  ): Promise<L1ToL2MessageWriter> {
     const l1TransactionReceipt = await this.l1RpcProvider.getTransactionReceipt(l1TransactionHash);
     if (!l1TransactionReceipt) {
       throw new Error(`Transaction "${l1TransactionHash}" cannot be found on L1...`);
@@ -145,24 +195,36 @@ export class ArbitrumRelayerService extends BaseRelayerService {
     const wrappedL1TransactionReceipt = new L1TransactionReceipt(l1TransactionReceipt);
     const messages = await wrappedL1TransactionReceipt.getL1ToL2Messages(this.l2Wallet);
     const message = messages[0];
+    return message;
+  }
+
+  private async isFinalizeCompleted(l1TransactionHash: string): Promise<void | false> {
+    const l1ToL2Message = await this.getL1ToL2Message(l1TransactionHash);
 
     console.log("Waiting for L2 side. It may take 10-15 minutes ⏰⏰");
-    const messageResult = await message.waitForStatus();
+    const messageResult = await l1ToL2Message.waitForStatus();
 
     const status = messageResult.status;
     if (status === L1ToL2MessageStatus.REDEEMED) {
       console.log(`L2 retryable txn executed ${messageResult.l2TxReceipt.transactionHash}`);
       return;
-    } else {
-      console.log(`L2 retryable txn failed with status ${L1ToL2MessageStatus[status]}`);
-      /**
-       * We use the redeem() method from Arbitrum SDK to manually redeem our ticket
-       */
-      console.log("Redeeming the ticket now...");
-      const l2Tx = await message.redeem();
-      const rec = await l2Tx.waitForRedeem();
-      console.log("The L2 side of your transaction is now executed:", await rec.transactionHash);
     }
+    console.log(`L2 retryable txn failed with status ${L1ToL2MessageStatus[status]}`);
+    return false;
+  }
+
+  private async finalize(l1TransactionHash: string): Promise<void> {
+    const l1ToL2Message = await this.getL1ToL2Message(l1TransactionHash);
+
+    console.log("Finalizing message travelling to Arbitrum.");
+
+    /**
+     * We use the redeem() method from Arbitrum SDK to manually redeem our ticket
+     */
+    console.log("Redeeming the ticket now...");
+    const l2Tx = await l1ToL2Message.redeem();
+    const rec = await l2Tx.waitForRedeem();
+    console.log("The L2 side of your transaction is now executed:", await rec.transactionHash);
 
     return;
   }

--- a/relayer/src/services/relayer/boba.ts
+++ b/relayer/src/services/relayer/boba.ts
@@ -70,7 +70,7 @@ export class BobaRelayerService extends BaseRelayerService {
     try {
       await messenger.finalizeMessage(message);
     } catch (err) {
-      if (!err.message.includes("message has already been received.")) {
+      if (!(err instanceof Error && err.message.includes("message has already been received."))) {
         throw err;
       } // Otherwise the message was relayed by someone else
     }

--- a/relayer/src/services/relayer/ethereum.ts
+++ b/relayer/src/services/relayer/ethereum.ts
@@ -3,38 +3,20 @@ import { keccak256 } from "ethers/lib/utils";
 
 import type { EthereumL2Messenger } from "../../../types-gen/contracts";
 import { EthereumL2Messenger__factory, Resolver__factory } from "../../../types-gen/contracts";
-import type { TypedEvent, TypedEventFilter } from "../../../types-gen/contracts/common";
-import { parseFillInvalidatedEvent } from "../../common/events/FillInvalidated";
-import { parseRequestFilledEvent } from "../../common/events/RequestFilled";
 import type { TransactionHash } from "../types";
 import { BaseRelayerService, RelayStep } from "../types";
 
-type RelayCallParams = {
-  requestId: string;
-  fillId: string;
-  sourceChainId: BigNumber;
-  filler: string;
-};
-
-const L1_CONTRACTS: Record<
-  number,
-  { ETHEREUM_L2_MESSENGER: string; RESOLVER_DEPLOY_BLOCK_NUMBER: number }
-> = {
+const L1_CONTRACTS: Record<number, { ETHEREUM_L2_MESSENGER: string }> = {
   1: {
     ETHEREUM_L2_MESSENGER: "0x3222C9a1e5d7856FCBc551A30a63634e7Fd634Da",
-    RESOLVER_DEPLOY_BLOCK_NUMBER: 16946576,
   },
   5: {
     ETHEREUM_L2_MESSENGER: "0x6064A4d69D6535981F1091Fa2243d9a106046e46",
-    RESOLVER_DEPLOY_BLOCK_NUMBER: 9066315,
   },
   1337: {
     ETHEREUM_L2_MESSENGER: process.env.ETHEREUM_L2_MESSENGER || "",
-    RESOLVER_DEPLOY_BLOCK_NUMBER: 0,
   },
 };
-
-const FILTER_BLOCKS_PER_ITERATION = 5000;
 
 export class EthereumRelayerService extends BaseRelayerService {
   prepareStep = undefined;
@@ -51,81 +33,6 @@ export class EthereumRelayerService extends BaseRelayerService {
 
     const ethereumMessengerAddress = L1_CONTRACTS[this.l2ChainId].ETHEREUM_L2_MESSENGER;
     this.messenger = EthereumL2Messenger__factory.connect(ethereumMessengerAddress, this.l2Wallet);
-  }
-
-  async parseEventDataFromTxHash(
-    l1TransactionHash: TransactionHash,
-  ): Promise<RelayCallParams | null> {
-    const receipt = await this.l2RpcProvider.getTransactionReceipt(l1TransactionHash);
-
-    if (!receipt) {
-      throw new Error(`Transaction "${l1TransactionHash}" cannot be found on Ethereum...`);
-    }
-
-    const requestFilledEvent = parseRequestFilledEvent(receipt.logs);
-
-    if (requestFilledEvent) {
-      return {
-        requestId: requestFilledEvent.requestId,
-        fillId: requestFilledEvent.fillId,
-        sourceChainId: requestFilledEvent.sourceChainId,
-        filler: requestFilledEvent.filler,
-      };
-    }
-
-    const fillInvalidatedEvent = parseFillInvalidatedEvent(receipt.logs);
-
-    if (fillInvalidatedEvent && this.destinationChainId) {
-      return {
-        ...fillInvalidatedEvent,
-        sourceChainId: BigNumber.from(this.destinationChainId),
-        filler: "0x0000000000000000000000000000000000000000",
-      };
-    }
-
-    return null;
-  }
-
-  private async findTransactionHashForMessage(
-    requestId: string,
-    fillId: string,
-    sourceChainId: BigNumber,
-    filler: string,
-    fillChainId: BigNumber,
-    resolverAddress: string,
-  ): Promise<string | undefined> {
-    const resolver = Resolver__factory.connect(resolverAddress, this.l1Wallet);
-    const currentBlock = await this.l1Wallet.provider.getBlock("latest");
-    const resolverDeployBlockNumber = L1_CONTRACTS[this.l1ChainId].RESOLVER_DEPLOY_BLOCK_NUMBER;
-    let currentBlockNumber = currentBlock.number;
-
-    while (currentBlockNumber > resolverDeployBlockNumber) {
-      const events = await resolver.queryFilter(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        "Resolution" as TypedEventFilter<TypedEvent<any, any>>,
-        currentBlockNumber - FILTER_BLOCKS_PER_ITERATION,
-        currentBlockNumber,
-      );
-
-      for (const event of events) {
-        if (event.event === "Resolution") {
-          const args = event.args;
-
-          if (
-            sourceChainId.eq(args.sourceChainId) &&
-            fillChainId.eq(args.fillChainId) &&
-            args.requestId === requestId &&
-            args.filler === filler &&
-            args.fillId === fillId
-          ) {
-            return event.transactionHash;
-          }
-        }
-      }
-      currentBlockNumber -= FILTER_BLOCKS_PER_ITERATION;
-    }
-
-    return undefined;
   }
 
   private createMessageHash(
@@ -147,20 +54,10 @@ export class EthereumRelayerService extends BaseRelayerService {
     return keccak256(encodedCall);
   }
 
-  private async getCallParameters(l1TransactionHash: TransactionHash): Promise<RelayCallParams> {
-    const callParameters = await this.parseEventDataFromTxHash(l1TransactionHash);
-    if (!callParameters) {
-      throw new Error(
-        "Couldn't find a matching event (RequestFilled | FillInvalidated) in the transaction logs.",
-      );
-    }
-    return callParameters;
-  }
-
   private async isRelayCompleted(
     l1TransactionHash: TransactionHash,
   ): Promise<TransactionHash | false> {
-    const callParameters = await this.getCallParameters(l1TransactionHash);
+    const callParameters = await this.parseFillEventDataFromTxHash(l1TransactionHash);
 
     const l2ChainId = await this.getL2ChainId();
     const parameters = [
@@ -177,11 +74,9 @@ export class EthereumRelayerService extends BaseRelayerService {
     if (isMessageRelayed) {
       console.log("Message has already been relayed..");
 
-      const resolverAddress = await this.messenger.resolver();
-      const transactionHash = await this.findTransactionHashForMessage(
+      const transactionHash = await this.findL1TransactionHashForMessage(
         ...parameters,
         BigNumber.from(l2ChainId),
-        resolverAddress,
       );
       if (!transactionHash) {
         throw new Error(
@@ -197,7 +92,7 @@ export class EthereumRelayerService extends BaseRelayerService {
   }
 
   private async relayTxToL1(l1TransactionHash: TransactionHash): Promise<TransactionHash> {
-    const callParameters = await this.getCallParameters(l1TransactionHash);
+    const callParameters = await this.parseFillEventDataFromTxHash(l1TransactionHash);
 
     console.log("Ethereum execution");
 

--- a/relayer/src/services/relayer/optimism.ts
+++ b/relayer/src/services/relayer/optimism.ts
@@ -12,7 +12,8 @@ import { BaseRelayerService } from "../types";
 
 export class OptimismRelayerService extends BaseRelayerService {
   customNetworkContracts: DeepPartial<OEContractsLike> | undefined;
-  messenger: CrossChainMessenger | undefined;
+  messenger: CrossChainMessenger;
+
   /**
    *
    * A static gas limit value high enough to make sure that the message relays
@@ -140,7 +141,7 @@ export class OptimismRelayerService extends BaseRelayerService {
   private async safeRelayMessage(message: CrossChainMessage): Promise<boolean> {
     const withdrawalHash = await this.getMessageWithdrawalHash(message);
     const isWithdrawn = await this.isMessageWithdrawn(withdrawalHash);
-    let tx = null;
+    let tx: TransactionResponse;
 
     if (!isWithdrawn) {
       console.log("Try relaying via Optimism Portal..");

--- a/relayer/src/services/relayer/polygon-zkevm.ts
+++ b/relayer/src/services/relayer/polygon-zkevm.ts
@@ -30,7 +30,7 @@ const CONTRACTS: Record<number, NetworkContracts> = {
 export class PolygonZKEvmRelayerService extends BaseRelayerService {
   MERKLE_PROOF_ENDPOINT = "/merkle-proof";
   BRIDGES_ENDPOINT = "/bridge";
-  customNetworkContracts: NetworkContracts;
+  customNetworkContracts?: NetworkContracts;
 
   async getNetworkConfig(): Promise<NetworkContracts> {
     const l2NetworkId = await this.getL2ChainId();
@@ -40,7 +40,7 @@ export class PolygonZKEvmRelayerService extends BaseRelayerService {
   async getMessageMerkleProof(
     depositCount: number,
     originNetwork: number,
-  ): Promise<MerkleProofResponse | undefined> {
+  ): Promise<MerkleProofResponse> {
     const networkConfig = await this.getNetworkConfig();
 
     const merkleProofUrl = new URL(networkConfig.bridgeServiceUrl + this.MERKLE_PROOF_ENDPOINT);
@@ -66,7 +66,7 @@ export class PolygonZKEvmRelayerService extends BaseRelayerService {
       const response = await this.getMessageInfo(depositCount, originNetwork);
       return response;
     } catch (e) {
-      if (e.message == "not found in the Storage") {
+      if ((e as Error).message && (e as Error).message == "not found in the Storage") {
         await sleep(5000);
         return this.getMessageInfoSafe(depositCount, originNetwork);
       }
@@ -96,9 +96,7 @@ export class PolygonZKEvmRelayerService extends BaseRelayerService {
 
   checkTransactionValidity(transactionReceipt: TransactionReceipt, networkName: string): void {
     if (!transactionReceipt) {
-      throw new Error(
-        `Transaction "${transactionReceipt.transactionHash}" cannot be found on ${networkName}...`,
-      );
+      throw new Error(`Transaction cannot be found on ${networkName}...`);
     }
     if (!transactionReceipt.status) {
       throw new Error(

--- a/relayer/src/services/types.ts
+++ b/relayer/src/services/types.ts
@@ -27,6 +27,10 @@ export abstract class BaseRelayerService {
   readonly l2ChainId: number;
   readonly destinationChainId?: number;
 
+  abstract readonly prepareStep?: PrepareStep;
+  abstract readonly relayTxToL1Step: RelayStep;
+  abstract readonly finalizeStep?: FinalizeStep;
+
   constructor(
     l1RpcURL: string,
     l2RpcURL: string,
@@ -68,8 +72,15 @@ export abstract class BaseRelayerService {
   addCustomNetwork(_filePath: string): void {
     return;
   }
-
-  abstract prepare(): Promise<boolean>;
-  abstract relayTxToL1(l2TransactionHash: TransactionHash): Promise<TransactionHash | undefined>;
-  abstract finalize(l1TransactionHash: TransactionHash): Promise<void>;
 }
+
+abstract class Step<T, U> {
+  constructor(
+    public execute: (arg: T) => Promise<U>,
+    public isCompleted: (arg: T) => Promise<U | false>,
+  ) {}
+}
+
+export class PrepareStep extends Step<void, void> {}
+export class RelayStep extends Step<TransactionHash, TransactionHash> {}
+export class FinalizeStep extends Step<TransactionHash, void> {}

--- a/relayer/src/services/types.ts
+++ b/relayer/src/services/types.ts
@@ -1,7 +1,11 @@
 import type { Provider } from "@ethersproject/providers";
 import { JsonRpcProvider } from "@ethersproject/providers";
-import { Wallet } from "ethers";
+import { BigNumber, Wallet } from "ethers";
 
+import { Resolver__factory } from "../../types-gen/contracts";
+import type { TypedEvent, TypedEventFilter } from "../../types-gen/contracts/common";
+import { parseFillInvalidatedEvent } from "../common/events/FillInvalidated";
+import { parseRequestFilledEvent } from "../common/events/RequestFilled";
 import { ExtendedJsonRpcProvider } from "../ethers/json-rpc-provider";
 import type { ArbitrumRelayerService } from "./relayer/arbitrum";
 import type { BobaRelayerService } from "./relayer/boba";
@@ -17,6 +21,31 @@ export type ExtendedRelayerService =
   | typeof OptimismRelayerService
   | typeof EthereumRelayerService
   | typeof PolygonZKEvmRelayerService;
+
+export type RelayCallParams = {
+  requestId: string;
+  fillId: string;
+  sourceChainId: BigNumber;
+  filler: string;
+};
+
+const L1_CONTRACTS: Record<number, { RESOLVER: string; RESOLVER_DEPLOY_BLOCK_NUMBER: number }> = {
+  1: {
+    RESOLVER: "0xCb60516819a28431233195A8b7E0227C288B61AD",
+    // TODO: import from `deployments` npm package once ready
+    RESOLVER_DEPLOY_BLOCK_NUMBER: 16946576,
+  },
+  5: {
+    RESOLVER: "0xDCBF185279C7D0F2d448cb674d9429323c8120DC",
+    RESOLVER_DEPLOY_BLOCK_NUMBER: 9066315,
+  },
+  1337: {
+    RESOLVER: process.env.RESOLVER || "",
+    RESOLVER_DEPLOY_BLOCK_NUMBER: 0,
+  },
+};
+
+const FILTER_BLOCKS_PER_ITERATION = 5000;
 
 export abstract class BaseRelayerService {
   readonly l1RpcUrl: string;
@@ -71,6 +100,83 @@ export abstract class BaseRelayerService {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   addCustomNetwork(_filePath: string): void {
     return;
+  }
+
+  protected async parseFillEventDataFromTxHash(
+    l2TransactionHash: TransactionHash,
+  ): Promise<RelayCallParams> {
+    const receipt = await this.l2RpcProvider.getTransactionReceipt(l2TransactionHash);
+
+    if (!receipt) {
+      throw new Error(`Transaction "${l2TransactionHash}" cannot be found on Ethereum...`);
+    }
+
+    const requestFilledEvent = parseRequestFilledEvent(receipt.logs);
+
+    if (requestFilledEvent) {
+      return {
+        requestId: requestFilledEvent.requestId,
+        fillId: requestFilledEvent.fillId,
+        sourceChainId: requestFilledEvent.sourceChainId,
+        filler: requestFilledEvent.filler,
+      };
+    }
+
+    const fillInvalidatedEvent = parseFillInvalidatedEvent(receipt.logs);
+
+    if (fillInvalidatedEvent && this.destinationChainId) {
+      return {
+        ...fillInvalidatedEvent,
+        sourceChainId: BigNumber.from(this.destinationChainId),
+        filler: "0x0000000000000000000000000000000000000000",
+      };
+    }
+
+    throw new Error(
+      "Couldn't find a matching event (RequestFilled | FillInvalidated) in the transaction logs.",
+    );
+  }
+
+  protected async findL1TransactionHashForMessage(
+    requestId: string,
+    fillId: string,
+    sourceChainId: BigNumber,
+    filler: string,
+    fillChainId: BigNumber,
+  ): Promise<string | undefined> {
+    const resolverAddress = L1_CONTRACTS[this.l1ChainId].RESOLVER;
+    const resolver = Resolver__factory.connect(resolverAddress, this.l1Wallet);
+    const currentBlock = await this.l1Wallet.provider.getBlock("latest");
+    const resolverDeployBlockNumber = L1_CONTRACTS[this.l1ChainId].RESOLVER_DEPLOY_BLOCK_NUMBER;
+    let currentBlockNumber = currentBlock.number;
+
+    while (currentBlockNumber > resolverDeployBlockNumber) {
+      const events = await resolver.queryFilter(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        "Resolution" as TypedEventFilter<TypedEvent<any, any>>,
+        currentBlockNumber - FILTER_BLOCKS_PER_ITERATION,
+        currentBlockNumber,
+      );
+
+      for (const event of events) {
+        if (event.event === "Resolution") {
+          const args = event.args;
+
+          if (
+            sourceChainId.eq(args.sourceChainId) &&
+            fillChainId.eq(args.fillChainId) &&
+            args.requestId === requestId &&
+            args.filler === filler &&
+            args.fillId === fillId
+          ) {
+            return event.transactionHash;
+          }
+        }
+      }
+      currentBlockNumber -= FILTER_BLOCKS_PER_ITERATION;
+    }
+
+    return undefined;
   }
 }
 

--- a/relayer/src/services/types.ts
+++ b/relayer/src/services/types.ts
@@ -183,10 +183,18 @@ export abstract class BaseRelayerService {
 abstract class Step<T, U> {
   constructor(
     public execute: (arg: T) => Promise<U>,
-    public isCompleted: (arg: T) => Promise<U | false>,
+    public isCompleted: (arg: T) => Promise<boolean>,
   ) {}
 }
 
 export class PrepareStep extends Step<void, void> {}
-export class RelayStep extends Step<TransactionHash, TransactionHash> {}
+export class RelayStep extends Step<TransactionHash, TransactionHash> {
+  constructor(
+    execute: (arg: TransactionHash) => Promise<TransactionHash>,
+    isCompleted: (arg: TransactionHash) => Promise<boolean>,
+    public recoverL1TransactionHash: (arg: TransactionHash) => Promise<TransactionHash>,
+  ) {
+    super(execute, isCompleted);
+  }
+}
 export class FinalizeStep extends Step<TransactionHash, void> {}

--- a/relayer/tests/unit/cli/programs/relay.spec.ts
+++ b/relayer/tests/unit/cli/programs/relay.spec.ts
@@ -136,7 +136,7 @@ describe("RelayerProgram", () => {
         .mockResolvedValue(getRandomTransactionHash());
       jest.spyOn(relayerFrom.relayTxToL1Step, "isCompleted").mockResolvedValue(false);
       jest.spyOn(relayerTo.finalizeStep, "execute").mockResolvedValue();
-      jest.spyOn(relayerTo.finalizeStep, "isCompleted").mockResolvedValue();
+      jest.spyOn(relayerTo.finalizeStep, "isCompleted").mockResolvedValue(true);
 
       await program.run();
 
@@ -163,8 +163,9 @@ describe("RelayerProgram", () => {
       jest
         .spyOn(relayerFrom.relayTxToL1Step, "execute")
         .mockResolvedValue(getRandomTransactionHash());
+      jest.spyOn(relayerFrom.relayTxToL1Step, "isCompleted").mockResolvedValue(true);
       jest
-        .spyOn(relayerFrom.relayTxToL1Step, "isCompleted")
+        .spyOn(relayerFrom.relayTxToL1Step, "recoverL1TransactionHash")
         .mockResolvedValue(getRandomTransactionHash());
       jest.spyOn(relayerTo.finalizeStep, "execute").mockResolvedValue();
       jest.spyOn(relayerTo.finalizeStep, "isCompleted").mockResolvedValue(false);
@@ -173,6 +174,7 @@ describe("RelayerProgram", () => {
 
       expect(relayerTo.prepareStep.execute).not.toHaveBeenCalled();
       expect(relayerFrom.relayTxToL1Step.execute).not.toHaveBeenCalled();
+      expect(relayerFrom.relayTxToL1Step.recoverL1TransactionHash).toHaveBeenCalled();
       expect(relayerTo.finalizeStep.execute).toHaveBeenCalled();
     });
   });

--- a/relayer/tests/unit/ethers/json-rpc-provider.spec.ts
+++ b/relayer/tests/unit/ethers/json-rpc-provider.spec.ts
@@ -54,7 +54,7 @@ describe("ExtendedJsonRpcProvider", () => {
         .spyOn(JsonRpcProvider.prototype, "estimateGas")
         .mockResolvedValue(BigNumber.from(originalGasEstimation));
 
-      const estimatedGas = await rpcProvider.estimateGas(undefined);
+      const estimatedGas = await rpcProvider.estimateGas({});
       expect(estimatedGas.toNumber()).toBe(
         (originalGasEstimation * (100 + bufferSizePercent)) / 100,
       );

--- a/relayer/tests/unit/map.spec.ts
+++ b/relayer/tests/unit/map.spec.ts
@@ -6,28 +6,34 @@ import {
 } from "@/services/relayer";
 import { createRelayer } from "@/services/relayer/map";
 import type { BaseRelayerService } from "@/services/types";
-import { getRandomNumber, getRandomPrivateKey, getRandomUrl } from "~/utils/data_generators";
+import { getRandomPrivateKey, getRandomUrl } from "~/utils/data_generators";
 
 jest.mock("@eth-optimism/sdk");
 
-describe("createRelayer", () => {
-  const testArgs: ConstructorParameters<typeof BaseRelayerService> = [
+function createTestArgs(
+  l1ChainId: number,
+  l2ChainId: number,
+  destinationChainId?: number,
+): ConstructorParameters<typeof BaseRelayerService> {
+  return [
     getRandomUrl("l1"),
     getRandomUrl("l2"),
     getRandomPrivateKey(),
-    getRandomNumber(),
-    getRandomNumber(),
-    getRandomNumber(),
+    l1ChainId,
+    l2ChainId,
+    destinationChainId,
   ];
+}
 
+describe("createRelayer", () => {
   it("maps arbitrum chain ids to an ArbitrumRelayerService", () => {
     const chainId = 42161;
     const goerliChainId = 421613;
     const testnetChainId = 412346;
 
-    const relayer = createRelayer(chainId, testArgs);
-    const goerliRelayer = createRelayer(goerliChainId, testArgs);
-    const testnetRelayer = createRelayer(testnetChainId, testArgs);
+    const relayer = createRelayer(chainId, createTestArgs(1, chainId));
+    const goerliRelayer = createRelayer(goerliChainId, createTestArgs(5, goerliChainId));
+    const testnetRelayer = createRelayer(testnetChainId, createTestArgs(1337, testnetChainId));
 
     expect(relayer instanceof ArbitrumRelayerService).toBe(true);
     expect(goerliRelayer instanceof ArbitrumRelayerService).toBe(true);
@@ -38,8 +44,8 @@ describe("createRelayer", () => {
     const chainId = 288;
     const goerliChainId = 2888;
 
-    const relayer = createRelayer(chainId, testArgs);
-    const goerliRelayer = createRelayer(goerliChainId, testArgs);
+    const relayer = createRelayer(chainId, createTestArgs(1, chainId));
+    const goerliRelayer = createRelayer(goerliChainId, createTestArgs(5, goerliChainId));
 
     expect(relayer instanceof BobaRelayerService).toBe(true);
     expect(goerliRelayer instanceof BobaRelayerService).toBe(true);
@@ -49,8 +55,8 @@ describe("createRelayer", () => {
     const chainId = 10;
     const goerliChainId = 420;
 
-    const relayer = createRelayer(chainId, testArgs);
-    const goerliRelayer = createRelayer(goerliChainId, testArgs);
+    const relayer = createRelayer(chainId, createTestArgs(1, chainId));
+    const goerliRelayer = createRelayer(goerliChainId, createTestArgs(5, goerliChainId));
 
     expect(relayer instanceof OptimismRelayerService).toBe(true);
     expect(goerliRelayer instanceof OptimismRelayerService).toBe(true);
@@ -61,9 +67,9 @@ describe("createRelayer", () => {
     const goerliChainId = 5;
     const localChainId = 1337;
 
-    const relayer = createRelayer(chainId, testArgs);
-    const goerliRelayer = createRelayer(goerliChainId, testArgs);
-    const localChainRelayer = createRelayer(localChainId, testArgs);
+    const relayer = createRelayer(chainId, createTestArgs(1, chainId));
+    const goerliRelayer = createRelayer(goerliChainId, createTestArgs(5, goerliChainId));
+    const localChainRelayer = createRelayer(localChainId, createTestArgs(1337, localChainId));
 
     expect(relayer instanceof EthereumRelayerService).toBe(true);
     expect(goerliRelayer instanceof EthereumRelayerService).toBe(true);
@@ -72,7 +78,7 @@ describe("createRelayer", () => {
 
   it("throws for unknown chain ids", () => {
     const chainId = 9372855;
-    expect(() => createRelayer(chainId, testArgs)).toThrow(
+    expect(() => createRelayer(chainId, createTestArgs(1, chainId))).toThrow(
       `No relayer program found for ${chainId}!`,
     );
   });

--- a/relayer/tsconfig.json
+++ b/relayer/tsconfig.json
@@ -19,7 +19,8 @@
     "paths": {
       "@/*": ["src/*"],
       "~/*": ["tests/*"]
-    }
+    },
+    "strict": true,
   },
   "include": ["src/**/*.ts", "src/**/*.json", "tests/**/*.ts", "types-gen/**/*.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
closes #1911 
closes #1693

I reused the logic for recovering the transaction hash of the Ethereum service. Could actually be used by any chain.