### PR TITLE
relayer: circleCI fails docker compose down

### DIFF
--- a/docker/arbitrum/arbitrum.sh
+++ b/docker/arbitrum/arbitrum.sh
@@ -38,6 +38,13 @@ patch_test_node_script
 
 down() {
     echo "Shutting down the end-to-end environment"
+
+    # First stop the scripts containers, as docker compose down will fail if they are running
+    image_id=$(docker ps --filter "ancestor=nitro-testnode-scripts" --format "{{.ID}}")
+    if [[ ! -z $image_id ]]; then
+        docker stop $image_id
+    fi
+
     docker-compose -f ${NITRO}/docker-compose.yaml down
 }
 


### PR DESCRIPTION
For some reason docker fails to stop to complete succesfully on circleCI. The nitro_default network is not being deleted since there is a container that relies on it, but is not being removed first.