### PR TITLE
frontend: Allow Matomo cookie inside iframe

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -47,6 +47,7 @@
     <!-- Matomo -->
     <script>
       var _paq = (window._paq = window._paq || []);
+      _paq.push(['setCookieSameSite', 'None']);
       /* require user tracking consent before processing data */
       _paq.push(['requireConsent']);
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,7 +61,7 @@
           g = d.createElement('script'),
           s = d.getElementsByTagName('script')[0];
         g.async = true;
-        g.src = '//cdn.matomo.cloud/beamerbridge.matomo.cloud/matomo.js';
+        g.src = 'https://cdn.matomo.cloud/beamerbridge.matomo.cloud/matomo.js';
         s.parentNode.insertBefore(g, s);
       })();
     </script>


### PR DESCRIPTION
Closes #1935 

When the Beamer app is loaded in an iframe (this is for example the case with Safe), Matomo's `setCookieSameSite` must be set to `None` in order to use the consent cookie.

Inform the Safe team in the issue once this is merged.