### PR TITLE
Commands improvements

### DIFF
--- a/beamer/config/commands.py
+++ b/beamer/config/commands.py
@@ -124,6 +124,13 @@ def read(
 
     if state_path.exists():
         config = Configuration.from_file(state_path)
+        if config.chain_id != chain_id:
+            log.error(
+                "Configuration chain ID differs from the deployment chain ID",
+                config_chain_id=config.chain_id,
+                deployment_chain_id=chain_id,
+            )
+            sys.exit(1)
         start_block = config.block
     else:
         start_block = min(

--- a/beamer/config/commands.py
+++ b/beamer/config/commands.py
@@ -137,6 +137,7 @@ def read(
         _replay_event(w3, deployment, config, event)
 
     config.block = fetcher.synced_block
+    state_path.parent.mkdir(parents=True, exist_ok=True)
     config.to_file(state_path)
     log.info("Stored configuration", path=str(state_path))
 

--- a/beamer/tests/config/test_write.py
+++ b/beamer/tests/config/test_write.py
@@ -102,11 +102,21 @@ def test_config_write_request_manager(deployment_objects, deployer):
     assert request_manager.tokens(token_address).ethInToken == 2_000
     assert request_manager.allowedLps(lp)
 
+    # Removal of an LP.
     current = desired.to_config(ape.chain.blocks[-1].number)
     desired.request_manager.whitelist.remove(lp)
 
     _write_config_state(rpc_file, artifact, deployer, current, desired)
     assert not request_manager.allowedLps(lp)
+
+    # Removal of a token.
+    current = desired.to_config(ape.chain.blocks[-1].number)
+    del desired.request_manager.tokens["TST"]
+    del desired.token_addresses["TST"]
+
+    _write_config_state(rpc_file, artifact, deployer, current, desired)
+    assert request_manager.tokens(token_address).transferLimit == 0
+    assert request_manager.tokens(token_address).ethInToken == 0
 
 
 def test_config_write_fill_manager(deployment_objects, deployer):


### PR DESCRIPTION
Small improvements to config commands:
- say whether any config updates have been found and, if yes, how many
- create state path parent directories as needed in case they don't exist
- additional check in the `read` command to make sure deployment and config chain IDs are same
- more tests for the `read` command