### PR TITLE
beamer: tests: use ganache, not ganache-cli

### DIFF
--- a/beamer/tests/agent/multiple_processors/test_multiple_event_processors.py
+++ b/beamer/tests/agent/multiple_processors/test_multiple_event_processors.py
@@ -37,7 +37,7 @@ class _ChainInfo:
 
 def _start_ganache(chain_id: ChainId, port: int, is_legacy: bool = True) -> psutil.Popen:
     cmd = [
-        "ganache-cli",
+        "ganache",
         "--chain.vmErrorsOnRPCResponse",
         "true",
         "--server.port",


### PR DESCRIPTION
ganache-cli has been deprecated and is now a separate package, which we don't need.