### PR TITLE
fix: TxReceipt typings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,6 +3,7 @@ jobs=4
 persistent=yes
 suggestion-mode=yes
 unsafe-load-any-extension=no
+load-plugins=plugins.pylint
 
 # Blacklist files or directories (basenames, not paths)
 ignore=
@@ -83,4 +84,4 @@ ignored-classes=
 ignored-modules=
 
 # List of members which are set dynamically and missed by pylint inference system
-generated-members=ape.reverts
+generated-members=ape.reverts,web3.types.TxReceipt.status

--- a/beamer/agent/chain.py
+++ b/beamer/agent/chain.py
@@ -33,7 +33,7 @@ _NewEventsCallback = Callable[[list[Event]], None]
 
 
 def _wrap_thread_func(func: Callable) -> Callable:
-    def wrapper(*args, **kwargs):  # type: ignore
+    def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
         except Exception:
@@ -464,7 +464,7 @@ def claim_request(request: Request, context: Context) -> None:
     context.logger.info(
         "Claimed request",
         request=request,
-        txn_hash=receipt.transactionHash.hex(),  # type: ignore
+        txn_hash=receipt.transactionHash.hex(),
     )
 
 
@@ -532,7 +532,7 @@ def maybe_challenge(claim: Claim, context: Context) -> bool:
     context.logger.info(
         "Challenged claim",
         claim=claim,
-        txn_hash=receipt.transactionHash.hex(),  # type: ignore
+        txn_hash=receipt.transactionHash.hex(),
     )
 
     return True
@@ -785,9 +785,7 @@ def _withdraw(claim: Claim, context: Context) -> None:
         return
 
     claim.transaction_pending = True
-    context.logger.info(
-        "Withdrew", claim=claim.id, txn_hash=receipt.transactionHash.hex()  # type: ignore
-    )
+    context.logger.info("Withdrew", claim=claim.id, txn_hash=receipt.transactionHash.hex())
 
 
 def _invalidate(request: Request, claim: Claim, context: Context) -> None:
@@ -805,5 +803,5 @@ def _invalidate(request: Request, claim: Claim, context: Context) -> None:
         request=request.id,
         fill_id=claim.fill_id,
         claim=claim.id,
-        txn_hash=receipt.transactionHash.hex(),  # type: ignore
+        txn_hash=receipt.transactionHash.hex(),
     )

--- a/beamer/config/commands.py
+++ b/beamer/config/commands.py
@@ -416,5 +416,5 @@ def write(
             log.error("Transaction failed", exc=exc)
             sys.exit(1)
         else:
-            txhash = receipt.transactionHash.hex()  # type: ignore
-            log.info("Transaction sent", block=receipt.blockNumber, txhash=txhash)  # type: ignore
+            txhash = receipt.transactionHash.hex()
+            log.info("Transaction sent", block=receipt.blockNumber, txhash=txhash)

--- a/beamer/util.py
+++ b/beamer/util.py
@@ -82,7 +82,7 @@ def transact(
         else:
             break
 
-    if receipt.status == 0:  # type: ignore
+    if receipt.status == 0:
         raise TransactionFailed("unknown error")
     return receipt
 

--- a/plugins/mypy.py
+++ b/plugins/mypy.py
@@ -1,0 +1,29 @@
+from typing import Optional, Callable
+from mypy.nodes import Var, SymbolTableNode, MDEF
+from mypy.plugin import Plugin, AnalyzeTypeContext
+
+
+class TxReceiptAttributePlugin(Plugin):
+
+    def get_type_analyze_hook(self, fullname: str) -> Optional[Callable]:
+        def func(ctx: AnalyzeTypeContext) -> None:
+            symbol_table = ctx.api.lookup_fully_qualified('web3.types.TxReceipt')
+            names = symbol_table.node.names
+            type_items = symbol_table.node.typeddict_type.items
+            for attr_name, attr_type in type_items.items():
+                if getattr(attr_type, "items", None):
+                    node = Var(attr_name, attr_type)
+                    node.info = attr_type.items[0].type
+                else:
+                    node = Var(attr_name, attr_type)
+                    node.info = attr_type.type
+                names[node.name] = SymbolTableNode(MDEF, node)
+            return symbol_table.node.typeddict_type
+
+        if 'TxReceipt' in fullname:
+            return func
+        return None
+
+
+def plugin(version: str) -> Plugin:
+    return TxReceiptAttributePlugin

--- a/plugins/pylint.py
+++ b/plugins/pylint.py
@@ -1,0 +1,20 @@
+from typing import TYPE_CHECKING
+
+from astroid import MANAGER, Call
+
+if TYPE_CHECKING:
+    from pylint.lint import PyLinter
+
+print("plugin loaded")
+
+def register(linter: "PyLinter") -> None:
+    """This required method auto registers the checker during initialization.
+
+    :param linter: The linter to register the checker to.
+    """
+    print('register')
+
+def transform(node):
+    print('transform ran')
+
+MANAGER.register_transform(Call, transform)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,9 +96,10 @@ warn_unused_ignores = true
 strict_equality = true
 disallow_untyped_defs = true
 explicit_package_bases = true
+plugins = "plugins.mypy"
 
 [[tool.mypy.overrides]]
-module = ["beamer.tests.*"]
+module = ["beamer.*"]
 disallow_untyped_defs = false
 disable_error_code = "attr-defined,name-defined"
 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,4 @@
+def func():
+    print("func ran")
+
+func()


### PR DESCRIPTION
We wanted to get rid of `# ignore: type` for TxReceipt type. I found that there is a middleware called attrdict_middleware in web3.py that is default to convert response to AttributeDict which is breaking typings.

Closes: #2015 