### PR TITLE
fix: change fill/invalidation timestamp after prove for op

### DIFF
--- a/beamer/agent/models/claim.py
+++ b/beamer/agent/models/claim.py
@@ -28,7 +28,7 @@ class Claim(StateMachine):
         self.transaction_pending = False
         self.invalidation_tx: Optional[HexBytes] = None
         self.invalidation_timestamp: Optional[Timestamp] = None
-        self.message_proved: bool = False
+        self.proved_tx: Optional[HexBytes] = None
         self.unprocessed_claim_made_events: set[ClaimMade] = set()
         super().__init__()
 


### PR DESCRIPTION
We need to wait for finality period that starts after prove operation for OP.