### PR TITLE
Remove tokens from deployment config

### DIFF
--- a/beamer/deploy/config.py
+++ b/beamer/deploy/config.py
@@ -56,7 +56,6 @@ class Chain:
     target_weight_ppm: int = field(metadata=schema(min=0))
     request_manager_arguments: _RequestManagerArgs
     fees: _Fees
-    tokens: tuple[_Token, ...] = field(metadata=schema(min_items=1))
 
     @staticmethod
     def from_file(config_file: Path) -> "Chain":

--- a/deployments/config/goerli/1442-polygon-zkevm.json
+++ b/deployments/config/goerli/1442-polygon-zkevm.json
@@ -26,12 +26,5 @@
         "min_fee_ppm": 300000,
         "lp_fee_ppm": 3000,
         "protocol_fee_ppm": 0
-    },
-    "tokens": [
-        {
-            "token_address": "mintable_token",
-            "transfer_limit": 10000,
-            "eth_in_token": 1000
-        }
-    ]
+    }
 }

--- a/deployments/config/goerli/420-optimism.json
+++ b/deployments/config/goerli/420-optimism.json
@@ -19,12 +19,5 @@
         "min_fee_ppm": 300000,
         "lp_fee_ppm": 3000,
         "protocol_fee_ppm": 0
-    },
-    "tokens": [
-        {
-            "token_address": "mintable_token",
-            "transfer_limit": 10000,
-            "eth_in_token": 1000
-        }
-    ]
+    }
 }

--- a/deployments/config/goerli/421613-arbitrum.json
+++ b/deployments/config/goerli/421613-arbitrum.json
@@ -20,12 +20,5 @@
         "min_fee_ppm": 300000,
         "lp_fee_ppm": 3000,
         "protocol_fee_ppm": 0
-    },
-    "tokens": [
-        {
-            "token_address": "mintable_token",
-            "transfer_limit": 10000,
-            "eth_in_token": 1000
-        }
-    ]
+    }
 }

--- a/deployments/config/goerli/5-ethereum.json
+++ b/deployments/config/goerli/5-ethereum.json
@@ -19,12 +19,5 @@
         "min_fee_ppm": 300000,
         "lp_fee_ppm": 0,
         "protocol_fee_ppm": 0
-    },
-    "tokens": [
-        {
-            "token_address": "mintable_token",
-            "transfer_limit": 10000,
-            "eth_in_token": 1000
-        }
-    ]
+    }
 }

--- a/deployments/config/goerli/84531-base.json
+++ b/deployments/config/goerli/84531-base.json
@@ -19,12 +19,5 @@
         "min_fee_ppm": 300000,
         "lp_fee_ppm": 3000,
         "protocol_fee_ppm": 0
-    },
-    "tokens": [
-        {
-            "token_address": "mintable_token",
-            "transfer_limit": 10000,
-            "eth_in_token": 1000
-        }
-    ]
+    }
 }

--- a/deployments/config/local/1001-polygon-zkevm.json
+++ b/deployments/config/local/1001-polygon-zkevm.json
@@ -26,12 +26,5 @@
         "min_fee_ppm": 300000,
         "lp_fee_ppm": 3000,
         "protocol_fee_ppm": 0
-    },
-    "tokens": [
-        {
-            "token_address": "mintable_token",
-            "transfer_limit": 10000,
-            "eth_in_token": 1000
-        }
-    ]
+    }
 }

--- a/deployments/config/local/1337-ethereum.json
+++ b/deployments/config/local/1337-ethereum.json
@@ -16,12 +16,5 @@
         "min_fee_ppm": 300000,
         "lp_fee_ppm": 0,
         "protocol_fee_ppm": 0
-    },
-    "tokens": [
-        {
-            "token_address": "mintable_token",
-            "transfer_limit": 1000,
-            "eth_in_token": 1000
-        }
-    ]
+    }
 }

--- a/deployments/config/local/412346-arbitrum.json
+++ b/deployments/config/local/412346-arbitrum.json
@@ -16,12 +16,5 @@
         "min_fee_ppm": 300000,
         "lp_fee_ppm": 0,
         "protocol_fee_ppm": 0
-    },
-    "tokens": [
-        {
-            "token_address": "mintable_token",
-            "transfer_limit": 1000,
-            "eth_in_token": 1000
-        }
-    ]
+    }
 }

--- a/deployments/config/local/901-optimism.json
+++ b/deployments/config/local/901-optimism.json
@@ -16,12 +16,5 @@
         "min_fee_ppm": 300000,
         "lp_fee_ppm": 0,
         "protocol_fee_ppm": 0
-    },
-    "tokens": [
-        {
-            "token_address": "mintable_token",
-            "transfer_limit": 1000,
-            "eth_in_token": 1000
-        }
-    ]
+    }
 }

--- a/deployments/config/mainnet/1-ethereum.json
+++ b/deployments/config/mainnet/1-ethereum.json
@@ -19,17 +19,5 @@
         "min_fee_ppm": 300000,
         "lp_fee_ppm": 3000,
         "protocol_fee_ppm": 0
-    },
-    "tokens": [
-        {
-            "token_address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-            "transfer_limit": 10000,
-            "eth_in_token": 1800
-        },
-        {
-            "token_address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-            "transfer_limit": 10000,
-            "eth_in_token": 1800
-        }
-    ]
+    }
 }

--- a/deployments/config/mainnet/10-optimism.json
+++ b/deployments/config/mainnet/10-optimism.json
@@ -19,17 +19,5 @@
         "min_fee_ppm": 300000,
         "lp_fee_ppm": 3000,
         "protocol_fee_ppm": 0
-    },
-    "tokens": [
-        {
-            "token_address": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
-            "transfer_limit": 10000,
-            "eth_in_token": 1800
-        },
-        {
-            "token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
-            "transfer_limit": 10000,
-            "eth_in_token": 1800
-        }
-    ]
+    }
 }

--- a/deployments/config/mainnet/1101-polygon-zkevm.json
+++ b/deployments/config/mainnet/1101-polygon-zkevm.json
@@ -26,17 +26,5 @@
         "min_fee_ppm": 300000,
         "lp_fee_ppm": 3000,
         "protocol_fee_ppm": 0
-    },
-    "tokens": [
-        {
-            "token_address": "0xA8CE8aee21bC2A48a5EF670afCc9274C7bbbC035",
-            "transfer_limit": 10000,
-            "eth_in_token": 1800
-        },
-        {
-            "token_address": "0xC5015b9d9161Dca7e18e32f6f25C4aD850731Fd4",
-            "transfer_limit": 10000,
-            "eth_in_token": 1800
-        }
-    ]
+    }
 }

--- a/deployments/config/mainnet/42161-arbitrum.json
+++ b/deployments/config/mainnet/42161-arbitrum.json
@@ -20,17 +20,5 @@
         "min_fee_ppm": 300000,
         "lp_fee_ppm": 3000,
         "protocol_fee_ppm": 0
-    },
-    "tokens": [
-        {
-            "token_address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
-            "transfer_limit": 10000,
-            "eth_in_token": 1800
-        },
-        {
-            "token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
-            "transfer_limit": 10000,
-            "eth_in_token": 1800
-        }
-    ]
+    }
 }


### PR DESCRIPTION
It's not necessary and the deployment commands do not use the field.