### PR TITLE
Frontend: update campaign texts

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,11 +2,7 @@
   <div
     class="app-content flex min-h-screen w-full flex-col bg-gradient-to-b from-black to-teal font-sans text-white antialiased"
   >
-    <div
-      class="flex h-16 w-full flex-col justify-center bg-fire text-center text-2xl font-semibold text-rosa lg:text-3xl"
-    >
-      ✦ &#129427; &#129427; &#129427; &#129427; &#129427; &#129427; &#129427; &#129427; &#129427; ✦
-    </div>
+    <Banner></Banner>
     <div class="container mx-auto max-w-5xl">
       <a href="https://beamerbridge.com" target="_blank">
         <img class="mt-6 ml-6 w-[10rem] md:w-[15rem]" src="@/assets/images/logo.svg" alt="logo"
@@ -54,6 +50,7 @@ import { onMounted } from 'vue';
 
 import type { Transfer } from '@/actions/transfers';
 import Footer from '@/components/Footer.vue';
+import Banner from '@/components/layout/Banner.vue';
 import Spinner from '@/components/Spinner.vue';
 import { useContinueInterruptedTransfers } from '@/composables/useContinueInterruptedTransfers';
 import useLoadConfiguration from '@/composables/useLoadConfiguration';

--- a/frontend/src/components/ShareTweet.vue
+++ b/frontend/src/components/ShareTweet.vue
@@ -33,21 +33,18 @@ const tweetText = computed(() => {
   const targetChain = transfer.value.targetChain;
   const transferTime = transfer.value.transferTimeSeconds;
 
-  const defaultText = `I just used @beamerbridge to seamlessly and securely transfer #${sourceToken.symbol} from ${sourceChain.name} to ${targetChain.name} in ${transferTime} seconds! 🔥
-
-Unlock lightning-fast and secure bridging with Beamer today 💪💫  Now also live on Polygon zkEVM!
-https://app.beamerbridge.com/`;
-
-  const subsidizedTransferText = `Unbelievable! @beamerbridge just unlocked 🦓 - it won't last, so don't miss out! 👀
-
-Sent #${sourceToken.symbol} from ${sourceChain.name} to ${targetChain.name} securely in ${transferTime} seconds using 🦓. You can do it too! 🔥
-
-Get lightning-fast and secure bridging with Beamer now 💪💫
-https://app.beamerbridge.com/`;
-
+  let defaultTextExtension = 'using @beamerbridge';
   if (isSubsidizedTransfer(transfer.value) && transfer.value.fees.uint256.isZero()) {
-    return subsidizedTransferText;
+    defaultTextExtension = 'and with 0 fees using @beamerbridge';
   }
+
+  const defaultText = `Unbelievable! I sent #${sourceToken.symbol} from ${sourceChain.name} to ${targetChain.name} in just ${transferTime} seconds ${defaultTextExtension}! 🔥
+
+Hit the volume threshold and enjoy, because it won't last! 👀🦓  
+
+Now also live on Polygon zkEVM! 💪💫
+https://app.beamerbridge.com/`;
+
   return defaultText;
 });
 

--- a/frontend/src/components/layout/Banner.vue
+++ b/frontend/src/components/layout/Banner.vue
@@ -1,0 +1,7 @@
+<template>
+  <div
+    class="flex h-16 w-full flex-col justify-center bg-fire text-center text-2xl font-semibold text-rosa lg:text-3xl"
+  >
+    ✦ Beamer is now live on Polygon zkEVM! ✦
+  </div>
+</template>

--- a/frontend/tests/unit/components/ShareTweet.spec.ts
+++ b/frontend/tests/unit/components/ShareTweet.spec.ts
@@ -58,7 +58,7 @@ describe('ShareTweet.vue', () => {
     });
   });
 
-  it('uses the default text by default', () => {
+  it('renders some text with a link to beamer website when transfer is shareable', () => {
     const transfer = generateTransfer({
       transferData: generateTransferData({
         requestInformation: generateRequestInformationData({ timestamp: 1 }),
@@ -73,11 +73,9 @@ describe('ShareTweet.vue', () => {
     });
 
     const ctaEl = wrapper.find('[data-test="cta"]');
-    const defaultText = `I just used @beamerbridge to seamlessly and securely transfer #${transfer.sourceAmount.token.symbol} from ${transfer.sourceChain.name} to ${transfer.targetChain.name} in ${transfer.transferTimeSeconds} seconds! 🔥
-
-Unlock lightning-fast and secure bridging with Beamer today 💪💫  Now also live on Polygon zkEVM!
-https://app.beamerbridge.com/`;
-    expect(ctaEl.attributes('href')).toContain(encodeURIComponent(defaultText));
+    expect(ctaEl.attributes('href')).toContain(
+      encodeURIComponent('https://app.beamerbridge.com/'),
+    );
   });
 
   it('uses the zebra campaign text when the transfer was subsidized', () => {
@@ -99,12 +97,6 @@ https://app.beamerbridge.com/`;
     });
 
     const ctaEl = wrapper.find('[data-test="cta"]');
-    const subsidizedTransferText = `Unbelievable! @beamerbridge just unlocked 🦓 - it won't last, so don't miss out! 👀
-
-Sent #${transfer.sourceAmount.token.symbol} from ${transfer.sourceChain.name} to ${transfer.targetChain.name} securely in ${transfer.transferTimeSeconds} seconds using 🦓. You can do it too! 🔥
-
-Get lightning-fast and secure bridging with Beamer now 💪💫
-https://app.beamerbridge.com/`;
-    expect(ctaEl.attributes('href')).toContain(encodeURIComponent(subsidizedTransferText));
+    expect(ctaEl.attributes('href')).toContain(encodeURIComponent('and with 0 fees'));
   });
 });


### PR DESCRIPTION
Based on the internal discussion, we are using a similar base text for both the zebra and the polygon zkevm campaign but render the zebra one whenever a transfer has been subsidized.