### PR TITLE
frontend: enable Base

### DIFF
--- a/frontend/config/chains/8453.json
+++ b/frontend/config/chains/8453.json
@@ -10,6 +10,5 @@
     "symbol": "ETH",
     "decimals": 18
   },
-  "internalRpcUrl": "https://base-mainnet.blastapi.io/4ce13fbe-7b55-42ef-a1a1-6e9be8006083",
-  "hidden": true
+  "internalRpcUrl": "https://base-mainnet.blastapi.io/4ce13fbe-7b55-42ef-a1a1-6e9be8006083"
 }


### PR DESCRIPTION
**Note: Do not merge before we are ready to announce and launch Base.**

One thing missing here. We need to include the FeeSub contract address in the `config/chains/8453.json` file if we want to enable fee subsidy for Base as well.