### PR TITLE
deployments: publish version 2.0.3

### DIFF
--- a/deployments-npm-package/package.json
+++ b/deployments-npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beamer-bridge/deployments",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "The beamer-bridge contract deployments & ABIs",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
Currently v2.0.2 doesn't contain the base artifacts.
We have a dev. version that has those, but I would like to pin the frontend for base against a non-dev version.