### PR TITLE
deployments: create package with abi bytecode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ workflows:
             deployments/artifacts/.* deployment-artifacts-updated true
             deployments/artifacts/.* docs-updated true
             deployments-npm-package/package.json deployment-package-json-updated true
+            deployments-npm-package/scripts/create-package.sh deployment-artifacts-updated true
             frontend/.* frontend-updated true
             subgraph/.* subgraph-updated true
             .circleci/.* frontend-updated true             

--- a/deployments-npm-package/package.json
+++ b/deployments-npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beamer-bridge/deployments",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "The beamer-bridge contract deployments & ABIs",
   "publishConfig": {
     "access": "public",

--- a/deployments-npm-package/scripts/create-package.sh
+++ b/deployments-npm-package/scripts/create-package.sh
@@ -2,11 +2,15 @@
 
 rm -rf dist
 mkdir -p dist/abis/{goerli,mainnet}
+mkdir -p dist/abis-without-bytecode/{goerli,mainnet}
 mkdir -p dist/artifacts
 
 cp -r ../deployments/artifacts/. dist/artifacts
 
-python ../scripts/generate-abi.py --only-abi ../deployments/artifacts/mainnet dist/abis/mainnet
-python ../scripts/generate-abi.py --only-abi ../deployments/artifacts/goerli dist/abis/goerli
+python ../scripts/generate-abi.py ../deployments/artifacts/mainnet dist/abis/mainnet
+python ../scripts/generate-abi.py ../deployments/artifacts/goerli dist/abis/goerli
+
+python ../scripts/generate-abi.py --only-abi ../deployments/artifacts/mainnet dist/abis-without-bytecode/mainnet
+python ../scripts/generate-abi.py --only-abi ../deployments/artifacts/goerli dist/abis-without-bytecode/goerli
 
 git rev-parse HEAD > git-commit-version.txt


### PR DESCRIPTION
Breaking change!

Currently we generate the abis without the bytecode. We do this because the frontend doesn’t use the bytecode. However the agent and backend code needs the bytecode.

The abis now generated in /abis/ will have the bytecode by default. If someone needs abis without the bytecode they are in the abis-without-bytecode folder.