### PR TITLE
deployments: bump npm package version to `v3.0.1`

### DIFF
--- a/deployments-npm-package/package.json
+++ b/deployments-npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beamer-bridge/deployments",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The beamer-bridge contract deployments & ABIs",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
Uses the improved generate-abi script that dumps ~4x smaller ABI files  